### PR TITLE
Configurable Metrics prefix

### DIFF
--- a/src/main/java/com/zaxxer/hikari/HikariConfig.java
+++ b/src/main/java/com/zaxxer/hikari/HikariConfig.java
@@ -54,6 +54,7 @@ public class HikariConfig implements HikariConfigMXBean
    private static final long IDLE_TIMEOUT = MINUTES.toMillis(10);
    private static final long MAX_LIFETIME = MINUTES.toMillis(30);
    private static final int DEFAULT_POOL_SIZE = 10;
+   private static final String METRICS_PREFIX = "pool";
 
    private static boolean unitTest;
 
@@ -80,6 +81,7 @@ public class HikariConfig implements HikariConfigMXBean
    private String poolName;
    private String transactionIsolationName;
    private String username;
+   private String metricsPrefix;
    private boolean isAutoCommit;
    private boolean isReadOnly;
    private boolean isInitializationFailFast;
@@ -720,6 +722,27 @@ public class HikariConfig implements HikariConfigMXBean
    }
 
    /**
+    * Get the default metricsPrefix used metrics
+    *
+    * @return the username
+    */
+   public String getMetricsPrefix()
+   {
+      return metricsPrefix;
+   }
+
+
+   /**
+   * Set the default prefix used for metrics.
+   *
+   * @param metricsPrefix the prefix for metrics
+   */
+   public void setMetricsPrefix(String metricsPrefix)
+   {
+      this.metricsPrefix = metricsPrefix;
+   }
+
+   /**
     * Get the thread factory used to create threads.
     *
     * @return the thread factory (may be null, in which case the default thread factory is used)
@@ -757,6 +780,11 @@ public class HikariConfig implements HikariConfigMXBean
       dataSourceJndiName = getNullIfEmpty(dataSourceJndiName);
       driverClassName = getNullIfEmpty(driverClassName);
       jdbcUrl = getNullIfEmpty(jdbcUrl);
+      metricsPrefix = getNullIfEmpty(metricsPrefix);
+
+      if (metricsPrefix == null) {
+        metricsPrefix = poolName + "." + METRICS_PREFIX;
+      }
 
       // Check Data Source Options
       if (dataSource != null) {

--- a/src/main/java/com/zaxxer/hikari/metrics/MetricsTrackerFactory.java
+++ b/src/main/java/com/zaxxer/hikari/metrics/MetricsTrackerFactory.java
@@ -21,9 +21,9 @@ public interface MetricsTrackerFactory
    /**
     * Create an instance of a MetricsTracker.
     *
-    * @param poolName the name of the pool
+    * @param metricsPrefix the name used to prefix metrics
     * @param poolStats a PoolStats instance to use
     * @return a MetricsTracker implementation instance
     */
-   MetricsTracker create(String poolName, PoolStats poolStats);
+   MetricsTracker create(String metricsPrefix, PoolStats poolStats);
 }

--- a/src/main/java/com/zaxxer/hikari/metrics/dropwizard/CodaHaleMetricsTracker.java
+++ b/src/main/java/com/zaxxer/hikari/metrics/dropwizard/CodaHaleMetricsTracker.java
@@ -28,21 +28,21 @@ import com.zaxxer.hikari.metrics.PoolStats;
 
 public final class CodaHaleMetricsTracker extends MetricsTracker
 {
-   private final String poolName;
+   private final String metricsPrefix;
    private final Timer connectionObtainTimer;
    private final Histogram connectionUsage;
    private final Meter connectionTimeoutMeter;
    private final MetricRegistry registry;
 
-   public CodaHaleMetricsTracker(final String poolName, final PoolStats poolStats, final MetricRegistry registry)
+   public CodaHaleMetricsTracker(final String metricsPrefix, final PoolStats poolStats, final MetricRegistry registry)
    {
-      this.poolName = poolName;
+      this.metricsPrefix = metricsPrefix;
       this.registry = registry;
-      this.connectionObtainTimer = registry.timer(MetricRegistry.name(poolName, "pool", "Wait"));
-      this.connectionUsage = registry.histogram(MetricRegistry.name(poolName, "pool", "Usage"));
-      this.connectionTimeoutMeter = registry.meter(MetricRegistry.name(poolName, "pool", "ConnectionTimeoutRate"));
+      this.connectionObtainTimer = registry.timer(MetricRegistry.name(metricsPrefix, "Wait"));
+      this.connectionUsage = registry.histogram(MetricRegistry.name(metricsPrefix, "Usage"));
+      this.connectionTimeoutMeter = registry.meter(MetricRegistry.name(metricsPrefix, "ConnectionTimeoutRate"));
 
-      registry.register(MetricRegistry.name(poolName, "pool", "TotalConnections"),
+      registry.register(MetricRegistry.name(metricsPrefix, "TotalConnections"),
                         new Gauge<Integer>() {
                            @Override
                            public Integer getValue() {
@@ -50,7 +50,7 @@ public final class CodaHaleMetricsTracker extends MetricsTracker
                            }
                         });
 
-      registry.register(MetricRegistry.name(poolName, "pool", "IdleConnections"),
+      registry.register(MetricRegistry.name(metricsPrefix, "IdleConnections"),
                         new Gauge<Integer>() {
                            @Override
                            public Integer getValue() {
@@ -58,7 +58,7 @@ public final class CodaHaleMetricsTracker extends MetricsTracker
                            }
                         });
 
-      registry.register(MetricRegistry.name(poolName, "pool", "ActiveConnections"),
+      registry.register(MetricRegistry.name(metricsPrefix, "ActiveConnections"),
                         new Gauge<Integer>() {
                            @Override
                            public Integer getValue() {
@@ -66,7 +66,7 @@ public final class CodaHaleMetricsTracker extends MetricsTracker
                            }
                         });
 
-      registry.register(MetricRegistry.name(poolName, "pool", "PendingConnections"),
+      registry.register(MetricRegistry.name(metricsPrefix, "PendingConnections"),
                         new Gauge<Integer>() {
                            @Override
                            public Integer getValue() {
@@ -79,12 +79,12 @@ public final class CodaHaleMetricsTracker extends MetricsTracker
    @Override
    public void close()
    {
-      registry.remove(MetricRegistry.name(poolName, "pool", "Wait"));
-      registry.remove(MetricRegistry.name(poolName, "pool", "Usage"));
-      registry.remove(MetricRegistry.name(poolName, "pool", "TotalConnections"));
-      registry.remove(MetricRegistry.name(poolName, "pool", "IdleConnections"));
-      registry.remove(MetricRegistry.name(poolName, "pool", "ActiveConnections"));
-      registry.remove(MetricRegistry.name(poolName, "pool", "PendingConnections"));
+      registry.remove(MetricRegistry.name(metricsPrefix, "Wait"));
+      registry.remove(MetricRegistry.name(metricsPrefix, "Usage"));
+      registry.remove(MetricRegistry.name(metricsPrefix, "TotalConnections"));
+      registry.remove(MetricRegistry.name(metricsPrefix, "IdleConnections"));
+      registry.remove(MetricRegistry.name(metricsPrefix, "ActiveConnections"));
+      registry.remove(MetricRegistry.name(metricsPrefix, "PendingConnections"));
    }
 
    /** {@inheritDoc} */

--- a/src/main/java/com/zaxxer/hikari/metrics/dropwizard/CodahaleHealthChecker.java
+++ b/src/main/java/com/zaxxer/hikari/metrics/dropwizard/CodahaleHealthChecker.java
@@ -61,7 +61,7 @@ public final class CodahaleHealthChecker
       final MetricRegistry metricRegistry = (MetricRegistry) hikariConfig.getMetricRegistry();
 
       final long checkTimeoutMs = Long.parseLong(healthCheckProperties.getProperty("connectivityCheckTimeoutMs", String.valueOf(hikariConfig.getConnectionTimeout())));
-      registry.register(MetricRegistry.name(hikariConfig.getPoolName(), "pool", "ConnectivityCheck"), new ConnectivityHealthCheck(pool, checkTimeoutMs));
+      registry.register(MetricRegistry.name(hikariConfig.getMetricsPrefix(), "ConnectivityCheck"), new ConnectivityHealthCheck(pool, checkTimeoutMs));
 
       final long expected99thPercentile = Long.parseLong(healthCheckProperties.getProperty("expected99thPercentileMs", "0"));
       if (metricRegistry != null && expected99thPercentile > 0) {
@@ -69,13 +69,13 @@ public final class CodahaleHealthChecker
             @Override
             public boolean matches(String name, Metric metric)
             {
-               return name.equals(MetricRegistry.name(hikariConfig.getPoolName(), "pool", "Wait"));
+               return name.equals(MetricRegistry.name(hikariConfig.getMetricsPrefix(), "Wait"));
             }
          });
 
          if (!timers.isEmpty()) {
             final Timer timer = timers.entrySet().iterator().next().getValue();
-            registry.register(MetricRegistry.name(hikariConfig.getPoolName(), "pool", "Connection99Percent"), new Connection99Percent(timer, expected99thPercentile));
+            registry.register(MetricRegistry.name(hikariConfig.getMetricsPrefix(), "Connection99Percent"), new Connection99Percent(timer, expected99thPercentile));
          }
       }
    }

--- a/src/main/java/com/zaxxer/hikari/metrics/dropwizard/CodahaleMetricsTrackerFactory.java
+++ b/src/main/java/com/zaxxer/hikari/metrics/dropwizard/CodahaleMetricsTrackerFactory.java
@@ -36,8 +36,8 @@ public final class CodahaleMetricsTrackerFactory implements MetricsTrackerFactor
    }
 
    @Override
-   public MetricsTracker create(String poolName, PoolStats poolStats)
+   public MetricsTracker create(String metricsPrefix, PoolStats poolStats)
    {
-      return new CodaHaleMetricsTracker(poolName, poolStats, registry);
+      return new CodaHaleMetricsTracker(metricsPrefix, poolStats, registry);
    }
 }

--- a/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
+++ b/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
@@ -286,7 +286,7 @@ public class HikariPool extends PoolBase implements HikariPoolMXBean, IBagStateL
    public void setMetricsTrackerFactory(MetricsTrackerFactory metricsTrackerFactory)
    {
       if (metricsTrackerFactory != null) {
-         this.metricsTracker = new MetricsTrackerDelegate(metricsTrackerFactory.create(config.getPoolName(), getPoolStats()));
+         this.metricsTracker = new MetricsTrackerDelegate(metricsTrackerFactory.create(config.getMetricsPrefix(), getPoolStats()));
       }
       else {
          this.metricsTracker = new NopMetricsTrackerDelegate();


### PR DESCRIPTION
Hi! I saw [issue 615](https://github.com/brettwooldridge/HikariCP/issues/615) and figure'd it would be something pretty easy to do in a morning. 
All the tests still pass, and I've written the update so that it wouldn't break anyone's metrics 
that are relying on the hardcoded "pool" being added to the pool name as the base of the
metrics name.
