### PR TITLE
Fix timeout calculation when skipping unusable connections from pool

### DIFF
--- a/hikaricp-java6/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
+++ b/hikaricp-java6/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
@@ -170,7 +170,7 @@ public final class HikariPool implements HikariPoolMBean, IBagStateListener
 
             if (now > connection.getExpirationTime() || (now - connection.getLastAccess() > 1000L && !isConnectionAlive(connection, timeout))) {
                closeConnection(connection); // Throw away the dead connection and try again
-               timeout -= elapsedTimeMs(start);
+               timeout = connectionTimeout - elapsedTimeMs(start);
                continue;
             }
             else if (leakDetectionThreshold != 0) {

--- a/hikaricp/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
+++ b/hikaricp/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
@@ -169,7 +169,7 @@ public final class HikariPool implements HikariPoolMBean, IBagStateListener
 
             if (now > connection.getExpirationTime() || (now - connection.getLastAccess() > 1000L && !isConnectionAlive(connection, timeout))) {
                closeConnection(connection); // Throw away the dead connection and try again
-               timeout -= elapsedTimeMs(start);
+               timeout = connectionTimeout - elapsedTimeMs(start);
                continue;
             }
             else if (leakDetectionThreshold != 0) {


### PR DESCRIPTION
The timeout calculation cumulatively subtracts the elapsed time since the beginning of getConnection(), resulting in timeout expiring faster than expected if several connection candidates from the `connectionBag` are not usable. Fixed by this pull request.
