### PR TITLE
Fixed an invalid timeout in java.sql.Connection.isValid call

### DIFF
--- a/src/main/java/com/zaxxer/hikari/HikariPool.java
+++ b/src/main/java/com/zaxxer/hikari/HikariPool.java
@@ -334,17 +334,17 @@ public final class HikariPool implements HikariPoolMBean
      */
     private boolean isConnectionAlive(final Connection connection, long timeoutMs)
     {
-        // Set a realistic minimum timeout
-        if (timeoutMs < 500)
+        // java.sql.Connection.isValid timeout is seconds, and can't be zero for timeout to work
+        if (timeoutMs < 1000)
         {
-            timeoutMs = 500;
+            timeoutMs = 1000;
         }
 
         try
         {
             if (jdbc4ConnectionTest)
             {
-                return connection.isValid((int) timeoutMs * 1000);
+                return connection.isValid((int) timeoutMs / 1000);
             }
 
             Statement statement = connection.createStatement();


### PR DESCRIPTION
HikeriPool.isConnectionAlive method wrongly multiplies a timeout value instead of dividing it. This causes an extremely long timeout or an integer overflow.
