### PR TITLE
Fix for #214.  Handle the `UnsupportedOperationException`

### DIFF
--- a/hikaricp-common/src/main/java/com/zaxxer/hikari/util/PoolUtilities.java
+++ b/hikaricp-common/src/main/java/com/zaxxer/hikari/util/PoolUtilities.java
@@ -126,6 +126,9 @@ public final class PoolUtilities
          catch (NoSuchMethodError e) {
             IS_JDBC40 = false;
          }
+         catch (UnsupportedOperationException e) {
+            IS_JDBC40 = false;
+         }
 
          jdbc40checked = true;
       }


### PR DESCRIPTION
Handle the `UnsupportedOperationException` that is thrown by `JdbcOdbcDriver.isValid()`.
