### PR TITLE
fix fast statement list overflow inconsistency

### DIFF
--- a/src/main/java/com/zaxxer/hikari/util/FastStatementList.java
+++ b/src/main/java/com/zaxxer/hikari/util/FastStatementList.java
@@ -62,6 +62,7 @@ public final class FastStatementList
         catch (ArrayIndexOutOfBoundsException oob)
         {
             // overflow-conscious code
+        	size--;
             int oldCapacity = elementData.length;
             int newCapacity = oldCapacity << 2;
             Statement[] newElementData = new Statement[newCapacity];

--- a/src/test/java/com/zaxxer/hikari/TestFastStatementList.java
+++ b/src/test/java/com/zaxxer/hikari/TestFastStatementList.java
@@ -1,5 +1,6 @@
 package com.zaxxer.hikari;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import com.zaxxer.hikari.performance.StubStatement;
@@ -14,6 +15,10 @@ public class TestFastStatementList
         for (int i = 0; i < 100; i++)
         {
             list.add(new StubStatement());
+        }
+        for (int i = 0; i < 100; i++)
+        {
+        	Assert.assertNotNull(list.get(i));
         }
     }
 }


### PR DESCRIPTION
The fast statement list returns nulls during iteration when there was a overflow. The effect is a NPE when closing a connection with more open statements than the fast list initial capacity.
