### PR TITLE
Throws customized fail-fast exception.

### DIFF
--- a/hikaricp-common/src/main/java/com/zaxxer/hikari/pool/FailFastException.java
+++ b/hikaricp-common/src/main/java/com/zaxxer/hikari/pool/FailFastException.java
@@ -1,0 +1,11 @@
+package com.zaxxer.hikari.pool;
+
+public class FailFastException extends RuntimeException {
+    public FailFastException(String message) {
+        super(message);
+    }
+
+    public FailFastException(String message, Throwable thr) {
+        super(message, thr);
+    }
+}


### PR DESCRIPTION
In our product we display the error messages to user when exception is thrown, but “fail-fast during initialization” is meaningless for end users, so we want to remove the fail-fast exception from exception stack when outputting error message. But the exception was general RuntimeException, we can only identify it by checking the exception message, which seems not reliable, so I did this change to throw a special exception and catch it for this purpose.