### PR TITLE
HikariPool: Log consitency

### DIFF
--- a/src/main/java/com/zaxxer/hikari/HikariConfig.java
+++ b/src/main/java/com/zaxxer/hikari/HikariConfig.java
@@ -824,7 +824,7 @@ public class HikariConfig implements HikariConfigMXBean
 
    private void logConfiguration()
    {
-      LOGGER.debug("HikariCP pool {} configuration:", poolName);
+      LOGGER.debug("{} - configuration:", poolName);
       final Set<String> propertyNames = new TreeSet<>(PropertyElf.getPropertyNames(HikariConfig.class));
       for (String prop : propertyNames) {
          try {

--- a/src/main/java/com/zaxxer/hikari/HikariConfig.java
+++ b/src/main/java/com/zaxxer/hikari/HikariConfig.java
@@ -474,6 +474,7 @@ public class HikariConfig implements HikariConfigMXBean
     * @param metricRegistry the Codahale MetricRegistry to set
     */
    public void setMetricRegistry(Object metricRegistry)
+   {
       if (metricsTrackerFactory != null) {
          throw new IllegalStateException("cannot use setMetricRegistry() and setMetricsTrackerFactory() together");
       }

--- a/src/main/java/com/zaxxer/hikari/HikariConfig.java
+++ b/src/main/java/com/zaxxer/hikari/HikariConfig.java
@@ -452,7 +452,7 @@ public class HikariConfig implements HikariConfigMXBean
    public void setMetricsTrackerFactory(MetricsTrackerFactory metricsTrackerFactory)
    {
       if (metricRegistry != null) {
-         throw new IllegalStateException("setMetricsTrackerFactory() cannot used in combination with setMetricRegistry()");
+         throw new IllegalStateException("cannot use setMetricsTrackerFactory() and setMetricRegistry() together");
       }
 
       this.metricsTrackerFactory = metricsTrackerFactory;
@@ -474,9 +474,8 @@ public class HikariConfig implements HikariConfigMXBean
     * @param metricRegistry the Codahale MetricRegistry to set
     */
    public void setMetricRegistry(Object metricRegistry)
-   {
       if (metricsTrackerFactory != null) {
-         throw new IllegalStateException("setMetricRegistry() cannot used in combination with setMetricsTrackerFactory()");
+         throw new IllegalStateException("cannot use setMetricRegistry() and setMetricsTrackerFactory() together");
       }
 
       if (metricRegistry != null) {
@@ -760,11 +759,11 @@ public class HikariConfig implements HikariConfigMXBean
 
       if (driverClassName != null && jdbcUrl == null) {
          logger.error("jdbcUrl is required with driverClassName");
-         throw new IllegalStateException("jdbcUrl is required with driverClassName");
+         throw new IllegalArgumentException("jdbcUrl is required with driverClassName");
       }
       else if (driverClassName != null && dataSourceClassName != null) {
          logger.error("cannot use driverClassName and dataSourceClassName together");
-         throw new IllegalStateException("cannot use driverClassName and dataSourceClassName together");
+         throw new IllegalArgumentException("cannot use driverClassName and dataSourceClassName together");
       }
       else if (jdbcUrl != null) {
          // OK

--- a/src/main/java/com/zaxxer/hikari/HikariDataSource.java
+++ b/src/main/java/com/zaxxer/hikari/HikariDataSource.java
@@ -69,7 +69,7 @@ public class HikariDataSource extends HikariConfig implements DataSource, Closea
       configuration.validate();
       configuration.copyState(this);
 
-      LOGGER.info("Hikari pool {} is starting.", configuration.getPoolName());
+      LOGGER.info("{} - is starting.", configuration.getPoolName());
       pool = fastPathPool = new HikariPool(this);
    }
 
@@ -78,7 +78,7 @@ public class HikariDataSource extends HikariConfig implements DataSource, Closea
    public Connection getConnection() throws SQLException
    {
       if (isClosed()) {
-         throw new SQLException("HikariDataSource " + this + " has been shutdown");
+         throw new SQLException("HikariDataSource " + this + " has been closed.");
       }
 
       if (fastPathPool != null) {
@@ -92,7 +92,7 @@ public class HikariDataSource extends HikariConfig implements DataSource, Closea
             result = pool;
             if (result == null) {
                validate();
-               LOGGER.info("Hikari pool {} is starting.", getPoolName());
+               LOGGER.info("{} - is starting.", getPoolName());
                pool = result = new HikariPool(this);
             }
          }
@@ -289,7 +289,7 @@ public class HikariDataSource extends HikariConfig implements DataSource, Closea
             pool.shutdown();
          }
          catch (InterruptedException e) {
-            LoggerFactory.getLogger(getClass()).warn("Interrupted during shutdown", e);
+        	 LOGGER.warn("Interrupted during closing", e);
          }
 
          if (pool.getDataSource() instanceof DriverDataSource) {

--- a/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
+++ b/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
@@ -208,7 +208,7 @@ public class HikariPool implements HikariPoolMXBean, IBagStateListener
       if (originalException instanceof SQLException) {
          sqlState = ((SQLException) originalException).getSQLState();
       }
-      throw new SQLTransientConnectionException(poolName + " - Connection not available, timeout after " + clockSource.elapsedMillis(startTime) + "ms.", sqlState, originalException);
+      throw new SQLTransientConnectionException(poolName + " - Connection is not available, request timed out after " + clockSource.elapsedMillis(startTime) + "ms.", sqlState, originalException);
    }
 
    /**

--- a/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
+++ b/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
@@ -196,7 +196,7 @@ public class HikariPool implements HikariPoolMXBean, IBagStateListener
          while (timeout > 0L);
       }
       catch (InterruptedException e) {
-         throw new SQLException("Interrupted during connection acquisition", e);
+         throw new SQLException(poolName + " - Interrupted during connection acquisition", e);
       }
       finally {
          suspendResumeLock.release();
@@ -208,7 +208,7 @@ public class HikariPool implements HikariPoolMXBean, IBagStateListener
       if (originalException instanceof SQLException) {
          sqlState = ((SQLException) originalException).getSQLState();
       }
-      throw new SQLTimeoutException(String.format("Timeout after %dms of waiting for a connection.", clockSource.elapsedMillis(startTime)), sqlState, originalException);
+      throw new SQLTimeoutException(poolName + " - Cannot acquire connection, Timeout after " + clockSource.elapsedMillis(startTime) + "ms.", sqlState, originalException);
    }
 
    /**
@@ -239,8 +239,8 @@ public class HikariPool implements HikariPoolMXBean, IBagStateListener
       try {
          poolState = POOL_SHUTDOWN;
 
-         LOGGER.info("Hikari pool {} is shutting down.", poolName);
-         logPoolState("Before shutdown ");
+         LOGGER.info("{} - is closing down.", poolName);
+         logPoolState("Before closing ");
 
          connectionBag.close();
          softEvictConnections();
@@ -270,7 +270,7 @@ public class HikariPool implements HikariPoolMXBean, IBagStateListener
          closeConnectionExecutor.awaitTermination(5L, TimeUnit.SECONDS);
       }
       finally {
-         logPoolState("After shutdown ");
+         logPoolState("After closing ");
 
          poolElf.unregisterMBeans();
          metricsTracker.close();
@@ -423,7 +423,7 @@ public class HikariPool implements HikariPoolMXBean, IBagStateListener
    public final synchronized void suspendPool()
    {
       if (suspendResumeLock == SuspendResumeLock.FAUX_LOCK) {
-         throw new IllegalStateException("Pool " + poolName + " is not suspendable");
+         throw new IllegalStateException(poolName + " - is not suspendable");
       }
       else if (poolState != POOL_SUSPENDED) {
          suspendResumeLock.suspend();
@@ -483,7 +483,7 @@ public class HikariPool implements HikariPoolMXBean, IBagStateListener
       // Speculative increment of totalConnections with expectation of success
       if (totalConnections.incrementAndGet() > config.getMaximumPoolSize()) {
          totalConnections.decrementAndGet(); // Pool is maxed out, so undo speculative increment of totalConnections
-         lastConnectionFailure.set(new SQLException("Hikari pool " + poolName +" is at maximum capacity"));
+         lastConnectionFailure.set(new SQLException(poolName +" - is at maximum capacity"));
          return true;
       }
 
@@ -497,7 +497,7 @@ public class HikariPool implements HikariPoolMXBean, IBagStateListener
 
          connectionBag.add(new PoolBagEntry(connection, this));
          lastConnectionFailure.set(null);
-         LOGGER.debug("{} - Connection {} added to pool", poolName, connection);
+         LOGGER.debug("{} - Added connection {}", poolName, connection);
 
          return true;
       }
@@ -505,7 +505,7 @@ public class HikariPool implements HikariPoolMXBean, IBagStateListener
          totalConnections.decrementAndGet(); // We failed, so undo speculative increment of totalConnections
          lastConnectionFailure.set(e);
          if (poolState == POOL_NORMAL) {
-            LOGGER.debug("{} - Connection attempt to database failed", poolName, e);
+        	 LOGGER.debug("{} - Cannot acquire connection from data source", poolName, e);
          }
          poolElf.quietlyCloseConnection(connection, "(exception during connection creation)");
          return false;

--- a/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
+++ b/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
@@ -24,7 +24,7 @@ import static com.zaxxer.hikari.util.UtilityElf.quietlySleep;
 
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.sql.SQLTimeoutException;
+import java.sql.SQLTransientConnectionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.FutureTask;
@@ -208,7 +208,7 @@ public class HikariPool implements HikariPoolMXBean, IBagStateListener
       if (originalException instanceof SQLException) {
          sqlState = ((SQLException) originalException).getSQLState();
       }
-      throw new SQLTimeoutException(poolName + " - Cannot acquire connection, Timeout after " + clockSource.elapsedMillis(startTime) + "ms.", sqlState, originalException);
+      throw new SQLTransientConnectionException(poolName + " - Connection not available, timeout after " + clockSource.elapsedMillis(startTime) + "ms.", sqlState, originalException);
    }
 
    /**

--- a/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
+++ b/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
@@ -239,7 +239,7 @@ public class HikariPool implements HikariPoolMXBean, IBagStateListener
       try {
          poolState = POOL_SHUTDOWN;
 
-         LOGGER.info("{} - is shutting down.", poolName);
+         LOGGER.info("{} - is closing down.", poolName);
          logPoolState("Before closing ");
 
          connectionBag.close();

--- a/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
+++ b/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
@@ -239,7 +239,7 @@ public class HikariPool implements HikariPoolMXBean, IBagStateListener
       try {
          poolState = POOL_SHUTDOWN;
 
-         LOGGER.info("{} - is closing down.", poolName);
+         LOGGER.info("{} - is shutting down.", poolName);
          logPoolState("Before closing ");
 
          connectionBag.close();
@@ -483,7 +483,7 @@ public class HikariPool implements HikariPoolMXBean, IBagStateListener
       // Speculative increment of totalConnections with expectation of success
       if (totalConnections.incrementAndGet() > config.getMaximumPoolSize()) {
          totalConnections.decrementAndGet(); // Pool is maxed out, so undo speculative increment of totalConnections
-         lastConnectionFailure.set(new SQLException(poolName +" - is at maximum capacity"));
+         lastConnectionFailure.set(new SQLException(poolName + " - is at maximum capacity"));
          return true;
       }
 
@@ -505,7 +505,7 @@ public class HikariPool implements HikariPoolMXBean, IBagStateListener
          totalConnections.decrementAndGet(); // We failed, so undo speculative increment of totalConnections
          lastConnectionFailure.set(e);
          if (poolState == POOL_NORMAL) {
-        	 LOGGER.debug("{} - Cannot acquire connection from data source", poolName, e);
+            LOGGER.debug("{} - Cannot acquire connection from data source", poolName, e);
          }
          poolElf.quietlyCloseConnection(connection, "(exception during connection creation)");
          return false;

--- a/src/main/java/com/zaxxer/hikari/pool/PoolElf.java
+++ b/src/main/java/com/zaxxer/hikari/pool/PoolElf.java
@@ -109,6 +109,21 @@ public final class PoolElf
    {
       if (transactionIsolationName != null) {
          try {
+            int level = Integer.parseInt(transactionIsolationName);
+            //its number
+            switch (level) {
+               case Connection.TRANSACTION_READ_UNCOMMITTED:
+               case Connection.TRANSACTION_READ_COMMITTED:
+               case Connection.TRANSACTION_REPEATABLE_READ:
+               case Connection.TRANSACTION_SERIALIZABLE:
+                  return level;
+            }
+            throw new IllegalArgumentException("Invalid transaction isolation value: " + transactionIsolationName);
+         }
+         catch (Exception e) {
+            //its name
+         }
+    	 try {
             Field field = Connection.class.getField(transactionIsolationName);
             return field.getInt(null);
          }

--- a/src/main/java/com/zaxxer/hikari/pool/PoolElf.java
+++ b/src/main/java/com/zaxxer/hikari/pool/PoolElf.java
@@ -188,7 +188,7 @@ public final class PoolElf
          connection.setReadOnly(isReadOnly);
       }
 
-      int defaultLevel = connection.getTransactionIsolation();
+      final int defaultLevel = connection.getTransactionIsolation();
       transactionIsolation = (transactionIsolation < 0 ? defaultLevel : transactionIsolation);
       if (transactionIsolation != defaultLevel) {
          connection.setTransactionIsolation(transactionIsolation);

--- a/src/main/java/com/zaxxer/hikari/pool/PoolElf.java
+++ b/src/main/java/com/zaxxer/hikari/pool/PoolElf.java
@@ -113,7 +113,7 @@ public final class PoolElf
             return field.getInt(null);
          }
          catch (Exception e) {
-            throw new IllegalArgumentException("Invalid transaction isolation value: " + transactionIsolationName);
+            throw new IllegalArgumentException(poolName + " - Invalid transaction isolation value: " + transactionIsolationName);
          }
       }
 
@@ -161,7 +161,7 @@ public final class PoolElf
    void setupConnection(final Connection connection, final long connectionTimeout) throws SQLException
    {
       if (isUseJdbc4Validation && !isJdbc4ValidationSupported(connection)) {
-         throw new SQLException("Connection.isValid() method is not supported, connection test query must be configured");
+         throw new SQLException("Connection.isValid() is not supported, connection test query must be configured");
       }
 
       networkTimeout = getAndSetNetworkTimeout(connection, connectionTimeout);
@@ -205,9 +205,7 @@ public final class PoolElf
    
          try (Statement statement = connection.createStatement()) {
             setQueryTimeout(statement, timeoutSec);
-            if (statement.execute(config.getConnectionTestQuery())) {
-               statement.getResultSet().close();
-            }
+            statement.execute(config.getConnectionTestQuery());
          }
    
          if (isIsolateInternalQueries && !isAutoCommit) {
@@ -438,9 +436,7 @@ public final class PoolElf
    {
       if (sql != null) {
          try (Statement statement = connection.createStatement()) {
-            if (statement.execute(sql)) {
-               statement.getResultSet().close();
-            }
+            statement.execute(sql);
 
             if (!isAutoCommit) {
                connection.commit();

--- a/src/main/java/com/zaxxer/hikari/pool/PoolElf.java
+++ b/src/main/java/com/zaxxer/hikari/pool/PoolElf.java
@@ -113,9 +113,10 @@ public final class PoolElf
             if (upperName.startsWith("TRANSACTION_")) {
                Field field = Connection.class.getField(upperName);
                return field.getInt(null);
-            } else {
+            }
+            else {
                final int level = Integer.parseInt(transactionIsolationName);
-               // its number
+               //its number
                switch (level) {
                   case Connection.TRANSACTION_READ_UNCOMMITTED:
                   case Connection.TRANSACTION_READ_COMMITTED:
@@ -125,9 +126,10 @@ public final class PoolElf
                      return level;
                   default:
                      throw new IllegalArgumentException();
-               }
+                }
             }
-         } catch (Exception e) {
+         }
+         catch (Exception e) {
             throw new IllegalArgumentException("Invalid transaction isolation value: " + transactionIsolationName);
          }
       }

--- a/src/main/java/com/zaxxer/hikari/pool/PoolElf.java
+++ b/src/main/java/com/zaxxer/hikari/pool/PoolElf.java
@@ -114,20 +114,17 @@ public final class PoolElf
                Field field = Connection.class.getField(upperName);
                return field.getInt(null);
             }
-            else {
-               final int level = Integer.parseInt(transactionIsolationName);
-               //its number
-               switch (level) {
-                  case Connection.TRANSACTION_READ_UNCOMMITTED:
-                  case Connection.TRANSACTION_READ_COMMITTED:
-                  case Connection.TRANSACTION_REPEATABLE_READ:
-                  case Connection.TRANSACTION_SERIALIZABLE:
-                  case Connection.TRANSACTION_NONE:
-                     return level;
-                  default:
-                     throw new IllegalArgumentException();
-                }
-            }
+            final int level = Integer.parseInt(transactionIsolationName);
+            switch (level) {
+               case Connection.TRANSACTION_READ_UNCOMMITTED:
+               case Connection.TRANSACTION_READ_COMMITTED:
+               case Connection.TRANSACTION_REPEATABLE_READ:
+               case Connection.TRANSACTION_SERIALIZABLE:
+               case Connection.TRANSACTION_NONE:
+                  return level;
+               default:
+                  throw new IllegalArgumentException();
+             }
          }
          catch (Exception e) {
             throw new IllegalArgumentException("Invalid transaction isolation value: " + transactionIsolationName);

--- a/src/main/java/com/zaxxer/hikari/pool/PoolElf.java
+++ b/src/main/java/com/zaxxer/hikari/pool/PoolElf.java
@@ -109,23 +109,24 @@ public final class PoolElf
    {
       if (transactionIsolationName != null) {
          try {
-            int level = Integer.parseInt(transactionIsolationName);
-            //its number
-            switch (level) {
-               case Connection.TRANSACTION_READ_UNCOMMITTED:
-               case Connection.TRANSACTION_READ_COMMITTED:
-               case Connection.TRANSACTION_REPEATABLE_READ:
-               case Connection.TRANSACTION_SERIALIZABLE:
-                  return level;
-            }
-            throw new IllegalArgumentException("Invalid transaction isolation value: " + transactionIsolationName);
-         }
-         catch (Exception e) {
-            //its name
-         }
-    	 try {
-            Field field = Connection.class.getField(transactionIsolationName);
-            return field.getInt(null);
+ 	   		String upperName = transactionIsolationName.toUpperCase();
+ 			if (upperName.startsWith("TRANSACTION_")) {
+ 				Field field = Connection.class.getField(transactionIsolationName);
+ 				return field.getInt(null);
+ 			}
+ 			else {
+ 	            int level = Integer.parseInt(transactionIsolationName);
+ 	            //its number
+ 	            switch (level) {
+ 	               case Connection.TRANSACTION_READ_UNCOMMITTED:
+ 	               case Connection.TRANSACTION_READ_COMMITTED:
+ 	               case Connection.TRANSACTION_REPEATABLE_READ:
+ 	               case Connection.TRANSACTION_SERIALIZABLE:
+ 	                  return level;
+ 	            }
+ 	            //invalid level
+ 	            throw new IllegalArgumentException();
+ 			}
          }
          catch (Exception e) {
             throw new IllegalArgumentException("Invalid transaction isolation value: " + transactionIsolationName);

--- a/src/main/java/com/zaxxer/hikari/pool/PoolElf.java
+++ b/src/main/java/com/zaxxer/hikari/pool/PoolElf.java
@@ -180,14 +180,15 @@ public final class PoolElf
       }
 
       networkTimeout = getAndSetNetworkTimeout(connection, connectionTimeout);
-      transactionIsolation = (transactionIsolation < 0 ? connection.getTransactionIsolation() : transactionIsolation);
 
       connection.setAutoCommit(isAutoCommit);
       if (isReadOnly != null) {
          connection.setReadOnly(isReadOnly);
       }
 
-      if (transactionIsolation != connection.getTransactionIsolation()) {
+      int defaultLevel = connection.getTransactionIsolation();
+      transactionIsolation = (transactionIsolation < 0 ? defaultLevel : transactionIsolation);
+      if (transactionIsolation != defaultLevel) {
          connection.setTransactionIsolation(transactionIsolation);
       }
 

--- a/src/main/java/com/zaxxer/hikari/pool/PoolElf.java
+++ b/src/main/java/com/zaxxer/hikari/pool/PoolElf.java
@@ -113,7 +113,7 @@ public final class PoolElf
             return field.getInt(null);
          }
          catch (Exception e) {
-            throw new IllegalArgumentException(poolName + " - Invalid transaction isolation value: " + transactionIsolationName);
+            throw new IllegalArgumentException("Invalid transaction isolation value: " + transactionIsolationName);
          }
       }
 
@@ -161,7 +161,7 @@ public final class PoolElf
    void setupConnection(final Connection connection, final long connectionTimeout) throws SQLException
    {
       if (isUseJdbc4Validation && !isJdbc4ValidationSupported(connection)) {
-         throw new SQLException("Connection.isValid() is not supported, connection test query must be configured");
+         throw new SQLException("Connection.isValid() method is not supported, connection test query must be configured");
       }
 
       networkTimeout = getAndSetNetworkTimeout(connection, connectionTimeout);

--- a/src/main/java/com/zaxxer/hikari/pool/PoolElf.java
+++ b/src/main/java/com/zaxxer/hikari/pool/PoolElf.java
@@ -109,26 +109,25 @@ public final class PoolElf
    {
       if (transactionIsolationName != null) {
          try {
- 	   		String upperName = transactionIsolationName.toUpperCase();
- 			if (upperName.startsWith("TRANSACTION_")) {
- 				Field field = Connection.class.getField(transactionIsolationName);
- 				return field.getInt(null);
- 			}
- 			else {
- 	            int level = Integer.parseInt(transactionIsolationName);
- 	            //its number
- 	            switch (level) {
- 	               case Connection.TRANSACTION_READ_UNCOMMITTED:
- 	               case Connection.TRANSACTION_READ_COMMITTED:
- 	               case Connection.TRANSACTION_REPEATABLE_READ:
- 	               case Connection.TRANSACTION_SERIALIZABLE:
- 	                  return level;
- 	            }
- 	            //invalid level
- 	            throw new IllegalArgumentException();
- 			}
-         }
-         catch (Exception e) {
+            final String upperName = transactionIsolationName.toUpperCase();
+            if (upperName.startsWith("TRANSACTION_")) {
+               Field field = Connection.class.getField(upperName);
+               return field.getInt(null);
+            } else {
+               final int level = Integer.parseInt(transactionIsolationName);
+               // its number
+               switch (level) {
+                  case Connection.TRANSACTION_READ_UNCOMMITTED:
+                  case Connection.TRANSACTION_READ_COMMITTED:
+                  case Connection.TRANSACTION_REPEATABLE_READ:
+                  case Connection.TRANSACTION_SERIALIZABLE:
+                  case Connection.TRANSACTION_NONE:
+                     return level;
+                  default:
+                     throw new IllegalArgumentException();
+               }
+            }
+         } catch (Exception e) {
             throw new IllegalArgumentException("Invalid transaction isolation value: " + transactionIsolationName);
          }
       }

--- a/src/test/java/com/zaxxer/hikari/ShutdownTest.java
+++ b/src/test/java/com/zaxxer/hikari/ShutdownTest.java
@@ -225,7 +225,7 @@ public class ShutdownTest
            ds.getConnection();
        }
        catch (SQLException e) {
-          Assert.assertTrue(e.getMessage().contains("has been shutdown"));
+          Assert.assertTrue(e.getMessage().contains("has been closed."));
        }
    }
 

--- a/src/test/java/com/zaxxer/hikari/TestValidation.java
+++ b/src/test/java/com/zaxxer/hikari/TestValidation.java
@@ -59,7 +59,7 @@ public class TestValidation
          config.validate();
          Assert.fail();
       }
-      catch (IllegalStateException ise) {
+      catch (IllegalArgumentException ise) {
          // pass
       }
    }
@@ -183,7 +183,7 @@ public class TestValidation
          config.validate();
          Assert.fail();
       }
-      catch (IllegalStateException ise) {
+      catch (IllegalArgumentException ise) {
          Assert.assertTrue(ise.getMessage().contains("together"));
       }
    }

--- a/src/test/java/com/zaxxer/hikari/TestValidation.java
+++ b/src/test/java/com/zaxxer/hikari/TestValidation.java
@@ -184,7 +184,7 @@ public class TestValidation
          Assert.fail();
       }
       catch (IllegalStateException ise) {
-         Assert.assertTrue(ise.getMessage().contains("cannot use"));
+         Assert.assertTrue(ise.getMessage().contains("together"));
       }
    }
 


### PR DESCRIPTION
HikariPool: Log consitency
PoolElf: I think two more round trips to db/driver is overkill (for pool
to support bad driver) especially jdbc spec reads 'closing statement
must close any current result set'. It is already slow (compare to
others) having network timeout as well as query timeout to validate
connection!