### PR TITLE
Changing the documented jConnect Sybase Driver to an implementation that works

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ Here is a list of JDBC *DataSource* classes for popular databases:
 | Oracle           | Oracle       | oracle.jdbc.pool.OracleDataSource |
 | PostgreSQL       | pgjdbc-ng    | com.impossibl.postgres.jdbc.PGDataSource |
 | PostgreSQL       | PostgreSQL   | org.postgresql.ds.PGSimpleDataSource |
-| SyBase           | jConnect     | com.sybase.jdbcx.SybDataSource |
+| SyBase           | jConnect     | com.sybase.jdbc4.jdbc.SybDataSource |
 
 ### Play Framework Plugin
 


### PR DESCRIPTION
The jConnect Driver (as of version 7.0) has two package implementations for the Driver: 1) com.sybase.jdbcx.SybDataSource and 2) com.sybase.jdbc4.jdbc.SybDataSource .

If 1) is used then an exception is thrown from the HikariCP since it's looking for a default constructor that is not there and throws the following exception upon initialisation:

Caused by: java.lang.InstantiationException: com.sybase.jdbcx.SybDataSource
at java.lang.Class.newInstance(Class.java:418)
at com.zaxxer.hikari.util.UtilityElf.createInstance(UtilityElf.java:117)
... 62 more
Caused by: java.lang.NoSuchMethodException: com.sybase.jdbcx.SybDataSource.()
at java.lang.Class.getConstructor0(Class.java:3069)
at java.lang.Class.newInstance(Class.java:403)
... 63 more


Switching to 2) the driver starts up successfully and it's fully operational, therefore I'm changing this documentation line to reflect that.

ps. HikariCP version 2.3.8 as advised since jdk8

thanks,
Dimitrios