### PR TITLE
update to Javassist-3.19.0-GA

### DIFF
--- a/hikaricp-java6/src/test/java/com/zaxxer/hikari/osgi/OSGiBundleTest.java
+++ b/hikaricp-java6/src/test/java/com/zaxxer/hikari/osgi/OSGiBundleTest.java
@@ -48,7 +48,7 @@ public class OSGiBundleTest
             systemProperty("org.ops4j.pax.logging.DefaultServiceLog.level").value("WARN"),
             mavenBundle("org.slf4j","slf4j-api","1.7.5"),
             mavenBundle("org.slf4j","slf4j-simple","1.7.5").noStart(),
-            mavenBundle("org.javassist", "javassist", "3.18.1-GA"),
+            mavenBundle("org.javassist", "javassist", "3.19.0-GA"),
             new File("target/classes").exists()
                 ?  bundle("reference:file:target/classes")
                 :  bundle("reference:file:../target/classes"),

--- a/hikaricp/src/main/java/com/zaxxer/hikari/proxy/JavassistProxyFactory.java
+++ b/hikaricp/src/main/java/com/zaxxer/hikari/proxy/JavassistProxyFactory.java
@@ -227,7 +227,7 @@ public final class JavassistProxyFactory
          paramTypes.add(toJavaClass(pt));
       }
 
-      return intf.getDeclaredMethod(intfMethod.getName(), paramTypes.toArray(new Class[0])).toString().contains("default ");
+      return intf.getDeclaredMethod(intfMethod.getName(), paramTypes.toArray(new Class[0])).isDefault();
    }
 
    private Class toJavaClass(CtClass cls) throws Exception

--- a/hikaricp/src/main/java/com/zaxxer/hikari/proxy/JavassistProxyFactory.java
+++ b/hikaricp/src/main/java/com/zaxxer/hikari/proxy/JavassistProxyFactory.java
@@ -227,7 +227,7 @@ public final class JavassistProxyFactory
          paramTypes.add(toJavaClass(pt));
       }
 
-      return intf.getDeclaredMethod(intfMethod.getName(), paramTypes.toArray(new Class[0])).isDefault();
+      return intf.getDeclaredMethod(intfMethod.getName(), paramTypes.toArray(new Class[0])).toString().contains("default ");
    }
 
    private Class toJavaClass(CtClass cls) throws Exception

--- a/hikaricp/src/main/java/com/zaxxer/hikari/proxy/JavassistProxyFactory.java
+++ b/hikaricp/src/main/java/com/zaxxer/hikari/proxy/JavassistProxyFactory.java
@@ -16,12 +16,15 @@
 
 package com.zaxxer.hikari.proxy;
 
+import java.lang.reflect.Array;
 import java.sql.CallableStatement;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Statement;
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import javassist.ClassPool;
@@ -157,6 +160,11 @@ public final class JavassistProxyFactory
                continue;
             }
 
+            // Ignore default methods (only for Jre8 or later)
+            if (isDefaultMethod(intf, intfCt, intfMethod)) {
+               continue;
+            }
+
             // Track what methods we've added
             methods.add(signature);
 
@@ -209,5 +217,40 @@ public final class JavassistProxyFactory
       }
 
       return false;
+   }
+
+   private boolean isDefaultMethod(Class intf, CtClass intfCt, CtMethod intfMethod) throws Exception
+   {
+      List<Class> paramTypes = new ArrayList<Class>();
+
+      for (CtClass pt : intfMethod.getParameterTypes()) {
+         paramTypes.add(toJavaClass(pt));
+      }
+
+      return intf.getDeclaredMethod(intfMethod.getName(), paramTypes.toArray(new Class[0])).toString().contains("default ");
+   }
+
+   private Class toJavaClass(CtClass cls) throws Exception
+   {
+      if (cls.getName().endsWith("[]")) {
+         return Array.newInstance(toJavaClass(cls.getName().replace("[]", "")), 0).getClass();
+      } else {
+         return toJavaClass(cls.getName());
+      }
+   }
+
+   private Class toJavaClass(String cn) throws Exception
+   {
+      if ("int".equals(cn)) { return int.class; }
+      if ("long".equals(cn)) { return long.class; }
+      if ("short".equals(cn)) { return short.class; }
+      if ("byte".equals(cn)) { return byte.class; }
+      if ("float".equals(cn)) { return float.class; }
+      if ("double".equals(cn)) { return double.class; }
+      if ("boolean".equals(cn)) { return boolean.class; }
+      if ("char".equals(cn)) { return char.class; }
+      if ("void".equals(cn)) { return void.class; }
+
+      return Class.forName(cn);
    }
 }

--- a/hikaricp/src/test/java/com/zaxxer/hikari/osgi/OSGiBundleTest.java
+++ b/hikaricp/src/test/java/com/zaxxer/hikari/osgi/OSGiBundleTest.java
@@ -48,7 +48,7 @@ public class OSGiBundleTest
             systemProperty("org.ops4j.pax.logging.DefaultServiceLog.level").value("WARN"),
             mavenBundle("org.slf4j","slf4j-api","1.7.5"),
             mavenBundle("org.slf4j","slf4j-simple","1.7.5").noStart(),
-            mavenBundle("org.javassist", "javassist", "3.18.1-GA"),
+            mavenBundle("org.javassist", "javassist", "3.19.0-GA"),
             new File("target/classes").exists()
                 ?  bundle("reference:file:target/classes")
                 :  bundle("reference:file:../target/classes"),

--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@
       <dependency>
          <groupId>org.javassist</groupId>
          <artifactId>javassist</artifactId>
-         <version>3.18.1-GA</version>
+         <version>3.19.0-GA</version>
          <scope>compile</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
VerifyError occurs when update to Javassist-3.19.0-GA as follows.
Java8's default methods should be ignored to avoid this issue.

```text
Caused by: java.lang.VerifyError: Illegal type at constant pool entry 417 in class com.zaxxer.hikari.proxy.PreparedStatementJavassistProxy
Exception Details:
  Location:
    com/zaxxer/hikari/proxy/PreparedStatementJavassistProxy.setObject(ILjava/lang/Object;Ljava/sql/SQLType;)V @4: invokespecial
  Reason:
    Constant pool index 417 is invalid
  Bytecode:
    0x0000000: 2a1b 2c2d b701 a1a7 000c 3a04 2a19 04b6
    0x0000010: 001b bfb1                              
  Exception Handler Table:
    bci [0, 7] => handler: 10
  Stackmap Table:
    full_frame(@10,{Object[#2],Integer,Object[#285],Object[#412]},{Object[#17]})
    same_frame(@19)

	at com.zaxxer.hikari.proxy.ProxyFactory.getProxyPreparedStatement(ProxyFactory.java) ~[HikariCP-2.2.5.jar:na]
	at com.zaxxer.hikari.proxy.ConnectionProxy.prepareStatement(ConnectionProxy.java:280) ~[HikariCP-2.2.5.jar:na]
	at com.zaxxer.hikari.proxy.ConnectionJavassistProxy.prepareStatement(ConnectionJavassistProxy.java) ~[HikariCP-2.2.5.jar:na]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:1.8.0_25]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[na:1.8.0_25]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.8.0_25]
	at java.lang.reflect.Method.invoke(Method.java:483) ~[na:1.8.0_25]
```
