### PR TITLE
Fix copy of properties when using a jdbc url.

### DIFF
--- a/hikaricp-java6/src/main/java/com/zaxxer/hikari/util/DriverDataSource.java
+++ b/hikaricp-java6/src/main/java/com/zaxxer/hikari/util/DriverDataSource.java
@@ -35,7 +35,8 @@ public final class DriverDataSource implements DataSource
    {
       try {
          this.jdbcUrl = jdbcUrl;
-         this.driverProperties = new Properties(properties);
+         this.driverProperties = new Properties();
+         this.driverProperties.putAll(properties);
          if (username != null) {
             driverProperties.put("user", driverProperties.getProperty("user", username));
          }

--- a/hikaricp/src/main/java/com/zaxxer/hikari/util/DriverDataSource.java
+++ b/hikaricp/src/main/java/com/zaxxer/hikari/util/DriverDataSource.java
@@ -35,7 +35,8 @@ public final class DriverDataSource implements DataSource
    {
       try {
          this.jdbcUrl = jdbcUrl;
-         this.driverProperties = new Properties(properties);
+         this.driverProperties = new Properties();
+         this.driverProperties.putAll(properties);
          if (username != null) {
             driverProperties.put("user", driverProperties.getProperty("user", username));
          }


### PR DESCRIPTION
Constructor Properties(Properties properties) is not a copy constructor.

Spotted while playing with preparedStatementCacheSize parameter of pgjdbc-ng.
