### PR TITLE
PropertyBeanSetter uses default locale

### DIFF
--- a/src/main/java/com/zaxxer/hikari/util/PropertyElf.java
+++ b/src/main/java/com/zaxxer/hikari/util/PropertyElf.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
@@ -100,13 +101,14 @@ public final class PropertyElf
    public static Object getProperty(final String propName, final Object target)
    {
       try {
-         String capitalized = "get" + propName.substring(0, 1).toUpperCase() + propName.substring(1);
+         // use the english locale to avoid the infamous turkish locale bug
+         String capitalized = "get" + propName.substring(0, 1).toUpperCase(Locale.ENGLISH) + propName.substring(1);
          Method method = target.getClass().getMethod(capitalized);
          return method.invoke(target);
       }
       catch (Exception e) {
          try {
-            String capitalized = "is" + propName.substring(0, 1).toUpperCase() + propName.substring(1);
+            String capitalized = "is" + propName.substring(0, 1).toUpperCase(Locale.ENGLISH) + propName.substring(1);
             Method method = target.getClass().getMethod(capitalized);
             return method.invoke(target);
          }
@@ -128,7 +130,8 @@ public final class PropertyElf
    private static void setProperty(final Object target, final String propName, final Object propValue, final List<Method> methods)
    {
       Method writeMethod = null;
-      String methodName = "set" + propName.substring(0, 1).toUpperCase() + propName.substring(1);
+      // use the english locale to avoid the infamous turkish locale bug
+      String methodName = "set" + propName.substring(0, 1).toUpperCase(Locale.ENGLISH) + propName.substring(1);
 
       for (Method method : methods) {
          if (method.getName().equals(methodName) && method.getParameterTypes().length == 1) {
@@ -138,7 +141,7 @@ public final class PropertyElf
       }
 
       if (writeMethod == null) {
-         methodName = "set" + propName.toUpperCase();
+         methodName = "set" + propName.toUpperCase(Locale.ENGLISH);
          for (Method method : methods) {
             if (method.getName().equals(methodName) && method.getParameterTypes().length == 1) {
                writeMethod = method;

--- a/src/main/java/com/zaxxer/hikari/util/UtilityElf.java
+++ b/src/main/java/com/zaxxer/hikari/util/UtilityElf.java
@@ -21,6 +21,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.sql.Connection;
+import java.util.Locale;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ThreadFactory;
@@ -125,7 +126,8 @@ public final class UtilityElf
    {
       if (transactionIsolationName != null) {
          try {
-            final String upperName = transactionIsolationName.toUpperCase();
+            // use the english locale to avoid the infamous turkish locale bug
+            final String upperName = transactionIsolationName.toUpperCase(Locale.ENGLISH);
             if (upperName.startsWith("TRANSACTION_")) {
                Field field = Connection.class.getField(upperName);
                return field.getInt(null);


### PR DESCRIPTION
Motivation:

toUpperCase works according to Locale settings, for example if your computer locale is Turkish, "idleTimeout" property turns into "setİdleTime" beacuse upper "i" is "İ" in Turkish.

Modifications:

Invoke toUpperCase with Locale.ENGLISH.

Result:

Fixes #641.
PropertyBeanSetter should work with Turkish locale.