### PR TITLE
Rollback failure when both the isAutoCommit and isIsolateInternalQueries are false.

### DIFF
--- a/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
+++ b/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
@@ -343,12 +343,12 @@ abstract class PoolBase
       else {
          setNetworkTimeout(connection, validationTimeout);
       }
-
+      connection.setAutoCommit(isAutoCommit);
+      
       checkDriverSupport(connection);
 
       connection.setReadOnly(isReadOnly);
-      connection.setAutoCommit(isAutoCommit);
-
+      
       if (transactionIsolation != defaultTransactionIsolation) {
          connection.setTransactionIsolation(transactionIsolation);
       }


### PR DESCRIPTION
The autoCommit should be changed  before checkDiverSupport, otherwise once both the isAutoCommit and isIsolateInternalQueries are false the rollback operation on a true connection will fail.