### PR TITLE
Make method static, fix possible NPE, and fix temp folder used

### DIFF
--- a/core/src/main/java/com/zaxxer/hikari/javassist/HikariClassTransformer.java
+++ b/core/src/main/java/com/zaxxer/hikari/javassist/HikariClassTransformer.java
@@ -397,7 +397,7 @@ public class HikariClassTransformer implements ClassFileTransformer
         }
     }
 
-    private void specialConnectionInjectCloseCheck(CtClass targetClass) throws Exception
+    private static void specialConnectionInjectCloseCheck(CtClass targetClass) throws Exception
     {
         for (CtMethod method : targetClass.getDeclaredMethods())
         {


### PR DESCRIPTION
On [`HikariClassTransformer` line 358](https://github.com/brettwooldridge/HikariCP/blob/dev/core/src/main/java/com/zaxxer/hikari/javassist/HikariClassTransformer.java#L358), `destInitializer` is dereferenced, despite the fact that it may be null. Restructing the `if` fixes this. The other two changes are trivial. Let me know if you don't want one of these for whatever reason and I'll back it out.
