### PR TITLE
Adding random 10 second for every hour in the maxlifetime.  This woul…

### DIFF
--- a/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
+++ b/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
@@ -442,16 +442,9 @@ public class HikariPool extends PoolBase implements HikariPoolMXBean, IBagStateL
 
          final long maxLifetime = config.getMaxLifetime();
          if (maxLifetime > 0) {
-            /*
-            3 minutes = 15 seconds variance
-            5 minutes = 30 seconds variance
-            30 minutes = 90 seconds variance
-            1 day = 71 minutes variance
-            */
-        	   final long randomIntervalInMillis = Math.max(10_000, maxLifetime / 20);
-        	 
-            final long variance = randomIntervalInMillis > 0 ? ThreadLocalRandom.current().nextLong(randomIntervalInMillis) : 0;
-            final long lifetime = maxLifetime - variance;
+        	// Determines the random variance max ceiling, from 10 seconds to 2.5% of the maxlifetime whichever is bigger.
+        	final long randomIntervalInMillis = maxLifetime > 10_000 ? Math.max(10_000, maxLifetime / 40) : 0;
+            final long lifetime = maxLifetime - randomIntervalInMillis;
             poolEntry.setFutureEol(houseKeepingExecutorService.schedule(new Runnable() {
                @Override
                public void run() {

--- a/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
+++ b/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
@@ -442,15 +442,14 @@ public class HikariPool extends PoolBase implements HikariPoolMXBean, IBagStateL
 
          final long maxLifetime = config.getMaxLifetime();
          if (maxLifetime > 0) {
-        	 long inHours = TimeUnit.MILLISECONDS.toHours(maxLifetime);
+            /*
+            3 minutes = 15 seconds variance
+            5 minutes = 30 seconds variance
+            30 minutes = 90 seconds variance
+            1 day = 71 minutes variance
+            */
+        	   final long randomIntervalInMillis = Math.max(10_000, maxLifetime / 20);
         	 
-        	 // Every hour will add a 10 second random factor for the maxlifetime
-        	 long randomIntervalInMillis = inHours * 10_000;
-        	 
-        	 // Support the up to 10 seconds spread out when the lifetime is less than 1 hour
-        	 if (inHours == 0) {
-        		 randomIntervalInMillis = maxLifetime > 60_000 ? 10_000 : 0;
-        	 }
             final long variance = randomIntervalInMillis > 0 ? ThreadLocalRandom.current().nextLong(randomIntervalInMillis) : 0;
             final long lifetime = maxLifetime - variance;
             poolEntry.setFutureEol(houseKeepingExecutorService.schedule(new Runnable() {

--- a/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
+++ b/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
@@ -443,7 +443,10 @@ public class HikariPool extends PoolBase implements HikariPoolMXBean, IBagStateL
          final long maxLifetime = config.getMaxLifetime();
          if (maxLifetime > 0) {
         	// Determines the random variance max ceiling, from 10 seconds to 2.5% of the maxlifetime whichever is bigger.
-        	final long randomIntervalInMillis = maxLifetime > 10_000 ? Math.max(10_000, maxLifetime / 40) : 0;
+        	final long maxIntervalInMillis = maxLifetime > 10_000 ? Math.max(10_000, maxLifetime / 40) : 0;
+        	
+        	// Randomize the current max interval
+        	final long randomIntervalInMillis = maxIntervalInMillis > 0 ? ThreadLocalRandom.current().nextLong(maxIntervalInMillis) : 0;
             final long lifetime = maxLifetime - randomIntervalInMillis;
             poolEntry.setFutureEol(houseKeepingExecutorService.schedule(new Runnable() {
                @Override


### PR DESCRIPTION
This is to help close the issue on the maxlifetime.  For every hour, it will add the random 10 second interval.  Please review and pull if you agree. 

Also if you agree, please do the same change on the JDK 1.7 version as well, please.  Thank you!