### PR TITLE
Skip the `testMetricUsage` test on Windows

### DIFF
--- a/src/test/java/com/zaxxer/hikari/pool/TestMetrics.java
+++ b/src/test/java/com/zaxxer/hikari/pool/TestMetrics.java
@@ -22,6 +22,7 @@ import java.util.SortedMap;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 
 import com.codahale.metrics.Histogram;
@@ -36,6 +37,8 @@ import com.zaxxer.hikari.HikariDataSource;
 import com.zaxxer.hikari.metrics.MetricsTrackerFactory;
 import com.zaxxer.hikari.metrics.dropwizard.CodahaleMetricsTrackerFactory;
 import com.zaxxer.hikari.util.UtilityElf;
+
+import shaded.org.codehaus.plexus.interpolation.os.Os;
 
 /**
  * Test HikariCP/CodaHale metrics integration.
@@ -77,6 +80,7 @@ public class TestMetrics
    @Test
    public void testMetricUsage() throws SQLException
    {
+      Assume.assumeFalse(Os.isFamily(Os.FAMILY_WINDOWS));
       MetricRegistry metricRegistry = new MetricRegistry();
 
       HikariConfig config = new HikariConfig();


### PR DESCRIPTION
There I am again, I haven't had the spurious wake-up issue since, which is good.

I know that the reference code is not exactly public, but it makes the skip reason readable enough.

Let me know what you think.