### PR TITLE
Add pool name to filler and closer threads

### DIFF
--- a/hikaricp/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
+++ b/hikaricp/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
@@ -141,8 +141,8 @@ public final class HikariPool implements HikariPoolMBean, IBagStateListener
          HikariMBeanElf.registerMBeans(configuration, this);
       }
 
-      addConnectionExecutor = createThreadPoolExecutor(configuration.getMaximumPoolSize(), "HikariCP connection filler", configuration.getThreadFactory());
-      closeConnectionExecutor = createThreadPoolExecutor(configuration.getMaximumPoolSize(), "HikariCP connection closer", configuration.getThreadFactory());
+      addConnectionExecutor = createThreadPoolExecutor(configuration.getMaximumPoolSize(), "HikariCP connection filler (pool " + configuration.getPoolName() + ")", configuration.getThreadFactory());
+      closeConnectionExecutor = createThreadPoolExecutor(configuration.getMaximumPoolSize(), "HikariCP connection closer (pool " + configuration.getPoolName() + ")", configuration.getThreadFactory());
 
       fillPool();
 


### PR DESCRIPTION
Simple patch to make debugging easier in environments involving lots of different pools (e.g., sharded databases)
