### PR TITLE
fix: should consider connection marked for eviction else where too

### DIFF
--- a/src/main/java/com/zaxxer/hikari/proxy/ConnectionProxy.java
+++ b/src/main/java/com/zaxxer/hikari/proxy/ConnectionProxy.java
@@ -104,18 +104,20 @@ public abstract class ConnectionProxy implements IHikariConnectionProxy
    @Override
    public final SQLException checkException(final SQLException sqle)
    {
-      String sqlState = sqle.getSQLState();
-      if (sqlState != null) {
-         boolean isForceClose = sqlState.startsWith("08") || SQL_ERRORS.contains(sqlState);
-         if (isForceClose) {
-            poolEntry.evict = true;
-            LOGGER.warn("{} - Connection {} marked as broken because of SQLSTATE({}), ErrorCode({})",
-                        poolEntry.parentPool, poolEntry, sqlState, sqle.getErrorCode(), sqle);
-         }
-         else {
-            SQLException nse = sqle.getNextException();
-            if (nse != null && nse != sqle) {
-               checkException(nse);
+      if (!poolEntry.evict) {
+         String sqlState = sqle.getSQLState();
+         if (sqlState != null) {
+            boolean isForceClose = sqlState.startsWith("08") || SQL_ERRORS.contains(sqlState);
+            if (isForceClose) {
+               poolEntry.evict = true;
+               LOGGER.warn("{} - Connection {} marked as broken because of SQLSTATE({}), ErrorCode({})",
+                           poolEntry.parentPool, poolEntry, sqlState, sqle.getErrorCode(), sqle);
+            }
+            else {
+               SQLException nse = sqle.getNextException();
+               if (nse != null && nse != sqle) {
+                  checkException(nse);
+               }
             }
          }
       }

--- a/src/main/java/com/zaxxer/hikari/proxy/ConnectionProxy.java
+++ b/src/main/java/com/zaxxer/hikari/proxy/ConnectionProxy.java
@@ -147,11 +147,10 @@ public abstract class ConnectionProxy implements IHikariConnectionProxy
       return statement;
    }
 
-   private final boolean closeOpenStatements()
+   private final void closeOpenStatements()
    {
       final int size = openStatements.size();
       if (size > 0) {
-         boolean success = true;
          for (int i = 0; i < size; i++) {
             try {
                final Statement statement = openStatements.get(i);
@@ -161,14 +160,11 @@ public abstract class ConnectionProxy implements IHikariConnectionProxy
             }
             catch (SQLException e) {
                checkException(e);
-               success &= !poolEntry.evict;
             }
          }
 
          openStatements.clear();
-         return success;
       }
-      return true;
    }
 
    // **********************************************************************
@@ -183,7 +179,8 @@ public abstract class ConnectionProxy implements IHikariConnectionProxy
          leakTask.cancel();
 
          try {
-            if (closeOpenStatements()) {
+            closeOpenStatements();
+            if (!poolEntry.evict) {
                if (isCommitStateDirty) {
                   lastAccess = clockSource.currentTime();
 


### PR DESCRIPTION
moved check so now it takes care of evict set during CloseOpenStatements() and 'before' that too.
at present it is not effective for most cases as it is checking evict only when user forgets to close statement.