### PR TITLE
Add example how to configure port for PGSimpleDataSource

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,7 @@ dataSourceClassName=org.postgresql.ds.PGSimpleDataSource
 dataSource.user=test
 dataSource.password=test
 dataSource.databaseName=mydb
+dataSource.portNumber=5432
 dataSource.serverName=localhost
 ```
 or ``java.util.Properties`` based:


### PR DESCRIPTION
It took me quite some time to figure out how to configure a custom port.

Finally found at: https://jdbc.postgresql.org/documentation/publicapi/org/postgresql/ds/PGSimpleDataSource.html

Note: You could probably add a link to any data-source Java-docs in the data-source-class-name-list and add a note that any property supported by data-source can be defined in as property (if not there already).