### PR TITLE
Fix dependency tree

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
    <modelVersion>4.0.0</modelVersion>
 
    <!-- For release: mvn release:perform -Darguments=-Dgpg.passphrase=PASSPHRASE -->
@@ -90,11 +92,13 @@
          <artifactId>maven-bundle-plugin</artifactId>
          <version>2.3.7</version>
          <type>maven-plugin</type>
+         <scope>provided</scope>
       </dependency>
       <dependency>
-      	<groupId>org.hsqldb</groupId>
-      	<artifactId>hsqldb</artifactId>
-      	<version>2.3.0</version>
+         <groupId>org.hsqldb</groupId>
+         <artifactId>hsqldb</artifactId>
+         <version>2.3.0</version>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>com.sun</groupId>
@@ -104,10 +108,9 @@
          <systemPath>${java.home}/../lib/tools.jar</systemPath>
       </dependency>
       <dependency>
-      	<groupId>org.javassist</groupId>
-      	<artifactId>javassist</artifactId>
-      	<version>3.18.1-GA</version>
-      	<type>bundle</type>
+         <groupId>org.javassist</groupId>
+         <artifactId>javassist</artifactId>
+         <version>3.18.1-GA</version>
       </dependency>
       <dependency>
          <groupId>net.snaq</groupId>


### PR DESCRIPTION
Due to improper scope on a few artifacts, shading HikariCP into another project included a lot of other transitive dependencies. I've also fixed some other minor issues.
