### PR TITLE
[2.3.x] Ensure closed connections returned to pool

### DIFF
--- a/hikaricp-common/src/main/java/com/zaxxer/hikari/proxy/ConnectionProxy.java
+++ b/hikaricp-common/src/main/java/com/zaxxer/hikari/proxy/ConnectionProxy.java
@@ -178,19 +178,9 @@ public abstract class ConnectionProxy implements IHikariConnectionProxy
       if (delegate != ClosedConnection.CLOSED_CONNECTION) {
          leakTask.cancel();
 
-         final int size = openStatements.size();
-         if (size > 0) {
-            for (int i = 0; i < size; i++) {
-               try {
-                  openStatements.get(i).close();
-               }
-               catch (SQLException e) {
-                  checkException(e);
-               }
-            }
-         }
-
          try {
+            closeOpenStatements();
+
             if (isCommitStateDirty && !delegate.getAutoCommit()) {
                LOGGER.debug("{} Performing rollback on {} due to dirty commit state.", parentPool, delegate);
                delegate.rollback();
@@ -213,6 +203,26 @@ public abstract class ConnectionProxy implements IHikariConnectionProxy
             bagEntry.lastAccess = lastAccess;
             parentPool.releaseConnection(bagEntry);
          }
+      }
+   }
+
+   private void closeOpenStatements()
+   {
+      final int size = openStatements.size();
+      if (size > 0) {
+         for (int i = 0; i < size; i++) {
+            try {
+               Statement statement = openStatements.get(i);
+               if (statement != null) {
+                  statement.close();
+               }
+            }
+            catch (SQLException e) {
+               checkException(e);
+            }
+         }
+
+         openStatements.clear();
       }
    }
 

--- a/hikaricp-common/src/main/java/com/zaxxer/hikari/proxy/ConnectionProxy.java
+++ b/hikaricp-common/src/main/java/com/zaxxer/hikari/proxy/ConnectionProxy.java
@@ -145,6 +145,26 @@ public abstract class ConnectionProxy implements IHikariConnectionProxy
       return statement;
    }
 
+   private final void closeOpenStatements()
+   {
+      final int size = openStatements.size();
+      if (size > 0) {
+         for (int i = 0; i < size; i++) {
+            try {
+               final Statement statement = openStatements.get(i);
+               if (statement != null) {
+                  statement.close();
+               }
+            }
+            catch (SQLException e) {
+               checkException(e);
+            }
+         }
+
+         openStatements.clear();
+      }
+   }
+
    private final void resetConnectionState() throws SQLException
    {
       LOGGER.debug("{} Resetting dirty on {} (readOnlyDirty={},autoCommitDirty={},isolationDirty={},catalogDirty={})",
@@ -203,26 +223,6 @@ public abstract class ConnectionProxy implements IHikariConnectionProxy
             bagEntry.lastAccess = lastAccess;
             parentPool.releaseConnection(bagEntry);
          }
-      }
-   }
-
-   private void closeOpenStatements()
-   {
-      final int size = openStatements.size();
-      if (size > 0) {
-         for (int i = 0; i < size; i++) {
-            try {
-               Statement statement = openStatements.get(i);
-               if (statement != null) {
-                  statement.close();
-               }
-            }
-            catch (SQLException e) {
-               checkException(e);
-            }
-         }
-
-         openStatements.clear();
       }
    }
 


### PR DESCRIPTION
If an exception occurs while closing a connection's open statements
(e.g. NullPointerException due to concurrent close of statement with
connection), the connection was not returned to the pool.

We now check for this possibility and ensure the connection is returned
to the pool.