### PR TITLE
Added a constructor for HikariConfig that accepts a Properties object. M...

### DIFF
--- a/core/src/main/java/com/zaxxer/hikari/HikariConfig.java
+++ b/core/src/main/java/com/zaxxer/hikari/HikariConfig.java
@@ -82,6 +82,18 @@ public final class HikariConfig implements HikariConfigMBean
     }
 
     /**
+     * Construct a HikariConfig from the specified properties object.
+     *
+     * @param properties the name of the property file
+     */
+    public HikariConfig(Properties properties)
+    {
+        this();
+	PropertyBeanSetter.setTargetFromProperties(this, properties);
+    }
+
+
+    /**
      * Construct a HikariConfig from the specified property file name.
      *
      * @param propertyFileName the name of the property file
@@ -96,9 +108,8 @@ public final class HikariConfig implements HikariConfigMBean
             throw new IllegalArgumentException("Property file " + propertyFileName + " was not found.");
         }
 
-        try
+        try ( FileInputStream fis = new FileInputStream(propFile) )
         {
-            FileInputStream fis = new FileInputStream(propFile);
             Properties props = new Properties();
             props.load(fis);
             PropertyBeanSetter.setTargetFromProperties(this, props);


### PR DESCRIPTION
...odified props-file reading constructor to use try-with-resources to ensure prompt file close.

The motivation here is integration with app servers and other projects that might wish to integrate HikariCP and allow configuration from their native config files. Such projects could read properties one by one and call set methods directly on the HikariConfig object, but that's fragile: if HikariCP ever adds new config, these projects will have to be updated to support them. With a constructor that accepts a Properties object, other projects can read their own native config, extract HikariCP-related properties based on a section or prefix, and construct their DataSource from whatever is found without worrying about HikariCP-specific config details.

(Also, the Properties-file based constructor opens but does not close a file descriptor; since HikariCP is a Java7+ project, try-with-resources is a quick way to ensure reliable resource cleanup.)
