### PR TITLE
Fix #76 avoid possible thread leak on shutdown

### DIFF
--- a/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
+++ b/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
@@ -295,7 +295,7 @@ public final class HikariPool implements HikariPoolMBean, IBagStateListener
                 int sleepBackoff = 200;
                 final int maxPoolSize = configuration.getMaximumPoolSize();
                 final int minIdle = configuration.getMinimumIdle();
-                while (totalConnections.get() < maxPoolSize && (minIdle == 0 || getIdleConnections() < minIdle))
+                while (!isShutdown && totalConnections.get() < maxPoolSize && (minIdle == 0 || getIdleConnections() < minIdle))
                 {
                     if (!addConnection())
                     {


### PR DESCRIPTION
There seems to be the possibility of a thread leak on pool shutdown. See my comments in https://github.com/brettwooldridge/HikariCP/issues/76.
