### PR TITLE
Add metric for recording count and rate of connection timeouts

### DIFF
--- a/src/main/java/com/zaxxer/hikari/metrics/MetricsTracker.java
+++ b/src/main/java/com/zaxxer/hikari/metrics/MetricsTracker.java
@@ -35,6 +35,10 @@ public class MetricsTracker implements AutoCloseable
    {
    }
 
+   public void recordConnectionTimeout()
+   {
+   }
+
    @Override
    public void close()
    {

--- a/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
+++ b/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
@@ -184,6 +184,7 @@ public class HikariPool extends PoolBase implements HikariPoolMXBean, IBagStateL
       }
 
       logPoolState("Timeout failure ");
+      metricsTracker.recordConnectionTimeout();
 
       String sqlState = null;
       final Throwable originalException = getLastConnectionFailure();

--- a/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
+++ b/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
@@ -584,6 +584,10 @@ abstract class PoolBase
          poolEntry.lastBorrowed = now;
          tracker.recordConnectionAcquiredNanos(ClockSource.INSTANCE.elapsedNanos(startTime, now));
       }
+
+      void recordConnectionTimeout() {
+         tracker.recordConnectionTimeout();
+      }
    }
 
    static final class NopMetricsTrackerDelegate extends MetricsTrackerDelegate
@@ -602,6 +606,12 @@ abstract class PoolBase
 
       @Override
       void recordBorrowStats(final PoolEntry poolEntry, final long startTime)
+      {
+         // no-op
+      }
+
+      @Override
+      void recordConnectionTimeout()
       {
          // no-op
       }


### PR DESCRIPTION
Added `MetricsTracker.recordConnectionTimeout()` and tied that into `HikariPool.getConnection()` when we hit the connection timeout threshold.  Also added an implementation to `CodaHaleMetricsTracker` with a counter and a meter.