### PR TITLE
do not fail if setLoginTimeout on delegate data source is not supported

### DIFF
--- a/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
+++ b/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
@@ -525,10 +525,7 @@ abstract class PoolBase
          try {
             dataSource.setLoginTimeout((int) TimeUnit.MILLISECONDS.toSeconds(Math.max(1000L, connectionTimeout)));
          }
-         catch (SQLException e) {
-            LOGGER.warn("{} - Unable to set DataSource login timeout", poolName, e);
-         }
-         catch (UnsupportedOperationException e) {
+         catch (SQLException | UnsupportedOperationException e) {
             LOGGER.warn("{} - Unable to set DataSource login timeout", poolName, e);
          }
       }

--- a/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
+++ b/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
@@ -528,6 +528,9 @@ abstract class PoolBase
          catch (SQLException e) {
             LOGGER.warn("{} - Unable to set DataSource login timeout", poolName, e);
          }
+         catch (UnsupportedOperationException e) {
+            LOGGER.warn("{} - Unable to set DataSource login timeout", poolName, e);
+         }
       }
    }
 


### PR DESCRIPTION
Some `DataSource` implementations (like [`BasicDataSource`](https://commons.apache.org/proper/commons-dbcp/api-1.4/org/apache/commons/dbcp/BasicDataSource.html) or [`DriverManagerDataSource`](https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/jdbc/datasource/DriverManagerDataSource.html)) do not support setting a login timeout. `UnsupportedOperationException` is thrown in these cases.

When a delegate `dataSource` is set for the HikariCP, it tries to invoke this method on the delegate. Only log a warning in this case instead of failing to initialize the HikariCP.

This is amongst others relevant for using HikariCP in Grails, which creates instances of `org.springframework.jdbc.datasource.DriverManagerDataSource` (at least in version 2.2.4).