### PR TITLE
cleanup

### DIFF
--- a/src/main/java/com/zaxxer/hikari/pool/PoolBagEntry.java
+++ b/src/main/java/com/zaxxer/hikari/pool/PoolBagEntry.java
@@ -120,7 +120,6 @@ public final class PoolBagEntry implements IConcurrentBagEntry
    public void resetConnectionState() throws SQLException
    {
       poolElf.resetConnectionState(this);
-      poolElf.resetPoolEntry(this);
    }
 
    /**

--- a/src/main/java/com/zaxxer/hikari/pool/PoolBagEntry.java
+++ b/src/main/java/com/zaxxer/hikari/pool/PoolBagEntry.java
@@ -112,7 +112,6 @@ public final class PoolBagEntry implements IConcurrentBagEntry
       parentPool.releaseConnection(this);
    }
 
-
    /**
     * Reset the connection to its original state.
     * @throws SQLException thrown if there is an error resetting the connection state

--- a/src/main/java/com/zaxxer/hikari/pool/PoolElf.java
+++ b/src/main/java/com/zaxxer/hikari/pool/PoolElf.java
@@ -270,6 +270,7 @@ public final class PoolElf
 
       if (poolEntry.networkTimeout != networkTimeout) {
          setNetworkTimeout(poolEntry.connection, networkTimeout);
+         poolEntry.setNetworkTimeout(networkTimeout);
          resetBits |= 0b10000;
       }
       

--- a/src/main/java/com/zaxxer/hikari/pool/PoolElf.java
+++ b/src/main/java/com/zaxxer/hikari/pool/PoolElf.java
@@ -245,22 +245,26 @@ public final class PoolElf
 
       if (poolEntry.isReadOnly != isReadOnly) {
          poolEntry.connection.setReadOnly(isReadOnly);
+         poolEntry.setReadOnly(isReadOnly);
          resetBits |= 0b00001;
       }
 
       if (poolEntry.isAutoCommit != isAutoCommit) {
          poolEntry.connection.setAutoCommit(isAutoCommit);
+         poolEntry.setAutoCommit(isAutoCommit);
          resetBits |= 0b00010;
       }
 
       if (poolEntry.transactionIsolation != transactionIsolation) {
          poolEntry.connection.setTransactionIsolation(transactionIsolation);
+         poolEntry.setTransactionIsolation(transactionIsolation);
          resetBits |= 0b00100;
       }
 
       final String currentCatalog = poolEntry.catalog;
       if ((currentCatalog != null && !currentCatalog.equals(catalog)) || (currentCatalog == null && catalog != null)) {
          poolEntry.connection.setCatalog(catalog);
+         poolEntry.setCatalog(catalog);
          resetBits |= 0b01000;
       }
 

--- a/src/main/java/com/zaxxer/hikari/proxy/ConnectionProxy.java
+++ b/src/main/java/com/zaxxer/hikari/proxy/ConnectionProxy.java
@@ -110,7 +110,7 @@ public abstract class ConnectionProxy implements IHikariConnectionProxy
          if (isForceClose) {
             poolEntry.evict = true;
             LOGGER.warn("{} - Connection {} marked as broken because of SQLSTATE({}), ErrorCode({})",
-                        poolEntry.parentPool, poolEntry, sqlState, sqle.getErrorCode(), sqle);
+                        poolEntry.parentPool, poolEntry.connection, sqlState, sqle.getErrorCode(), sqle);
          }
          else {
             SQLException nse = sqle.getNextException();

--- a/src/main/java/com/zaxxer/hikari/proxy/ConnectionProxy.java
+++ b/src/main/java/com/zaxxer/hikari/proxy/ConnectionProxy.java
@@ -50,7 +50,7 @@ public abstract class ConnectionProxy implements IHikariConnectionProxy
 
    private final LeakTask leakTask;
    private final PoolBagEntry poolEntry;
-   private final FastList<Statement> openStatements;
+   private final FastList<Statement> statements;
    
    private long lastAccess;
    private boolean isCommitStateDirty;
@@ -76,7 +76,7 @@ public abstract class ConnectionProxy implements IHikariConnectionProxy
       this.lastAccess = now;
 
       this.delegate = bagEntry.connection;
-      this.openStatements = bagEntry.openStatements;
+      this.statements = bagEntry.openStatements;
    }
 
    /** {@inheritDoc} */
@@ -126,7 +126,7 @@ public abstract class ConnectionProxy implements IHikariConnectionProxy
    @Override
    public final void untrackStatement(final Statement statement)
    {
-      openStatements.remove(statement);
+      statements.remove(statement);
    }
 
    /** {@inheritDoc} */
@@ -142,18 +142,18 @@ public abstract class ConnectionProxy implements IHikariConnectionProxy
 
    private final <T extends Statement> T trackStatement(final T statement)
    {
-      openStatements.add(statement);
+      statements.add(statement);
 
       return statement;
    }
 
-   private final void closeOpenStatements()
+   private final void closeStatements()
    {
-      final int size = openStatements.size();
+      final int size = statements.size();
       if (size > 0) {
          for (int i = 0; i < size; i++) {
             try {
-               final Statement statement = openStatements.get(i);
+               final Statement statement = statements.get(i);
                if (statement != null) {
                   statement.close();
                }
@@ -163,7 +163,7 @@ public abstract class ConnectionProxy implements IHikariConnectionProxy
             }
          }
 
-         openStatements.clear();
+         statements.clear();
       }
    }
 
@@ -177,14 +177,13 @@ public abstract class ConnectionProxy implements IHikariConnectionProxy
    {
       if (delegate != ClosedConnection.CLOSED_CONNECTION) {
          leakTask.cancel();
+         closeStatements();
 
          try {
-            closeOpenStatements();
             if (isCommitStateDirty) {
-               lastAccess = clockSource.currentTime();
-
                if (!poolEntry.isAutoCommit) {
                   delegate.rollback();
+                  lastAccess = clockSource.currentTime();
                   LOGGER.debug("{} - Executed rollback on connection {} due to dirty commit state on close().", poolEntry.parentPool, delegate);
                }
             }

--- a/src/main/java/com/zaxxer/hikari/proxy/ConnectionProxy.java
+++ b/src/main/java/com/zaxxer/hikari/proxy/ConnectionProxy.java
@@ -177,9 +177,9 @@ public abstract class ConnectionProxy implements IHikariConnectionProxy
    {
       if (delegate != ClosedConnection.CLOSED_CONNECTION) {
          leakTask.cancel();
-         closeStatements();
 
          try {
+            closeStatements();
             if (isCommitStateDirty) {
                if (!poolEntry.isAutoCommit) {
                   delegate.rollback();


### PR DESCRIPTION
set lastAccess only if rolled back
method and var renamed,  closeStatements() moved out of try, already catching SQLExceptions
remove resetPoolEntry(), calling individual method if changed
unintentional logging