### PR TITLE
Disable jdbc4ConnectionTest when connectionTestQuery is set

### DIFF
--- a/src/main/java/com/zaxxer/hikari/HikariConfig.java
+++ b/src/main/java/com/zaxxer/hikari/HikariConfig.java
@@ -466,7 +466,11 @@ public class HikariConfig implements HikariConfigMBean
             idleTimeout = IDLE_TIMEOUT;
         }
 
-        if (!isJdbc4connectionTest && connectionTestQuery == null)
+        if (connectionTestQuery != null)
+        {
+            isJdbc4connectionTest = false;
+        }
+        else if (!isJdbc4connectionTest)
         {
             logger.error("Either jdbc4ConnectionTest must be enabled or a connectionTestQuery must be specified.");
             throw new IllegalStateException("Either jdbc4ConnectionTest must be enabled or a connectionTestQuery must be specified.");


### PR DESCRIPTION
Documentation says that `jdbc4ConnectionTest` is mutually exclusive with the `connectionTestQuery` property; this commit makes that happen.
