### PR TITLE
Shutdown will throw NPE if invoked from checkFailFast

### DIFF
--- a/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
+++ b/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
@@ -216,8 +216,10 @@ public class HikariPool extends PoolBase implements HikariPoolMXBean, IBagStateL
 
          softEvictConnections();
 
-         addConnectionExecutor.shutdown();
-         addConnectionExecutor.awaitTermination(5L, SECONDS);
+         if (addConnectionExecutor != null) {
+            addConnectionExecutor.shutdown();
+            addConnectionExecutor.awaitTermination(5L, SECONDS);
+         }
          if (config.getScheduledExecutorService() == null && houseKeepingExecutorService != null) {
             houseKeepingExecutorService.shutdown();
             houseKeepingExecutorService.awaitTermination(5L, SECONDS);
@@ -240,8 +242,10 @@ public class HikariPool extends PoolBase implements HikariPoolMXBean, IBagStateL
          }
 
          shutdownNetworkTimeoutExecutor();
-         closeConnectionExecutor.shutdown();
-         closeConnectionExecutor.awaitTermination(5L, SECONDS);
+         if (closeConnectionExecutor != null) {
+            closeConnectionExecutor.shutdown();
+            closeConnectionExecutor.awaitTermination(5L, SECONDS);
+         }
       }
       finally {
          logPoolState("After closing ");


### PR DESCRIPTION
Motivation:

Shutdown may be invoked as a result of checkFailFast failing resulting in an NPE as the executors are setup later in the constructor.

Modifications:

Add null checks before trying to shutdown the executors.

Result:

"Graceful" shutdown.