### PR TITLE
Unwrap ConnectionProvider to DataSource

### DIFF
--- a/hikaricp-common/src/main/java/com/zaxxer/hikari/hibernate/HikariConnectionProvider.java
+++ b/hikaricp-common/src/main/java/com/zaxxer/hikari/hibernate/HikariConnectionProvider.java
@@ -31,6 +31,8 @@ import org.slf4j.LoggerFactory;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 
+import javax.sql.DataSource;
+
 /**
  * Connection provider for Hibernate 4.3.
  *
@@ -125,12 +127,16 @@ public class HikariConnectionProvider implements ConnectionProvider, Configurabl
    @SuppressWarnings("unchecked")
    public <T> T unwrap(Class<T> unwrapType)
    {
-      if (isUnwrappableAs(unwrapType)) {
-         return (T) this;
-      }
-      else {
-         throw new UnknownUnwrapTypeException(unwrapType);
-      }
+       if ( ConnectionProvider.class.equals( unwrapType ) ||
+               HikariConnectionProvider.class.isAssignableFrom( unwrapType ) ) {
+           return (T) this;
+       }
+       else if ( DataSource.class.isAssignableFrom( unwrapType ) ) {
+           return (T) this.hds;
+       }
+       else {
+           throw new UnknownUnwrapTypeException( unwrapType );
+       }
    }
 
    // *************************************************************************


### PR DESCRIPTION
Issue 273 (https://github.com/brettwooldridge/HikariCP/issues/273), special case for when called to unwrap a DataSource, copying the same behavior as the ConnectionProvider implementations by Hibernate.