### PR TITLE
Sync Java 6/7 and Java 8 versions

### DIFF
--- a/hikaricp-java6/pom.xml
+++ b/hikaricp-java6/pom.xml
@@ -6,7 +6,6 @@
 
    <groupId>com.zaxxer</groupId>
    <artifactId>HikariCP-java6</artifactId>
-   <version>2.0.1-SNAPSHOT</version>
    <packaging>bundle</packaging>
 
    <name>HikariCP-java6</name>

--- a/hikaricp-java6/src/test/java/com/zaxxer/hikari/IsolationTest.java
+++ b/hikaricp-java6/src/test/java/com/zaxxer/hikari/IsolationTest.java
@@ -1,0 +1,62 @@
+package com.zaxxer.hikari;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class IsolationTest
+{
+    @Test
+    public void testIsolation() throws SQLException
+    {
+        HikariDataSource ds = new HikariDataSource();
+        ds.setMinimumIdle(1);
+        ds.setMaximumPoolSize(1);
+        ds.setIsolateInternalQueries(true);
+        ds.setDataSourceClassName("com.zaxxer.hikari.mocks.StubDataSource");
+
+        try
+        {
+            Connection connection = ds.getConnection();
+            connection.close();
+
+            Connection connection2 = ds.getConnection();
+            connection2.close();
+
+            Assert.assertNotSame(connection, connection2);
+            Assert.assertSame(connection.unwrap(Connection.class), connection2.unwrap(Connection.class));
+        }
+        finally
+        {
+            ds.close();
+        }
+    }
+
+    @Test
+    public void testNonIsolation() throws SQLException
+    {
+        HikariDataSource ds = new HikariDataSource();
+        ds.setMinimumIdle(1);
+        ds.setMaximumPoolSize(1);
+        ds.setIsolateInternalQueries(false);
+        ds.setDataSourceClassName("com.zaxxer.hikari.mocks.StubDataSource");
+
+        try
+        {
+            Connection connection = ds.getConnection();
+            connection.close();
+
+            Connection connection2 = ds.getConnection();
+            connection2.close();
+
+            Assert.assertSame(connection, connection2);
+            Assert.assertSame(connection.unwrap(Connection.class), connection2.unwrap(Connection.class));
+        }
+        finally
+        {
+            ds.close();
+        }
+    }
+}

--- a/hikaricp-java6/src/test/java/com/zaxxer/hikari/ShutdownTest.java
+++ b/hikaricp-java6/src/test/java/com/zaxxer/hikari/ShutdownTest.java
@@ -141,7 +141,7 @@ public class ShutdownTest
 
         PoolUtilities.quietlySleep(300);
 
-        Assert.assertTrue("Totals connection count not as expected, ", pool.getTotalConnections() > 0);
+        Assert.assertTrue("Totals connection count not as expected, ", pool.getTotalConnections() == 5);
         
         ds.close();
 

--- a/hikaricp-java6/src/test/java/com/zaxxer/hikari/TestConnectionTimeoutRetry.java
+++ b/hikaricp-java6/src/test/java/com/zaxxer/hikari/TestConnectionTimeoutRetry.java
@@ -253,7 +253,7 @@ public class TestConnectionTimeoutRetry
             Connection connection6 = ds.getConnection();
             Connection connection7 = ds.getConnection();
     
-            Thread.sleep(1000);
+            Thread.sleep(1200);
     
             Assert.assertSame("Totals connections not as expected", 10, TestElf.getPool(ds).getTotalConnections());
             Assert.assertSame("Idle connections not as expected", 3, TestElf.getPool(ds).getIdleConnections());

--- a/hikaricp/pom.xml
+++ b/hikaricp/pom.xml
@@ -4,6 +4,7 @@
 
    <!-- For release: mvn release:perform -Darguments=-Dgpg.passphrase=PASSPHRASE -->
 
+   <groupId>com.zaxxer</groupId>
    <artifactId>HikariCP</artifactId>
    <packaging>bundle</packaging>
 

--- a/hikaricp/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
+++ b/hikaricp/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
@@ -335,7 +335,7 @@ public final class HikariPool implements HikariPoolMBean, IBagStateListener
    @Override
    public int getIdleConnections()
    {
-      return (int) connectionBag.getCount(STATE_NOT_IN_USE);
+      return connectionBag.getCount(STATE_NOT_IN_USE);
    }
 
    /** {@inheritDoc} */

--- a/hikaricp/src/main/java/com/zaxxer/hikari/util/ConcurrentBag.java
+++ b/hikaricp/src/main/java/com/zaxxer/hikari/util/ConcurrentBag.java
@@ -286,9 +286,9 @@ public class ConcurrentBag<T extends com.zaxxer.hikari.util.ConcurrentBag.IBagMa
       return synchronizer.getQueueLength();
    }
 
-   public long getCount(final int state)
+   public int getCount(final int state)
    {
-      return sharedList.stream().filter(reference -> reference.getState() == state).count();
+      return (int) sharedList.stream().filter(reference -> reference.getState() == state).count();
    }
 
    /**

--- a/hikaricp/src/test/java/com/zaxxer/hikari/ConnectionStateTest.java
+++ b/hikaricp/src/test/java/com/zaxxer/hikari/ConnectionStateTest.java
@@ -17,6 +17,10 @@ public class ConnectionStateTest
         ds.setMaximumPoolSize(1);
         ds.setConnectionTestQuery("VALUES 1");
         ds.setDataSourceClassName("com.zaxxer.hikari.mocks.StubDataSource");
+        ds.addDataSourceProperty("user", "bar");
+        ds.addDataSourceProperty("password", "secret");
+        ds.addDataSourceProperty("url", "baf");
+        ds.addDataSourceProperty("loginTimeout", "10");
 
         try
         {

--- a/hikaricp/src/test/java/com/zaxxer/hikari/TestFastList.java
+++ b/hikaricp/src/test/java/com/zaxxer/hikari/TestFastList.java
@@ -86,7 +86,7 @@ public class TestFastList
           
        }
 
-       FastList<Base> list = new FastList<>(Base.class, 2);
+       FastList<Base> list = new FastList<Base>(Base.class, 2);
        list.add(new Foo());
        list.add(new Foo());
        list.add(new Bar());


### PR DESCRIPTION
I ran a diff between the two branches. There were a number of small changes between the two, especially in the tests, as well as a missed file. I've changed a few things to minimize the diff where possible, leaving only actual functional changes.
