### PR TITLE
#112: allow clients to provide an IMetricsTracker instance directly

### DIFF
--- a/hikaricp-java6/src/main/java/com/zaxxer/hikari/HikariConfig.java
+++ b/hikaricp-java6/src/main/java/com/zaxxer/hikari/HikariConfig.java
@@ -38,6 +38,7 @@ import org.slf4j.LoggerFactory;
 import com.zaxxer.hikari.proxy.JavassistProxyFactory;
 import com.zaxxer.hikari.util.PoolUtilities;
 import com.zaxxer.hikari.util.PropertyBeanSetter;
+import com.zaxxer.hikari.metrics.IMetricsTracker;
 
 public class HikariConfig implements HikariConfigMBean
 {
@@ -79,6 +80,7 @@ public class HikariConfig implements HikariConfigMBean
    private boolean isJdbc4connectionTest;
    private boolean isIsolateInternalQueries;
    private boolean isRecordMetrics;
+   private IMetricsTracker metricsTracker;
    private boolean isRegisterMbeans;
    private DataSource dataSource;
    private Properties dataSourceProperties;
@@ -454,6 +456,31 @@ public class HikariConfig implements HikariConfigMBean
    public void setRecordMetrics(boolean recordMetrics)
    {
       this.isRecordMetrics = recordMetrics;
+      if (!recordMetrics) {
+         this.metricsTracker = null;
+      }
+   }
+
+   /**
+   * Get the externally-created metrics tracker to use for metrics.
+   * @return the externally-created metrics tracker 
+   */
+   public IMetricsTracker getMetricsTracker()
+   {
+      return metricsTracker;
+   }
+
+   /**
+   * Set the externally-created metrics tracker to use for metrics.
+   * A non-null value overrides anything passed to setMetricsTrackerClassName.
+   * @param metricsTracker the externally-created metrics tracker 
+   */
+   public void setMetricsTracker(IMetricsTracker metricsTracker)
+   {
+      this.metricsTracker = metricsTracker;
+      if (metricsTracker != null) {
+         isRecordMetrics = true;
+      }
    }
 
    public boolean isRegisterMbeans()

--- a/hikaricp-java6/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
+++ b/hikaricp-java6/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
@@ -132,9 +132,17 @@ public final class HikariPool implements HikariPoolMBean, IBagStateListener
       this.isJdbc4ConnectionTest = configuration.isJdbc4ConnectionTest();
       this.leakDetectionThreshold = configuration.getLeakDetectionThreshold();
       this.transactionIsolation = PoolUtilities.getTransactionIsolation(configuration.getTransactionIsolation());
-      this.isRecordMetrics = configuration.isRecordMetrics();
-      this.metricsTracker = MetricsFactory.createMetricsTracker((isRecordMetrics ? configuration.getMetricsTrackerClassName()
-            : "com.zaxxer.hikari.metrics.MetricsTracker"), configuration.getPoolName());
+
+      IMetricsTracker metricsTracker = configuration.getMetricsTracker();
+      if (metricsTracker == null) {
+         this.isRecordMetrics = configuration.isRecordMetrics();
+         this.metricsTracker = MetricsFactory.createMetricsTracker((isRecordMetrics ? configuration.getMetricsTrackerClassName()
+               : "com.zaxxer.hikari.metrics.MetricsTracker"), configuration.getPoolName());
+      }
+      else {
+         this.metricsTracker = metricsTracker;
+         this.isRecordMetrics = true;
+      }
 
       this.dataSource = initializeDataSource();
 

--- a/hikaricp-java6/src/test/java/com/zaxxer/hikari/MetricsTrackerTest.java
+++ b/hikaricp-java6/src/test/java/com/zaxxer/hikari/MetricsTrackerTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2014 Brett Wooldridge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.zaxxer.hikari;
+
+import java.sql.Connection;
+
+import org.junit.Test;
+
+import static org.mockito.Mockito.*;
+
+import com.zaxxer.hikari.mocks.StubConnection;
+import com.zaxxer.hikari.metrics.IMetricsTracker;
+
+public class MetricsTrackerTest {
+   @Test
+   public void trackOneConnection() throws Exception
+   {
+      IMetricsTracker.MetricsContext mockContext = mock(IMetricsTracker.MetricsContext.class);
+      IMetricsTracker mockTracker = mock(IMetricsTracker.class);
+      when(mockTracker.recordConnectionRequest(anyLong())).thenReturn(mockContext);
+
+      HikariConfig config = new HikariConfig();
+      config.setMinimumIdle(1);
+      config.setMaximumPoolSize(1);
+      config.setInitializationFailFast(true);
+      config.setConnectionTestQuery("VALUES 1");
+      config.setDataSourceClassName("com.zaxxer.hikari.mocks.StubDataSource");
+      config.setMetricsTracker(mockTracker);
+
+      HikariDataSource ds = new HikariDataSource(config);
+      try {
+         Connection conn = ds.getConnection();
+         conn.close();
+      }
+      finally {
+         ds.close();
+      }
+
+      verify(mockTracker).recordConnectionRequest(anyLong());
+      verify(mockContext).stop();
+      verify(mockTracker).recordConnectionUsage(anyLong());
+   }
+}
+

--- a/hikaricp/src/main/java/com/zaxxer/hikari/HikariConfig.java
+++ b/hikaricp/src/main/java/com/zaxxer/hikari/HikariConfig.java
@@ -38,6 +38,7 @@ import org.slf4j.LoggerFactory;
 import com.zaxxer.hikari.proxy.JavassistProxyFactory;
 import com.zaxxer.hikari.util.PoolUtilities;
 import com.zaxxer.hikari.util.PropertyBeanSetter;
+import com.zaxxer.hikari.metrics.IMetricsTracker;
 
 public class HikariConfig implements HikariConfigMBean
 {
@@ -79,6 +80,7 @@ public class HikariConfig implements HikariConfigMBean
    private boolean isJdbc4connectionTest;
    private boolean isIsolateInternalQueries;
    private boolean isRecordMetrics;
+   private IMetricsTracker metricsTracker;
    private boolean isRegisterMbeans;
    private DataSource dataSource;
    private Properties dataSourceProperties;
@@ -454,6 +456,31 @@ public class HikariConfig implements HikariConfigMBean
    public void setRecordMetrics(boolean recordMetrics)
    {
       this.isRecordMetrics = recordMetrics;
+      if (!recordMetrics) {
+         this.metricsTracker = null;
+      }
+   }
+
+   /**
+   * Get the externally-created metrics tracker to use for metrics.
+   * @return the externally-created metrics tracker 
+   */
+   public IMetricsTracker getMetricsTracker()
+   {
+      return metricsTracker;
+   }
+
+   /**
+   * Set the externally-created metrics tracker to use for metrics.
+   * A non-null value overrides anything passed to setMetricsTrackerClassName.
+   * @param metricsTracker the externally-created metrics tracker 
+   */
+   public void setMetricsTracker(IMetricsTracker metricsTracker)
+   {
+      this.metricsTracker = metricsTracker;
+      if (metricsTracker != null) {
+         isRecordMetrics = true;
+      }
    }
 
    public boolean isRegisterMbeans()

--- a/hikaricp/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
+++ b/hikaricp/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
@@ -131,9 +131,18 @@ public final class HikariPool implements HikariPoolMBean, IBagStateListener
       this.isJdbc4ConnectionTest = configuration.isJdbc4ConnectionTest();
       this.leakDetectionThreshold = configuration.getLeakDetectionThreshold();
       this.transactionIsolation = PoolUtilities.getTransactionIsolation(configuration.getTransactionIsolation());
-      this.isRecordMetrics = configuration.isRecordMetrics();
-      this.metricsTracker = MetricsFactory.createMetricsTracker((isRecordMetrics ? configuration.getMetricsTrackerClassName()
-            : "com.zaxxer.hikari.metrics.MetricsTracker"), configuration.getPoolName());
+
+      IMetricsTracker metricsTracker = configuration.getMetricsTracker();
+      if (metricsTracker == null) {
+         this.isRecordMetrics = configuration.isRecordMetrics();
+         this.metricsTracker = MetricsFactory.createMetricsTracker((isRecordMetrics ? configuration.getMetricsTrackerClassName()
+               : "com.zaxxer.hikari.metrics.MetricsTracker"), configuration.getPoolName());
+      }
+      else {
+         this.metricsTracker = metricsTracker;
+         this.isRecordMetrics = true;
+      }
+
 
       this.dataSource = initializeDataSource();
 

--- a/hikaricp/src/test/java/com/zaxxer/hikari/MetricsTrackerTest.java
+++ b/hikaricp/src/test/java/com/zaxxer/hikari/MetricsTrackerTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2014 Brett Wooldridge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.zaxxer.hikari;
+
+import java.sql.Connection;
+
+import org.junit.Test;
+
+import static org.mockito.Mockito.*;
+
+import com.zaxxer.hikari.mocks.StubConnection;
+import com.zaxxer.hikari.metrics.IMetricsTracker;
+
+public class MetricsTrackerTest {
+   @Test
+   public void trackOneConnection() throws Exception
+   {
+      IMetricsTracker.MetricsContext mockContext = mock(IMetricsTracker.MetricsContext.class);
+      IMetricsTracker mockTracker = mock(IMetricsTracker.class);
+      when(mockTracker.recordConnectionRequest(anyLong())).thenReturn(mockContext);
+
+      HikariConfig config = new HikariConfig();
+      config.setMinimumIdle(1);
+      config.setMaximumPoolSize(1);
+      config.setInitializationFailFast(true);
+      config.setConnectionTestQuery("VALUES 1");
+      config.setDataSourceClassName("com.zaxxer.hikari.mocks.StubDataSource");
+      config.setMetricsTracker(mockTracker);
+
+      HikariDataSource ds = new HikariDataSource(config);
+      try {
+         Connection conn = ds.getConnection();
+         conn.close();
+      }
+      finally {
+         ds.close();
+      }
+
+      verify(mockTracker).recordConnectionRequest(anyLong());
+      verify(mockContext).stop();
+      verify(mockTracker).recordConnectionUsage(anyLong());
+   }
+}
+


### PR DESCRIPTION
...rather than having to specify a class name.

This eases wiring metrics with Spring for clients who wish to do so, without introducing any new dependencies within Hikari or committing to a specific metrics library in the API.
