### PR TITLE
Fixed invalid minimum value for connectionTimeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ If this property is not specified, the default catalog defined by the JDBC drive
 :watch:``connectionTimeout``<br/>
 This property controls the maximum number of milliseconds that a client (that's you) will wait
 for a connection from the pool.  If this time is exceeded without a connection becoming
-available, a SQLException will be thrown.  250ms is the minimum value.  *Default: 30000 (30 seconds)*
+available, a SQLException will be thrown.  100ms is the minimum value.  *Default: 30000 (30 seconds)*
 
 :watch:``idleTimeout``<br/>
 This property controls the maximum amount of time (in milliseconds) that a connection is


### PR DESCRIPTION
In the `README.md` it says `250ms` but the code reads `100ms`:

``` java
   @Override
   public void setConnectionTimeout(long connectionTimeoutMs)
   {
      if (connectionTimeoutMs == 0) {
         this.connectionTimeout = Integer.MAX_VALUE;
      }
      else if (connectionTimeoutMs < 100) {
         throw new IllegalArgumentException("connectionTimeout cannot be less than 100ms");
      }
      else {
         this.connectionTimeout = connectionTimeoutMs;
      }
   }
```
