### PR TITLE
Fix not to throw NPE if username or password is null

### DIFF
--- a/hikaricp/src/main/java/com/zaxxer/hikari/HikariDataSource.java
+++ b/hikaricp/src/main/java/com/zaxxer/hikari/HikariDataSource.java
@@ -273,13 +273,13 @@ public class HikariDataSource extends HikariConfig implements DataSource, Closea
          if (username != null && !username.equals(otherKey.username)) {
             return false;
          }
-         else if (!username.equals(otherKey.username)) {
+         else if (username != otherKey.username) {
             return false;
          }
          else if (password != null && !password.equals(otherKey.password)) {
             return false;
          }
-         else if (!password.equals(otherKey.password)) {
+         else if (password != otherKey.password) {
             return false;
          }
 


### PR DESCRIPTION
The java6 & java8 trees were not in sync regarding this issue; copied the legit-looking java6 version over the broken java8 one.
