### PR TITLE
Expose the PoolMbean calls to the datasource and verify they actually work

### DIFF
--- a/hikaricp-common/src/main/java/com/zaxxer/hikari/HikariDataSource.java
+++ b/hikaricp-common/src/main/java/com/zaxxer/hikari/HikariDataSource.java
@@ -79,6 +79,26 @@ public class HikariDataSource extends HikariConfig implements DataSource, Closea
       multiPool.put(new MultiPoolKey(getUsername(), getPassword()), pool);
    }
 
+   /** Expose the PoolMbean's idle connection count */
+   public int getIdleConnections() {
+      return pool.getIdleConnections();
+   }
+
+   /** Expose the PoolMbean's active connection count */
+   public int getActiveConnections() {
+      return pool.getActiveConnections();
+   }
+
+   /** Expose the PoolMbean's total connection count */
+   public int getTotalConnections() {
+      return pool.getTotalConnections();
+   }
+
+   /** Expose the PoolMbean's threads awaiting connection count */
+   public int getThreadsAwaitingConnection() {
+      return pool.getThreadsAwaitingConnection();
+   }
+
    /** {@inheritDoc} */
    @Override
    public Connection getConnection() throws SQLException
@@ -203,7 +223,7 @@ public class HikariDataSource extends HikariConfig implements DataSource, Closea
       if (iface.isInstance(this)) {
          return true;
       }
-      
+
       if (pool != null) {
          if (iface.isInstance(pool.getDataSource())) {
             return true;

--- a/hikaricp-common/src/test/java/com/zaxxer/hikari/TestMBean.java
+++ b/hikaricp-common/src/test/java/com/zaxxer/hikari/TestMBean.java
@@ -17,6 +17,7 @@ package com.zaxxer.hikari;
 
 import java.sql.SQLException;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 public class TestMBean
@@ -33,6 +34,10 @@ public class TestMBean
         config.setDataSourceClassName("com.zaxxer.hikari.mocks.StubDataSource");
 
         HikariDataSource ds = new HikariDataSource(config);
+        Assert.assertEquals(0, ds.getIdleConnections());
+        Assert.assertEquals(0, ds.getActiveConnections());
+        Assert.assertEquals(0, ds.getTotalConnections());
+        Assert.assertEquals(0, ds.getThreadsAwaitingConnection());
         ds.close();
     }
 }


### PR DESCRIPTION
Hi.  I messaged you some time ago about some NuProcess threading issues, thanks for helping out on that front.  Today I was upgrading my database connection library in a project and saw that BoneCP was no longer being maintained.  I looked over Hikari and came away impressed!  The only functionality missing from BoneCP that I needed was the ability to access meta-data on the pool in real time for some generic status services my system exposes.

So, here's a simple patch.  If you'd rather do this some other that's fine.  I'm just angling for a solution, and thought it would be better to show up with one than to just ask you for one.