### PR TITLE
Race condition while adding threads

### DIFF
--- a/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
+++ b/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
@@ -304,6 +304,8 @@ public class HikariPool extends PoolBase implements HikariPoolMXBean, IBagStateL
                quietlySleep(sleepBackoff);
                sleepBackoff = Math.min(connectionTimeout / 2, (long) (sleepBackoff * 1.5));
             }
+
+            connectionBag.getSynchronizer().signal();
          }
       }, true);
 

--- a/src/main/java/com/zaxxer/hikari/util/ConcurrentBag.java
+++ b/src/main/java/com/zaxxer/hikari/util/ConcurrentBag.java
@@ -309,6 +309,10 @@ public class ConcurrentBag<T extends IConcurrentBagEntry> implements AutoCloseab
       return synchronizer.getQueueLength();
    }
 
+   public QueuedSequenceSynchronizer getSynchronizer() {
+      return synchronizer;
+   }
+
    /**
     * Get a count of the number of items in the specified state at the time of this call.
     *

--- a/src/test/java/com/zaxxer/hikari/pool/AddConnectionRaceConditionTest.java
+++ b/src/test/java/com/zaxxer/hikari/pool/AddConnectionRaceConditionTest.java
@@ -1,0 +1,115 @@
+package com.zaxxer.hikari.pool;
+
+import java.lang.reflect.Field;
+
+import java.sql.Connection;
+
+import java.util.List;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+
+import org.junit.Test;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import com.zaxxer.hikari.mocks.StubConnection;
+import com.zaxxer.hikari.util.ConcurrentBag;
+
+/**
+ * @author Matthew Tambara (matthew.tambara@liferay.com)
+ */
+public class AddConnectionRaceConditionTest
+{
+   @Test
+   public void testRaceCondition() throws Exception {
+      HikariConfig config = new HikariConfig();
+      config.setMinimumIdle(0);
+      config.setMaximumPoolSize(10);
+      config.setInitializationFailFast(false);
+      config.setPoolName("Test Pool");
+      config.setDataSourceClassName("com.zaxxer.hikari.mocks.StubDataSource");
+
+      // Initialize HikariPool with no initial connections and room to grow
+
+      HikariDataSource ds = new HikariDataSource(config);
+
+      Connection connection = null;
+
+      try {
+         Field field = HikariDataSource.class.getDeclaredField("pool");
+
+         field.setAccessible(true);
+
+         _hikariPool = (HikariPool)field.get(ds);
+
+         field = HikariPool.class.getDeclaredField("addConnectionExecutor");
+
+         field.setAccessible(true);
+
+         ThreadPoolExecutor threadPoolExecutor = (ThreadPoolExecutor)field.get(_hikariPool);
+
+         // At this point, HikariPool hasn't started adding connections, so this wrapper ThreadFactory will kick in
+
+         threadPoolExecutor.setThreadFactory(new RaceThreadFactory(threadPoolExecutor.getThreadFactory()));
+
+         field = HikariPool.class.getDeclaredField("connectionBag");
+
+         field.setAccessible(true);
+
+         ConcurrentBag<?> concurrentBag = (ConcurrentBag<?>)field.get(_hikariPool);
+
+         field = ConcurrentBag.class.getDeclaredField("sharedList");
+
+         field.setAccessible(true);
+
+         // Get the list of connections in ConcurrentBag directly
+
+         _sharedList = (List<PoolEntry>)field.get(concurrentBag);
+
+         // Attempt to get a connection from the pool
+
+        connection = _hikariPool.getConnection(5000);
+      }
+      catch (Exception e) {
+         throw e;
+      }
+      finally {
+         if (connection != null) {
+            connection.close();
+         }
+      }
+
+	}
+
+   private HikariPool _hikariPool;
+   private List<PoolEntry> _sharedList;
+
+   protected class RaceThreadFactory implements ThreadFactory
+   {
+      public RaceThreadFactory(ThreadFactory threadFactory)
+      {
+         _threadFactory = threadFactory;
+      }
+
+      @Override
+      public Thread newThread(Runnable r)
+      {
+         try {
+
+            /*
+             * Add a connection to the pool before the worker thread can begin.
+             * This will cause getIdleConnections() <= minimumIdle to fail and not
+             * add a new connection, and therefore not call QueuedSequenceSynchronizer.signal()
+             */
+
+            _sharedList.add(new PoolEntry(new StubConnection(), _hikariPool));
+         }
+         catch (Exception e) {
+            throw new RuntimeException(e);
+         }
+
+         return _threadFactory.newThread(r);
+      }
+      private final ThreadFactory _threadFactory;
+   }
+}


### PR DESCRIPTION
I'm sending this pull to notify you about and provide a potential solution for a bug in your code. There is a race condition when 2 threads call `HikariPool.getConnection()` while there are no idle connections available and `minimumIdle` is set to 0. Both threads will go into `ConcurrentBag.borrow(long, TimeUnit)`, see that there are no available threads to borrow, and create new worker threads to add one connection each in `HikariPool.addBagItem()`. The borrowing threads will then wait until signalled, at which point they will wake up and check for available connections again. The workers will execute sequentially and each try to create a new connection. This is the execution that leads to the race condition:

Worker 1 adds a connection as usual, signalling the borrow threads to wake up. 

Worker 1 finishes (`isDone()`)

Before the borrow threads can check for new connections, worker 2 tries to add a new connection.

Worker 2 checks if `getIdleConnections() <= minimumIdle`, sees the connection worker 1 added, and skips the `addConnection` call.

Borrow thread 1 sucessfully borrows a connection.

Borrow thread 2 cannot borrow a connection and goes to sleep waiting for Worker 2 to signal.

Worker 2 finishes (`isDone()`)

I have included a potential solution to this problem (signal at the end of the worker thread no matter what) and a test to reproduce this race condition (`AddConnectionRaceConditionTest`).

Let me know if you have any questions.

(cc @shuyangzhou)