### PR TITLE
Allow the use of a user provided MetricsTracker

### DIFF
--- a/src/main/java/com/zaxxer/hikari/HikariDataSource.java
+++ b/src/main/java/com/zaxxer/hikari/HikariDataSource.java
@@ -29,6 +29,7 @@ import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.zaxxer.hikari.metrics.MetricsTrackerFactory;
 import com.zaxxer.hikari.pool.HikariPool;
 import com.zaxxer.hikari.proxy.IHikariConnectionProxy;
 import com.zaxxer.hikari.util.DriverDataSource;
@@ -192,17 +193,17 @@ public class HikariDataSource extends HikariConfig implements DataSource, Closea
 
    /** {@inheritDoc} */
    @Override
-   public void setMetricRegistry(Object metricRegistry)
+   public void setMetricsTrackerFactory(MetricsTrackerFactory metricsTrackerFactory)
    {
-      boolean isAlreadySet = getMetricRegistry() != null;
-      super.setMetricRegistry(metricRegistry);
+      boolean isAlreadySet = getMetricsTrackerFactory() != null;
+      super.setMetricsTrackerFactory(metricsTrackerFactory);
 
       if (pool != null) {
          if (isAlreadySet) {
-            throw new IllegalStateException("MetricRegistry can only be set one time");
+            throw new IllegalStateException("MetricsTrackerFactory can only be set one time");
          }
          else {
-            pool.setMetricRegistry(super.getMetricRegistry());
+            pool.setMetricsTrackerFactory(super.getMetricsTrackerFactory());
          }
       }
    }

--- a/src/main/java/com/zaxxer/hikari/metrics/CodahaleMetricsTrackerFactory.java
+++ b/src/main/java/com/zaxxer/hikari/metrics/CodahaleMetricsTrackerFactory.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2013,2014 Brett Wooldridge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.zaxxer.hikari.metrics;
+
+import com.codahale.metrics.MetricRegistry;
+
+public final class CodahaleMetricsTrackerFactory implements MetricsTrackerFactory
+{
+   private final MetricRegistry registry;
+
+   public CodahaleMetricsTrackerFactory(MetricRegistry registry) {
+      this.registry = registry;
+   }
+
+   public MetricRegistry getRegistry()
+   {
+      return registry;
+   }
+
+   @Override
+   public MetricsTracker create(String poolName, PoolStats poolStats)
+   {
+      return new CodaHaleMetricsTracker(poolName, poolStats, registry);
+   }
+}

--- a/src/main/java/com/zaxxer/hikari/metrics/MetricsTrackerFactory.java
+++ b/src/main/java/com/zaxxer/hikari/metrics/MetricsTrackerFactory.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2013,2014 Brett Wooldridge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.zaxxer.hikari.metrics;
+
+public interface MetricsTrackerFactory {
+   MetricsTracker create(String poolName, PoolStats poolStats);
+}

--- a/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
+++ b/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
@@ -46,7 +46,9 @@ import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariPoolMXBean;
 import com.zaxxer.hikari.metrics.CodaHaleMetricsTracker;
 import com.zaxxer.hikari.metrics.CodahaleHealthChecker;
+import com.zaxxer.hikari.metrics.CodahaleMetricsTrackerFactory;
 import com.zaxxer.hikari.metrics.MetricsTracker;
+import com.zaxxer.hikari.metrics.MetricsTrackerFactory;
 import com.zaxxer.hikari.metrics.MetricsTracker.MetricsContext;
 import com.zaxxer.hikari.metrics.PoolStats;
 import com.zaxxer.hikari.proxy.ConnectionProxy;
@@ -285,9 +287,19 @@ public class HikariPool implements HikariPoolMXBean, IBagStateListener
 
    public void setMetricRegistry(Object metricRegistry)
    {
-      this.isRecordMetrics = metricRegistry != null;
+      if (metricRegistry != null) {
+         setMetricsTrackerFactory(new CodahaleMetricsTrackerFactory((MetricRegistry) metricRegistry));
+      }
+      else {
+         setMetricsTrackerFactory(null);
+      }
+   }
+
+   public void setMetricsTrackerFactory(MetricsTrackerFactory metricsTrackerFactory)
+   {
+      this.isRecordMetrics = metricsTrackerFactory != null;
       if (isRecordMetrics) {
-         this.metricsTracker = new CodaHaleMetricsTracker(poolName, getPoolStats(), (MetricRegistry) metricRegistry);
+         this.metricsTracker = metricsTrackerFactory.create(config.getPoolName(), getPoolStats());
       }
       else {
          this.metricsTracker = new MetricsTracker();


### PR DESCRIPTION
This pull request intends to allow the use of other metrics libraries than Dropwizard Metrics. It uses the current MetricsTracker class without modification, it simply adds a MetricsTrackerFactory interface that will create an instance of a subclass of MetricsTracker.

The Dropwizard/CodeHale current implementation has been adapted to use a MetricsTrackerFactory, some methods have been rewritten but no method has been deleted or deprecated.