### PR TITLE
Allow a custom ExecutorService to be set for each pool

### DIFF
--- a/hikaricp/src/main/java/com/zaxxer/hikari/HikariConfig.java
+++ b/hikaricp/src/main/java/com/zaxxer/hikari/HikariConfig.java
@@ -26,6 +26,7 @@ import java.sql.SQLException;
 import java.util.Properties;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
 import javax.sql.DataSource;
@@ -81,6 +82,7 @@ public class HikariConfig implements HikariConfigMBean
    private Properties dataSourceProperties;
    private IConnectionCustomizer customizer;
    private int transactionIsolation;
+   private ThreadFactory threadFactory;
 
    static {
       JavassistProxyFactory.initialize();
@@ -623,6 +625,26 @@ public class HikariConfig implements HikariConfigMBean
    public void setUsername(String username)
    {
       this.username = username;
+   }
+
+   /**
+    * Get the thread factory used to create threads.
+    *
+    * @return the thread factory (may be null, in which case the default thread factory is used)
+    */
+   public ThreadFactory getThreadFactory()
+   {
+      return threadFactory;
+   }
+
+   /**
+    * Set the thread factory to be used to create threads.
+    *
+    * @param threadFactory the thread factory (setting to null causes the default thread factory to be used)
+    */
+   public void setThreadFactory(ThreadFactory threadFactory)
+   {
+      this.threadFactory = threadFactory;
    }
 
    public void validate()

--- a/hikaricp/src/main/java/com/zaxxer/hikari/proxy/IHikariConnectionProxy.java
+++ b/hikaricp/src/main/java/com/zaxxer/hikari/proxy/IHikariConnectionProxy.java
@@ -19,7 +19,7 @@ package com.zaxxer.hikari.proxy;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.Timer;
+import java.util.concurrent.ScheduledExecutorService;
 
 import com.zaxxer.hikari.util.ConcurrentBag.IBagManagable;
 
@@ -35,9 +35,9 @@ public interface IHikariConnectionProxy extends Connection, IBagManagable
     * Catpure the stack and start leak detection.
     *
     * @param leakThreshold the number of milliseconds before a leak is reported
-    * @param houseKeepingTimer the timer to run the leak detection task with
+    * @param houseKeepingExecutorService the executor service to run the leak detection task with
     */
-   void captureStack(long leakThreshold, Timer houseKeepingTimer);
+   void captureStack(long leakThreshold, ScheduledExecutorService houseKeepingExecutorService);
 
    /**
     * Check if the provided SQLException contains a SQLSTATE that indicates

--- a/hikaricp/src/main/java/com/zaxxer/hikari/proxy/LeakTask.java
+++ b/hikaricp/src/main/java/com/zaxxer/hikari/proxy/LeakTask.java
@@ -16,14 +16,12 @@
 
 package com.zaxxer.hikari.proxy;
 
-import java.util.TimerTask;
-
 import org.slf4j.LoggerFactory;
 
 /**
  * @author Brett Wooldridge
  */
-class LeakTask extends TimerTask
+class LeakTask implements Runnable
 {
    private final long leakTime;
    private StackTraceElement[] stackTrace;
@@ -46,13 +44,8 @@ class LeakTask extends TimerTask
       }
    }
 
-   @Override
-   public boolean cancel()
+   public void cancel()
    {
-      boolean cancelled = super.cancel();
-      if (cancelled) {
-         stackTrace = null;
-      }
-      return cancelled;
+      stackTrace = null;
    }
 }

--- a/hikaricp/src/main/java/com/zaxxer/hikari/util/DefaultThreadFactory.java
+++ b/hikaricp/src/main/java/com/zaxxer/hikari/util/DefaultThreadFactory.java
@@ -1,0 +1,21 @@
+package com.zaxxer.hikari.util;
+
+import java.util.concurrent.ThreadFactory;
+
+public class DefaultThreadFactory implements ThreadFactory {
+
+   private String threadName;
+   private boolean daemon;
+
+   public DefaultThreadFactory(String threadName, boolean daemon){
+       this.threadName = threadName;
+       this.daemon = daemon;
+   }
+
+   @Override
+   public Thread newThread(Runnable r) {
+       Thread thread = new Thread(r, threadName);
+       thread.setDaemon(daemon);
+       return thread;
+   }
+}

--- a/hikaricp/src/main/java/com/zaxxer/hikari/util/PoolUtilities.java
+++ b/hikaricp/src/main/java/com/zaxxer/hikari/util/PoolUtilities.java
@@ -88,16 +88,11 @@ public final class PoolUtilities
       }
    }
 
-   public static ThreadPoolExecutor createThreadPoolExecutor(final int queueSize, final String threadName)
+   public static ThreadPoolExecutor createThreadPoolExecutor(final int queueSize, final String threadName, ThreadFactory threadFactory)
    {
-      ThreadFactory threadFactory = new ThreadFactory() {
-         public Thread newThread(Runnable r)
-         {
-            Thread t = new Thread(r, threadName);
-            t.setDaemon(true);
-            return t;
-         }
-      };
+      if (threadFactory == null) {
+         threadFactory = new DefaultThreadFactory(threadName, true);
+      }
 
       int processors = Math.max(1, Runtime.getRuntime().availableProcessors() / 2);
       LinkedBlockingQueue<Runnable> queue = new LinkedBlockingQueue<Runnable>(queueSize);


### PR DESCRIPTION
This allows for HikariCP to be used when a SecurityManager is in place, preventing/warning of the creation of threads not using the applications main ExecutorService. One such application is BungeeCord, you can see it's security manager [here](https://github.com/SpigotMC/BungeeCord/blob/master/proxy/src/main/java/net/md_5/bungee/BungeeSecurityManager.java). Currently it's only warning of the action.

I believe Android also has a similar limitation in place.

Users of the library may also want to change the ExecutorService so that they can reuse it throughout their project.
