### PR TITLE
Add ORA-02399: exceeded maximum connect time to SQL_ERRORS.

### DIFF
--- a/src/main/java/com/zaxxer/hikari/pool/ProxyConnection.java
+++ b/src/main/java/com/zaxxer/hikari/pool/ProxyConnection.java
@@ -81,6 +81,7 @@ public abstract class ProxyConnection implements Connection
       SQL_ERRORS.add("01002"); // SQL92 disconnect error
       SQL_ERRORS.add("JZ0C0"); // Sybase disconnect error
       SQL_ERRORS.add("JZ0C1"); // Sybase disconnect error
+      SQL_ERRORS.add("61000"); // Oracle ORA-02399: exceeded maximum connect time.
    }
 
    protected ProxyConnection(final PoolEntry poolEntry, final Connection connection, final FastList<Statement> openStatements, final ProxyLeakTask leakTask, final long now, final boolean isReadOnly, final boolean isAutoCommit) {


### PR DESCRIPTION
Not handling it avoids eviction of the connection and corrupts the pool.
For example the following NullPointerException is thrown when trying to use the pool afterwards:
java.lang.NullPointerException at com.zaxxer.hikari.pool.PoolBase.isConnectionAlive(PoolBase.java:128)
at com.zaxxer.hikari.pool.HikariPool.getConnection(HikariPool.java:171)
at com.zaxxer.hikari.pool.HikariPool.getConnection(HikariPool.java:147)
at com.zaxxer.hikari.HikariDataSource.getConnection(HikariDataSource.java:99)
.......