### PR TITLE
Improved keep alive query handling

### DIFF
--- a/src/main/java/com/zaxxer/hikari/pool/PoolElf.java
+++ b/src/main/java/com/zaxxer/hikari/pool/PoolElf.java
@@ -5,7 +5,6 @@ import static com.zaxxer.hikari.util.UtilityElf.createInstance;
 import java.lang.management.ManagementFactory;
 import java.lang.reflect.Field;
 import java.sql.Connection;
-import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Properties;
@@ -205,9 +204,7 @@ public final class PoolElf
    
          try (Statement statement = connection.createStatement()) {
             setQueryTimeout(statement, timeoutSec);
-            try (ResultSet rs = statement.executeQuery(config.getConnectionTestQuery())) { 
-               /* auto close */
-            }
+            statement.execute(config.getConnectionTestQuery());
          }
    
          if (isIsolateInternalQueries && !isAutoCommit) {


### PR DESCRIPTION
Judging from the try-with-resources and the small scope, we are not
interested in the ResultSet.

(NB: I originally fixed this on 2.3.x, read that you rather want
fixes on the dev branch, so forward ported it but saw it was
fixed already, so good on you! I just propose this as a better fix, do
with it what you want)