### PR TITLE
correct  param description

### DIFF
--- a/hikaricp-common/src/main/java/com/zaxxer/hikari/pool/BaseHikariPool.java
+++ b/hikaricp-common/src/main/java/com/zaxxer/hikari/pool/BaseHikariPool.java
@@ -401,7 +401,7 @@ public abstract class BaseHikariPool implements HikariPoolMBean, IBagStateListen
    /**
     * Permanently close the real (underlying) connection (eat any exception).
     *
-    * @param connectionProxy the connection to actually close
+    * @param bagEntry the bagEntry which track the connection to actually close
     */
    protected abstract void closeConnection(final PoolBagEntry bagEntry);
 

--- a/hikaricp-java6/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
+++ b/hikaricp-java6/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
@@ -125,7 +125,7 @@ public final class HikariPool extends BaseHikariPool
    /**
     * Permanently close the real (underlying) connection (eat any exception).
     *
-    * @param connectionProxy the connection to actually close
+    * @param bagEntry the bagEntry which track the connection to actually close
     */
    protected void closeConnection(final PoolBagEntry bagEntry)
    {

--- a/hikaricp/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
+++ b/hikaricp/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
@@ -112,7 +112,7 @@ public final class HikariPool extends BaseHikariPool
    /**
     * Permanently close the real (underlying) connection (eat any exception).
     *
-    * @param connectionProxy the connection to actually close
+    * @param bagEntry the bagEntry which track the connection to actually close
     */
    @Override
    protected void closeConnection(final PoolBagEntry bagEntry)


### PR DESCRIPTION
Correct the param description for closeConnection(final PoolBagEntry bagEntry).
Glad to see recent changes from hikariCP(  the common code drawn into hikaricp-common to make the code more concise. )
