### PR TITLE
removed isClosed() check

### DIFF
--- a/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
+++ b/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
@@ -173,8 +173,7 @@ public class HikariPool extends PoolBase implements HikariPoolMXBean, IBagStateL
                metricsTracker.recordBorrowStats(poolEntry, startTime);
                return poolEntry.createProxyConnection(leakTask.start(poolEntry), now);
             }
-         }
-         while (timeout > 0L);
+         } while (timeout > 0L);
       }
       catch (InterruptedException e) {
          throw new SQLException(poolName + " - Interrupted during connection acquisition", e);
@@ -227,8 +226,7 @@ public class HikariPool extends PoolBase implements HikariPoolMXBean, IBagStateL
             do {
                softEvictConnections();
                abortActiveConnections(assassinExecutor);
-            }
-            while (getTotalConnections() > 0 && clockSource.elapsedMillis(start) < TimeUnit.SECONDS.toMillis(5));
+            } while (getTotalConnections() > 0 && clockSource.elapsedMillis(start) < TimeUnit.SECONDS.toMillis(5));
          } finally {
             assassinExecutor.shutdown();
             assassinExecutor.awaitTermination(5L, TimeUnit.SECONDS);

--- a/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
+++ b/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
@@ -95,7 +95,7 @@ abstract class PoolBase
    void quietlyCloseConnection(final Connection connection, final String closureReason)
    {
       try {
-         if (connection == null || connection.isClosed()) {
+         if (connection == null) {
             return;
          }
 
@@ -128,10 +128,10 @@ abstract class PoolBase
             if (isNetworkTimeoutSupported != TRUE) {
                setQueryTimeout(statement, (int) TimeUnit.MILLISECONDS.toSeconds(validationTimeout));
             }
-         
+
             statement.execute(config.getConnectionTestQuery());
          }
-   
+
          if (isIsolateInternalQueries && !isReadOnly && !isAutoCommit) {
             connection.rollback();
          }
@@ -461,6 +461,7 @@ abstract class PoolBase
       if (sql != null) {
          try (Statement statement = connection.createStatement()) {
 
+            //con created few ms before, set query timeout is omitted
             statement.execute(sql);
 
             if (!isReadOnly) {


### PR DESCRIPTION
no need for trip to driver/db for closing con.
http://docs.oracle.com/javase/7/docs/api/java/sql/Connection.html#close() states
Calling the method close on a Connection object that is already closed is a no-op.

moreover isClosed() was not guarded by network timeout.