### PR TITLE
Removing test redundant for com.zaxxer.hikari.pool.TestConnectionTimeoutRetry.testConnectionRetries

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,16 +6,15 @@ Changes in 2.4.7
 
  * Removed Oracle SQL state 61000, added specific error code (2399) to evict connections
    when it is encountered.
-   
- * issue 641, 643: Reflection used method String.toUpperCase() without a Locale, which causes
+
+ * issue 664: do not recycle PoolEntry objects that have closed their held connection.
+
+ * issue 641, 643: reflection used method String.toUpperCase() without a Locale, which causes
    problems in some locales such as Turkish.
 
- * pull 632: Added support for Prometheus metrics tracker.
+ * pull 632: added support for Prometheus metrics tracker.
  
  * issue 650: detect Amazon Redshift connection refused error codes.
-
- * Added Oracle SQL error code 61000 (exceeded maximum connect time) to evict connections
-   when it is encountered.
 
 Changes in 2.4.6
 

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,22 @@
 HikariCP Changes
 
+Changes in 2.4.7
+
+ * Miscellaneous stability improvements.
+
+ * Removed Oracle SQL state 61000, added specific error code (2399) to evict connections
+   when it is encountered.
+   
+ * issue 641, 643: Reflection used method String.toUpperCase() without a Locale, which causes
+   problems in some locales such as Turkish.
+
+ * pull 632: Added support for Prometheus metrics tracker.
+ 
+ * issue 650: detect Amazon Redshift connection refused error codes.
+
+ * Added Oracle SQL error code 61000 (exceeded maximum connect time) to evict connections
+   when it is encountered.
+
 Changes in 2.4.6
 
  * Added Oracle SQL error code 61000 (exceeded maximum connect time) to evict connections

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,17 @@
 HikariCP Changes
 
+Changes in 2.4.5
+
+ * issue 596: fix bug that occurs when minimumIdle is set to 0, but maximumPoolSize is
+   not explicitly set.
+ 
+ * issue 594: fix incompatibility with various libraries caused by storing a non-String
+   object in System properties.
+
+ * issue 593: improve logging when network timeout is not supported by the driver
+
+ * issue 591: improve thread-safety of Statement proxies
+ 
 Changes in 2.4.4
 
  * Generate unique sequential pool names, even across container classloaders to avoid

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,16 @@
 HikariCP Changes
 
+Changes in 2.4.6
+
+ * Added Oracle SQL error code 61000 (exceeded maximum connect time) to evict connections
+   when it is encountered.
+
+ * issue 621: fix NPE in shutdown if invoked during initialization.
+
+ * issue 606, 610: housekeeper thread was running before all class members were
+   initialized, causing an unrecoverable exception and disabling idle connection
+   retirement (maximumLifetime still applied).
+
 Changes in 2.4.5
 
  * issue 596: fix bug that occurs when minimumIdle is set to 0, but maximumPoolSize is

--- a/README.md
+++ b/README.md
@@ -437,8 +437,8 @@ Please perform changes and submit pull requests from the ``dev`` branch instead 
 [Issue Stats]:http://issuestats.com/github/brettwooldridge/HikariCP
 [Issue Stats img]:http://issuestats.com/github/brettwooldridge/HikariCP/badge/issue?style=flat&concise=true
 
-[Coverage Status]:https://coveralls.io/r/brettwooldridge/HikariCP?branch=master
-[Coverage Status img]:https://coveralls.io/repos/brettwooldridge/HikariCP/badge.svg?branch=master
+[Coverage Status]:https://coveralls.io/r/brettwooldridge/HikariCP?branch=dev
+[Coverage Status img]:https://coveralls.io/repos/brettwooldridge/HikariCP/badge.svg?branch=dev
 
 [Dependency Status]:https://www.versioneye.com/user/projects/551ce51c3661f1bee50004e0
 [Dependency Status img]:https://www.versioneye.com/user/projects/551ce51c3661f1bee50004e0/badge.svg?style=flat

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ _Java 7 and Java 8 maven artifact:_
     <dependency>
         <groupId>com.zaxxer</groupId>
         <artifactId>HikariCP</artifactId>
-        <version>2.4.5</version>
+        <version>2.4.6</version>
     </dependency>
 ```
 _Java 6 maven artifact (*maintenance mode*):_

--- a/README.md
+++ b/README.md
@@ -136,7 +136,8 @@ available, a SQLException will be thrown.  1000ms is the minimum value.
 
 &#8986;``idleTimeout``<br/>
 This property controls the maximum amount of time that a connection is allowed to sit idle in the
-pool.  Whether a connection is retired as idle or not is subject to a maximum variation of +30
+pool.  **This setting only applies when ``minimumIdle`` is defined to be less than ``maximumPoolSize``.**
+Whether a connection is retired as idle or not is subject to a maximum variation of +30
 seconds, and average variation of +15 seconds.  A connection will never be retired as idle *before*
 this timeout.  A value of 0 means that idle connections are never removed from the pool.
 *Default: 600000 (10 minutes)*

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ _Java 7 and Java 8 maven artifact:_
     <dependency>
         <groupId>com.zaxxer</groupId>
         <artifactId>HikariCP</artifactId>
-        <version>2.4.3</version>
+        <version>2.4.5</version>
     </dependency>
 ```
 _Java 6 maven artifact (*maintenance mode*):_

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ _Java 7 and Java 8 maven artifact:_
     <dependency>
         <groupId>com.zaxxer</groupId>
         <artifactId>HikariCP</artifactId>
-        <version>2.4.6</version>
+        <version>2.4.7</version>
     </dependency>
 ```
 _Java 6 maven artifact (*maintenance mode*):_

--- a/README.md
+++ b/README.md
@@ -432,7 +432,7 @@ YourKit supports open source projects with its full-featured Java Profiler.  Cli
 Please perform changes and submit pull requests from the ``dev`` branch instead of ``master``.  Please set your editor to use spaces instead of tabs, and adhere to the apparent style of the code you are editing.  The ``dev`` branch is always more "current" than the ``master`` if you are looking to live life on the edge.
 
 [Build Status]:https://travis-ci.org/brettwooldridge/HikariCP
-[Build Status img]:https://travis-ci.org/brettwooldridge/HikariCP.svg?branch=master
+[Build Status img]:https://travis-ci.org/brettwooldridge/HikariCP.svg?branch=dev
 
 [Issue Stats]:http://issuestats.com/github/brettwooldridge/HikariCP
 [Issue Stats img]:http://issuestats.com/github/brettwooldridge/HikariCP/badge/issue?style=flat&concise=true

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
    <groupId>com.zaxxer</groupId>
    <artifactId>HikariCP</artifactId>
-   <version>2.4.7-SNAPSHOT</version>
+   <version>2.4.7</version>
    <packaging>bundle</packaging>
 
    <name>HikariCP</name>
@@ -19,7 +19,7 @@
       <connection>scm:git:git@github.com:brettwooldridge/HikariCP.git</connection>
       <developerConnection>scm:git:git@github.com:brettwooldridge/HikariCP.git</developerConnection>
       <url>git@github.com:brettwooldridge/HikariCP.git</url>
-      <tag>HEAD</tag>
+      <tag>HikariCP-2.4.7</tag>
    </scm>
 
    <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
    <groupId>com.zaxxer</groupId>
    <artifactId>HikariCP</artifactId>
-   <version>2.4.6</version>
+   <version>2.4.7-SNAPSHOT</version>
    <packaging>bundle</packaging>
 
    <name>HikariCP</name>
@@ -19,7 +19,7 @@
       <connection>scm:git:git@github.com:brettwooldridge/HikariCP.git</connection>
       <developerConnection>scm:git:git@github.com:brettwooldridge/HikariCP.git</developerConnection>
       <url>git@github.com:brettwooldridge/HikariCP.git</url>
-      <tag>HikariCP-2.4.6</tag>
+      <tag>HEAD</tag>
    </scm>
 
    <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -42,17 +42,21 @@
 
       <felix.bundle.plugin.version>3.0.1</felix.bundle.plugin.version>
       <felix.version>5.4.0</felix.version>
-      <hibernate.version>5.0.7.Final</hibernate.version>
+      <hibernate.version>5.2.0.Final</hibernate.version>
       <javassist.version>3.20.0-GA</javassist.version>
       <jndi.version>0.11.4.1</jndi.version>
       <maven.release.version>2.5.3</maven.release.version>
       <metrics.version>3.1.2</metrics.version>
       <simpleclient.version>0.0.14</simpleclient.version>
       <mockito.version>1.10.19</mockito.version>
-      <pax.exam.version>4.8.0</pax.exam.version>
-      <pax.url.version>2.4.5</pax.url.version>
-      <slf4j.version>1.7.16</slf4j.version>
-      <log4j.version>2.5</log4j.version>
+      <pax.exam.version>4.9.1</pax.exam.version>
+      <pax.url.version>2.4.7</pax.url.version>
+      <slf4j.version>1.7.21</slf4j.version>
+      <log4j.version>2.6.1</log4j.version>
+      <commons.csv.version>1.4</commons.csv.version>
+      <h2.version>1.4.192</h2.version>
+      <hamcrest.version>1.3</hamcrest.version>
+      <junit.version>4.12</junit.version>
    </properties>
 
    <parent>
@@ -92,13 +96,31 @@
       <dependency>
          <groupId>org.apache.commons</groupId>
          <artifactId>commons-csv</artifactId>
-         <version>1.2</version>
+         <version>${commons.csv.version}</version>
          <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.mockito</groupId>
          <artifactId>mockito-all</artifactId>
          <version>${mockito.version}</version>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>junit</groupId>
+         <artifactId>junit</artifactId>
+         <version>${junit.version}</version>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.hamcrest</groupId>
+         <artifactId>hamcrest-core</artifactId>
+         <version>${hamcrest.version}</version>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.hamcrest</groupId>
+         <artifactId>hamcrest-library</artifactId>
+         <version>${hamcrest.version}</version>
          <scope>test</scope>
       </dependency>
       <dependency>
@@ -198,7 +220,7 @@
       <dependency>
          <groupId>com.h2database</groupId>
          <artifactId>h2</artifactId>
-         <version>1.4.191</version>
+         <version>${h2.version}</version>
          <scope>test</scope>
       </dependency>
    </dependencies>
@@ -209,7 +231,7 @@
             <!-- Generate proxies -->
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>exec-maven-plugin</artifactId>
-            <version>1.4.0</version>
+            <version>1.5.0</version>
             <executions>
                <execution>
                   <phase>compile</phase>
@@ -227,7 +249,7 @@
          <plugin>
             <groupId>org.jacoco</groupId>
             <artifactId>jacoco-maven-plugin</artifactId>
-            <version>0.7.5.201505241946</version>
+            <version>0.7.7.201606060606</version>
             <executions>
                <!-- Prepares the property pointing to the JaCoCo runtime agent which is passed as VM argument when Maven the Surefire plugin is executed. -->
                <execution>
@@ -356,7 +378,7 @@
             <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-source-plugin</artifactId>
-               <version>2.4</version>
+               <version>3.0.0</version>
                <configuration>
                   <!-- outputDirectory>/absolute/path/to/the/output/directory</outputDirectory>
                      <finalName>filename-of-generated-jar-file</finalName -->
@@ -404,7 +426,7 @@
                <plugin>
                   <groupId>org.eluder.coveralls</groupId>
                   <artifactId>coveralls-maven-plugin</artifactId>
-                  <version>4.1.0</version>
+                  <version>4.2.0</version>
                   <executions>
                      <execution>
                         <id>coveralls</id>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
    <groupId>com.zaxxer</groupId>
    <artifactId>HikariCP</artifactId>
-   <version>2.4.5</version>
+   <version>2.4.6-SNAPSHOT</version>
    <packaging>bundle</packaging>
 
    <name>HikariCP</name>
@@ -19,7 +19,7 @@
       <connection>scm:git:git@github.com:brettwooldridge/HikariCP.git</connection>
       <developerConnection>scm:git:git@github.com:brettwooldridge/HikariCP.git</developerConnection>
       <url>git@github.com:brettwooldridge/HikariCP.git</url>
-      <tag>HikariCP-2.4.5</tag>
+      <tag>HEAD</tag>
    </scm>
 
    <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
    <groupId>com.zaxxer</groupId>
    <artifactId>HikariCP</artifactId>
-   <version>2.4.6-SNAPSHOT</version>
+   <version>2.4.6</version>
    <packaging>bundle</packaging>
 
    <name>HikariCP</name>
@@ -19,7 +19,7 @@
       <connection>scm:git:git@github.com:brettwooldridge/HikariCP.git</connection>
       <developerConnection>scm:git:git@github.com:brettwooldridge/HikariCP.git</developerConnection>
       <url>git@github.com:brettwooldridge/HikariCP.git</url>
-      <tag>HEAD</tag>
+      <tag>HikariCP-2.4.6</tag>
    </scm>
 
    <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 
       <felix.bundle.plugin.version>3.0.1</felix.bundle.plugin.version>
       <felix.version>5.4.0</felix.version>
-      <hibernate.version>5.2.0.Final</hibernate.version>
+      <hibernate.version>5.0.9.Final</hibernate.version>
       <javassist.version>3.20.0-GA</javassist.version>
       <jndi.version>0.11.4.1</jndi.version>
       <maven.release.version>2.5.3</maven.release.version>

--- a/pom.xml
+++ b/pom.xml
@@ -106,15 +106,15 @@
          <scope>test</scope>
       </dependency>
       <dependency>
-         <groupId>junit</groupId>
-         <artifactId>junit</artifactId>
-         <version>${junit.version}</version>
-         <scope>test</scope>
-      </dependency>
-      <dependency>
          <groupId>org.hamcrest</groupId>
          <artifactId>hamcrest-core</artifactId>
          <version>${hamcrest.version}</version>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>junit</groupId>
+         <artifactId>junit</artifactId>
+         <version>${junit.version}</version>
          <scope>test</scope>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -187,6 +187,12 @@
          <version>${pax.url.version}</version>
          <scope>test</scope>
       </dependency>
+      <dependency>
+         <groupId>com.h2database</groupId>
+         <artifactId>h2</artifactId>
+         <version>1.4.191</version>
+         <scope>test</scope>
+      </dependency>
    </dependencies>
 
    <build>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
    <groupId>com.zaxxer</groupId>
    <artifactId>HikariCP</artifactId>
-   <version>2.4.5-SNAPSHOT</version>
+   <version>2.4.5</version>
    <packaging>bundle</packaging>
 
    <name>HikariCP</name>
@@ -19,7 +19,7 @@
       <connection>scm:git:git@github.com:brettwooldridge/HikariCP.git</connection>
       <developerConnection>scm:git:git@github.com:brettwooldridge/HikariCP.git</developerConnection>
       <url>git@github.com:brettwooldridge/HikariCP.git</url>
-      <tag>HEAD</tag>
+      <tag>HikariCP-2.4.5</tag>
    </scm>
 
    <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
    <groupId>com.zaxxer</groupId>
    <artifactId>HikariCP</artifactId>
-   <version>2.4.7</version>
+   <version>2.4.8-SNAPSHOT</version>
    <packaging>bundle</packaging>
 
    <name>HikariCP</name>
@@ -19,7 +19,7 @@
       <connection>scm:git:git@github.com:brettwooldridge/HikariCP.git</connection>
       <developerConnection>scm:git:git@github.com:brettwooldridge/HikariCP.git</developerConnection>
       <url>git@github.com:brettwooldridge/HikariCP.git</url>
-      <tag>HikariCP-2.4.7</tag>
+      <tag>HEAD</tag>
    </scm>
 
    <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
       <jndi.version>0.11.4.1</jndi.version>
       <maven.release.version>2.5.3</maven.release.version>
       <metrics.version>3.1.2</metrics.version>
+      <simpleclient.version>0.0.14</simpleclient.version>
       <mockito.version>1.10.19</mockito.version>
       <pax.exam.version>4.8.0</pax.exam.version>
       <pax.url.version>2.4.5</pax.url.version>
@@ -134,6 +135,13 @@
          <groupId>io.dropwizard.metrics</groupId>
          <artifactId>metrics-healthchecks</artifactId>
          <version>${metrics.version}</version>
+         <scope>provided</scope>
+         <optional>true</optional>
+      </dependency>
+      <dependency>
+         <groupId>io.prometheus</groupId>
+         <artifactId>simpleclient</artifactId>
+         <version>${simpleclient.version}</version>
          <scope>provided</scope>
          <optional>true</optional>
       </dependency>

--- a/src/main/java/com/zaxxer/hikari/HikariConfig.java
+++ b/src/main/java/com/zaxxer/hikari/HikariConfig.java
@@ -883,18 +883,10 @@ public class HikariConfig implements HikariConfigMXBean
    private int generatePoolNumber()
    {
       // POOL_NUMBER is global to the VM to avoid overlapping pool numbers in classloader scoped environments
-      final Properties sysProps = System.getProperties();
-      synchronized (sysProps) {
-         final String poolNumber = (String) sysProps.get("com.zaxxer.hikari.pool_number");
-         if (poolNumber == null) {
-            sysProps.put("com.zaxxer.hikari.pool_number", "0");
-            return 0;
-         }
-         else {
-            final int next = Integer.parseInt(poolNumber) + 1;
-            sysProps.put("com.zaxxer.hikari.pool_number", String.valueOf(next));
-            return next;
-         }
+      synchronized (System.getProperties()) {
+         final int next = Integer.getInteger("com.zaxxer.hikari.pool_number", 0) + 1;
+         System.setProperty("com.zaxxer.hikari.pool_number", String.valueOf(next));
+         return next;
       }
    }
 

--- a/src/main/java/com/zaxxer/hikari/HikariConfig.java
+++ b/src/main/java/com/zaxxer/hikari/HikariConfig.java
@@ -53,6 +53,7 @@ public class HikariConfig implements HikariConfigMXBean
    private static final long VALIDATION_TIMEOUT = SECONDS.toMillis(5);
    private static final long IDLE_TIMEOUT = MINUTES.toMillis(10);
    private static final long MAX_LIFETIME = MINUTES.toMillis(30);
+   private static final int DEFAULT_POOL_SIZE = 10;
 
    private static boolean unitTest;
 
@@ -825,7 +826,7 @@ public class HikariConfig implements HikariConfigMXBean
       }
 
       if (maxPoolSize < 1) {
-         maxPoolSize = (minIdle <= 0) ? 10 : minIdle;
+         maxPoolSize = (minIdle <= 0) ? DEFAULT_POOL_SIZE : minIdle;
       }
 
       if (minIdle < 0 || minIdle > maxPoolSize) {

--- a/src/main/java/com/zaxxer/hikari/HikariConfig.java
+++ b/src/main/java/com/zaxxer/hikari/HikariConfig.java
@@ -27,7 +27,6 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.naming.InitialContext;
 import javax.naming.NamingException;

--- a/src/main/java/com/zaxxer/hikari/HikariConfig.java
+++ b/src/main/java/com/zaxxer/hikari/HikariConfig.java
@@ -824,13 +824,11 @@ public class HikariConfig implements HikariConfigMXBean
          validationTimeout = VALIDATION_TIMEOUT;
       }
 
-      if (maxPoolSize < 0) {
-         if (minIdle < 0) {
-            minIdle = 10;
-         }
-         maxPoolSize = minIdle;
+      if (maxPoolSize < 1) {
+         maxPoolSize = (minIdle <= 0) ? 10 : minIdle;
       }
-      else if (minIdle < 0 || minIdle > maxPoolSize) {
+
+      if (minIdle < 0 || minIdle > maxPoolSize) {
          minIdle = maxPoolSize;
       }
    }
@@ -881,7 +879,7 @@ public class HikariConfig implements HikariConfigMXBean
 
    private int generatePoolNumber()
    {
-      // POOL_NUMBER is global to the VM to avoid overlapping pool numbers in classloader scoped environments
+      // Pool number is global to the VM to avoid overlapping pool numbers in classloader scoped environments
       synchronized (System.getProperties()) {
          final int next = Integer.getInteger("com.zaxxer.hikari.pool_number", 0) + 1;
          System.setProperty("com.zaxxer.hikari.pool_number", String.valueOf(next));

--- a/src/main/java/com/zaxxer/hikari/HikariDataSource.java
+++ b/src/main/java/com/zaxxer/hikari/HikariDataSource.java
@@ -251,7 +251,9 @@ public class HikariDataSource extends HikariConfig implements DataSource, Closea
    }
 
    /**
-    * Evict a connection from the pool.
+    * Evict a connection from the pool.  If the connection has already been closed (returned to the pool)
+    * this may result in a "soft" eviction; the connection will be evicted sometime in the future if it is
+    * currently in use.  If the connection has not been closed, the eviction is immediate.
     *
     * @param connection the connection to evict from the pool
     */

--- a/src/main/java/com/zaxxer/hikari/metrics/prometheus/HikariCPCollector.java
+++ b/src/main/java/com/zaxxer/hikari/metrics/prometheus/HikariCPCollector.java
@@ -1,0 +1,39 @@
+package com.zaxxer.hikari.metrics.prometheus;
+
+import com.zaxxer.hikari.metrics.PoolStats;
+import io.prometheus.client.Collector;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+class HikariCPCollector extends Collector {
+   private final PoolStats poolStats;
+   private final List<String> labelNames;
+   private final List<String> labelValues;
+
+   HikariCPCollector(String poolName, PoolStats poolStats) {
+      this.poolStats = poolStats;
+      this.labelNames = Collections.singletonList("pool");
+      this.labelValues = Collections.singletonList(poolName);
+   }
+
+   @Override
+   public List<MetricFamilySamples> collect() {
+      return Arrays.asList(
+         createSample("hikaricp_active_connections", "Active connections", poolStats.getActiveConnections()),
+         createSample("hikaricp_idle_connections", "Idle connections", poolStats.getIdleConnections()),
+         createSample("hikaricp_pending_threads", "Pending threads", poolStats.getPendingThreads()),
+         createSample("hikaricp_connections", "The number of current connections", poolStats.getTotalConnections())
+      );
+   }
+
+   private MetricFamilySamples createSample(String name, String helpMessage, double value) {
+      List<MetricFamilySamples.Sample> samples = Collections.singletonList(new MetricFamilySamples.Sample(name,
+         labelNames,
+         labelValues,
+         value));
+
+      return new MetricFamilySamples(name, Type.GAUGE, helpMessage, samples);
+   }
+}

--- a/src/main/java/com/zaxxer/hikari/metrics/prometheus/PrometheusMetricsTracker.java
+++ b/src/main/java/com/zaxxer/hikari/metrics/prometheus/PrometheusMetricsTracker.java
@@ -1,0 +1,52 @@
+package com.zaxxer.hikari.metrics.prometheus;
+
+import com.zaxxer.hikari.metrics.MetricsTracker;
+import io.prometheus.client.Counter;
+import io.prometheus.client.Summary;
+
+class PrometheusMetricsTracker extends MetricsTracker {
+   private final Counter.Child connectionTimeoutCounter;
+   private final Summary.Child elapsedAcquiredSummary;
+   private final Summary.Child elapsedBorrowedSummary;
+
+   PrometheusMetricsTracker(String poolName) {
+      super();
+
+      Counter counter = Counter.build()
+         .name("hikaricp_connection_timeout_count")
+         .labelNames("pool")
+         .help("Connection timeout count")
+         .register();
+
+      this.connectionTimeoutCounter = counter.labels(poolName);
+
+      Summary elapsedAcquiredSummary = Summary.build()
+         .name("hikaricp_connection_acquired_nanos")
+         .labelNames("pool")
+         .help("Connection acquired time")
+         .register();
+      this.elapsedAcquiredSummary = elapsedAcquiredSummary.labels(poolName);
+
+      Summary elapsedBorrowedSummary = Summary.build()
+         .name("hikaricp_connection_usage_millis")
+         .labelNames("pool")
+         .help("Connection usage")
+         .register();
+      this.elapsedBorrowedSummary = elapsedBorrowedSummary.labels(poolName);
+   }
+
+   @Override
+   public void recordConnectionAcquiredNanos(long elapsedAcquiredNanos) {
+      elapsedAcquiredSummary.observe(elapsedAcquiredNanos);
+   }
+
+   @Override
+   public void recordConnectionUsageMillis(long elapsedBorrowedMillis) {
+      elapsedBorrowedSummary.observe(elapsedBorrowedMillis);
+   }
+
+   @Override
+   public void recordConnectionTimeout() {
+      connectionTimeoutCounter.inc();
+   }
+}

--- a/src/main/java/com/zaxxer/hikari/metrics/prometheus/PrometheusMetricsTrackerFactory.java
+++ b/src/main/java/com/zaxxer/hikari/metrics/prometheus/PrometheusMetricsTrackerFactory.java
@@ -1,0 +1,19 @@
+package com.zaxxer.hikari.metrics.prometheus;
+
+import com.zaxxer.hikari.metrics.MetricsTracker;
+import com.zaxxer.hikari.metrics.MetricsTrackerFactory;
+import com.zaxxer.hikari.metrics.PoolStats;
+
+/**
+ * <pre>{@code
+ * HikariConfig config = new HikariConfig();
+ * config.setMetricsTrackerFactory(new PrometheusMetricsTrackerFactory());
+ * }</pre>
+ */
+public class PrometheusMetricsTrackerFactory implements MetricsTrackerFactory {
+   @Override
+   public MetricsTracker create(String poolName, PoolStats poolStats) {
+      new HikariCPCollector(poolName, poolStats).register();
+      return new PrometheusMetricsTracker(poolName);
+   }
+}

--- a/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
+++ b/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
@@ -216,8 +216,10 @@ public class HikariPool extends PoolBase implements HikariPoolMXBean, IBagStateL
 
          softEvictConnections();
 
-         addConnectionExecutor.shutdown();
-         addConnectionExecutor.awaitTermination(5L, SECONDS);
+         if (addConnectionExecutor != null) {
+            addConnectionExecutor.shutdown();
+            addConnectionExecutor.awaitTermination(5L, SECONDS);
+         }
          if (config.getScheduledExecutorService() == null && houseKeepingExecutorService != null) {
             houseKeepingExecutorService.shutdown();
             houseKeepingExecutorService.awaitTermination(5L, SECONDS);
@@ -240,8 +242,10 @@ public class HikariPool extends PoolBase implements HikariPoolMXBean, IBagStateL
          }
 
          shutdownNetworkTimeoutExecutor();
-         closeConnectionExecutor.shutdown();
-         closeConnectionExecutor.awaitTermination(5L, SECONDS);
+         if (closeConnectionExecutor != null) {
+            closeConnectionExecutor.shutdown();
+            closeConnectionExecutor.awaitTermination(5L, SECONDS);
+         }
       }
       finally {
          logPoolState("After closing ");

--- a/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
+++ b/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
@@ -493,14 +493,14 @@ public class HikariPool extends PoolBase implements HikariPoolMXBean, IBagStateL
    private void abortActiveConnections(final ExecutorService assassinExecutor)
    {
       for (PoolEntry poolEntry : connectionBag.values(STATE_IN_USE)) {
+         Connection connection = poolEntry.close();
          try {
-            poolEntry.connection.abort(assassinExecutor);
+            connection.abort(assassinExecutor);
          }
          catch (Throwable e) {
-            quietlyCloseConnection(poolEntry.connection, "(connection aborted during shutdown)");
+            quietlyCloseConnection(connection, "(connection aborted during shutdown)");
          }
          finally {
-            poolEntry.close();
             if (connectionBag.remove(poolEntry)) {
                totalConnections.decrementAndGet();
             }

--- a/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
+++ b/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
@@ -602,10 +602,10 @@ public class HikariPool extends PoolBase implements HikariPoolMXBean, IBagStateL
             connectionTimeout = config.getConnectionTimeout();
             validationTimeout = config.getValidationTimeout();
             leakTask.updateLeakDetectionThreshold(config.getLeakDetectionThreshold());
-   
+
             final long idleTimeout = config.getIdleTimeout();
             final long now = clockSource.currentTime();
-   
+
             // Detect retrograde time, allowing +128ms as per NTP spec.
             if (clockSource.plusMillis(now, 128) < clockSource.plusMillis(previous, HOUSEKEEPING_PERIOD_MS)) {
                LOGGER.warn("{} - Retrograde clock change detected (housekeeper delta={}), soft-evicting connections from pool.",
@@ -617,11 +617,11 @@ public class HikariPool extends PoolBase implements HikariPoolMXBean, IBagStateL
             }
             else if (now > clockSource.plusMillis(previous, (3 * HOUSEKEEPING_PERIOD_MS) / 2)) {
                // No point evicting for forward clock motion, this merely accelerates connection retirement anyway
-               LOGGER.warn("{} - Thread starvation or clock leap detected (housekeeper delta={}).", clockSource.elapsedDisplayString(previous, now), poolName);
+               LOGGER.warn("{} - Thread starvation or clock leap detected (housekeeper delta={}).", poolName, clockSource.elapsedDisplayString(previous, now));
             }
-   
+
             previous = now;
-   
+
             String afterPrefix = "Pool ";
             if (idleTimeout > 0L) {
                final List<PoolEntry> idleList = connectionBag.values(STATE_NOT_IN_USE);
@@ -629,7 +629,7 @@ public class HikariPool extends PoolBase implements HikariPoolMXBean, IBagStateL
                if (removable > 0) {
                   logPoolState("Before cleanup ");
                   afterPrefix = "After cleanup  ";
-   
+
                   // Sort pool entries on lastAccessed
                   Collections.sort(idleList, LASTACCESS_COMPARABLE);
                   for (PoolEntry poolEntry : idleList) {
@@ -642,9 +642,9 @@ public class HikariPool extends PoolBase implements HikariPoolMXBean, IBagStateL
                   }
                }
             }
-   
+
             logPoolState(afterPrefix);
-   
+
             fillPool(); // Try to maintain minimum connections
          }
          catch (Exception e) {

--- a/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
+++ b/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
@@ -436,7 +436,7 @@ abstract class PoolBase
             if (isNetworkTimeoutSupported == UNINITIALIZED) {
                isNetworkTimeoutSupported = FALSE;
 
-               LOGGER.warn("{} - Failed to get/set network timeout for connection. ({})", poolName, e.getMessage());
+               LOGGER.info("{} - Driver does not support get/set network timeout for connections. ({})", poolName, e.getMessage());
                if (validationTimeout < SECONDS.toMillis(1)) {
                   LOGGER.warn("{} - A validationTimeout of less than 1 second cannot be honored on drivers without setNetworkTimeout() support.", poolName);
                }

--- a/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
+++ b/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
@@ -344,10 +344,10 @@ abstract class PoolBase
          setNetworkTimeout(connection, validationTimeout);
       }
 
-      checkDriverSupport(connection);
-
       connection.setReadOnly(isReadOnly);
       connection.setAutoCommit(isAutoCommit);
+
+      checkDriverSupport(connection);
 
       if (transactionIsolation != defaultTransactionIsolation) {
          connection.setTransactionIsolation(transactionIsolation);
@@ -414,7 +414,7 @@ abstract class PoolBase
          catch (Throwable e) {
             if (isQueryTimeoutSupported == UNINITIALIZED) {
                isQueryTimeoutSupported = FALSE;
-               LOGGER.warn("{} - Failed to set query timeout for statement. ({})", poolName, e.getMessage());
+               LOGGER.info("{} - Failed to set query timeout for statement. ({})", poolName, e.getMessage());
             }
          }
       }
@@ -525,10 +525,10 @@ abstract class PoolBase
    {
       if (connectionTimeout != Integer.MAX_VALUE) {
          try {
-            dataSource.setLoginTimeout((int) MILLISECONDS.toSeconds(Math.max(1000L, connectionTimeout)));
+            dataSource.setLoginTimeout(Math.max(1, (int) MILLISECONDS.toSeconds(500L + connectionTimeout)));
          }
          catch (Throwable e) {
-            LOGGER.warn("{} - Failed to set login timeout for data source. ({})", poolName, e.getMessage());
+            LOGGER.info("{} - Failed to set login timeout for data source. ({})", poolName, e.getMessage());
          }
       }
    }

--- a/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
+++ b/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
@@ -12,6 +12,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import java.lang.management.ManagementFactory;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.sql.SQLTransientConnectionException;
 import java.sql.Statement;
 import java.util.Properties;
 import java.util.concurrent.Executor;
@@ -313,6 +314,10 @@ abstract class PoolBase
          String password = config.getPassword();
 
          connection = (username == null) ? dataSource.getConnection() : dataSource.getConnection(username, password);
+         if (connection == null) {
+            throw new SQLTransientConnectionException("DataSource returned null unexpectedly");
+         }
+
          setupConnection(connection);
          lastConnectionFailure.set(null);
          return connection;

--- a/src/main/java/com/zaxxer/hikari/pool/PoolEntry.java
+++ b/src/main/java/com/zaxxer/hikari/pool/PoolEntry.java
@@ -82,8 +82,10 @@ final class PoolEntry implements IConcurrentBagEntry
     */
    void recycle(final long lastAccessed)
    {
-      this.lastAccessed = lastAccessed;
-      hikariPool.releaseConnection(this);
+      if (connection != null) {
+         this.lastAccessed = lastAccessed;
+         hikariPool.releaseConnection(this);
+      }
    }
 
    /**

--- a/src/main/java/com/zaxxer/hikari/pool/ProxyConnection.java
+++ b/src/main/java/com/zaxxer/hikari/pool/ProxyConnection.java
@@ -81,6 +81,7 @@ public abstract class ProxyConnection implements Connection
       SQL_ERRORS.add("01002"); // SQL92 disconnect error
       SQL_ERRORS.add("JZ0C0"); // Sybase disconnect error
       SQL_ERRORS.add("JZ0C1"); // Sybase disconnect error
+      SQL_ERRORS.add("61000"); // Oracle ORA-02399: exceeded maximum connect time.
    }
 
    protected ProxyConnection(final PoolEntry poolEntry, final Connection connection, final FastList<Statement> openStatements, final ProxyLeakTask leakTask, final long now, final boolean isReadOnly, final boolean isAutoCommit) {

--- a/src/main/java/com/zaxxer/hikari/pool/ProxyConnection.java
+++ b/src/main/java/com/zaxxer/hikari/pool/ProxyConnection.java
@@ -162,7 +162,7 @@ public abstract class ProxyConnection implements Connection
       return sqle;
    }
 
-   final void untrackStatement(final Statement statement)
+   final synchronized void untrackStatement(final Statement statement)
    {
       openStatements.remove(statement);
    }

--- a/src/main/java/com/zaxxer/hikari/pool/ProxyConnection.java
+++ b/src/main/java/com/zaxxer/hikari/pool/ProxyConnection.java
@@ -82,10 +82,10 @@ public abstract class ProxyConnection implements Connection
       ERROR_STATES.add("01002"); // SQL92 disconnect error
       ERROR_STATES.add("JZ0C0"); // Sybase disconnect error
       ERROR_STATES.add("JZ0C1"); // Sybase disconnect error
-      ERROR_STATES.add("61000"); // Oracle ORA-02399: exceeded maximum connect time.
 
       ERROR_CODES = new HashSet<>();
       ERROR_CODES.add(500150);
+      ERROR_CODES.add(2399);
    }
 
    protected ProxyConnection(final PoolEntry poolEntry, final Connection connection, final FastList<Statement> openStatements, final ProxyLeakTask leakTask, final long now, final boolean isReadOnly, final boolean isAutoCommit) {

--- a/src/main/java/com/zaxxer/hikari/pool/ProxyConnection.java
+++ b/src/main/java/com/zaxxer/hikari/pool/ProxyConnection.java
@@ -182,7 +182,7 @@ public abstract class ProxyConnection implements Connection
       leakTask.cancel();
    }
 
-   private final <T extends Statement> T trackStatement(final T statement)
+   private final synchronized <T extends Statement> T trackStatement(final T statement)
    {
       openStatements.add(statement);
 
@@ -205,7 +205,9 @@ public abstract class ProxyConnection implements Connection
             }
          }
 
-         openStatements.clear();
+         synchronized (this) {
+            openStatements.clear();
+         }
       }
    }
 

--- a/src/main/java/com/zaxxer/hikari/util/FastList.java
+++ b/src/main/java/com/zaxxer/hikari/util/FastList.java
@@ -184,6 +184,10 @@ public final class FastList<T> extends ArrayList<T>
    @Override
    public T remove(int index)
    {
+      if (size == 0) {
+         return null;
+      }
+
       final T old = elementData[index];
 
       final int numMoved = size - index - 1;

--- a/src/main/java/com/zaxxer/hikari/util/PropertyElf.java
+++ b/src/main/java/com/zaxxer/hikari/util/PropertyElf.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
@@ -100,13 +101,14 @@ public final class PropertyElf
    public static Object getProperty(final String propName, final Object target)
    {
       try {
-         String capitalized = "get" + propName.substring(0, 1).toUpperCase() + propName.substring(1);
+         // use the english locale to avoid the infamous turkish locale bug
+         String capitalized = "get" + propName.substring(0, 1).toUpperCase(Locale.ENGLISH) + propName.substring(1);
          Method method = target.getClass().getMethod(capitalized);
          return method.invoke(target);
       }
       catch (Exception e) {
          try {
-            String capitalized = "is" + propName.substring(0, 1).toUpperCase() + propName.substring(1);
+            String capitalized = "is" + propName.substring(0, 1).toUpperCase(Locale.ENGLISH) + propName.substring(1);
             Method method = target.getClass().getMethod(capitalized);
             return method.invoke(target);
          }
@@ -128,7 +130,8 @@ public final class PropertyElf
    private static void setProperty(final Object target, final String propName, final Object propValue, final List<Method> methods)
    {
       Method writeMethod = null;
-      String methodName = "set" + propName.substring(0, 1).toUpperCase() + propName.substring(1);
+      // use the english locale to avoid the infamous turkish locale bug
+      String methodName = "set" + propName.substring(0, 1).toUpperCase(Locale.ENGLISH) + propName.substring(1);
 
       for (Method method : methods) {
          if (method.getName().equals(methodName) && method.getParameterTypes().length == 1) {
@@ -138,7 +141,7 @@ public final class PropertyElf
       }
 
       if (writeMethod == null) {
-         methodName = "set" + propName.toUpperCase();
+         methodName = "set" + propName.toUpperCase(Locale.ENGLISH);
          for (Method method : methods) {
             if (method.getName().equals(methodName) && method.getParameterTypes().length == 1) {
                writeMethod = method;

--- a/src/main/java/com/zaxxer/hikari/util/Sequence.java
+++ b/src/main/java/com/zaxxer/hikari/util/Sequence.java
@@ -49,17 +49,16 @@ public interface Sequence
    {
       public static Sequence create()
       {
-         try {
-            if (Sequence.class.getClassLoader().loadClass("java.util.concurrent.atomic.LongAdder") != null && !Boolean.getBoolean("com.zaxxer.hikari.useAtomicLongSequence")) {
-               return new Java8Sequence();
-            }
+         if (UtilityElf.isJdk8Plus() && !Boolean.getBoolean("com.zaxxer.hikari.useAtomicLongSequence")) {
+            return new Java8Sequence();
          }
-         catch (ClassNotFoundException e) {
+         else {
             try {
                Class<?> longAdderClass = Sequence.class.getClassLoader().loadClass("com.codahale.metrics.LongAdder");
                return new DropwizardSequence(longAdderClass);
             }
             catch (Exception e2) {
+               // fall thru
             }
          }
 

--- a/src/main/java/com/zaxxer/hikari/util/UtilityElf.java
+++ b/src/main/java/com/zaxxer/hikari/util/UtilityElf.java
@@ -165,7 +165,7 @@ public final class UtilityElf
          return false;
       }
 
-      return Float.parseFloat(matcher.group(1)) > 1.7;
+      return Float.parseFloat(matcher.group(1)) > 1.7f;
    }
 
    public static final class DefaultThreadFactory implements ThreadFactory {

--- a/src/main/java/com/zaxxer/hikari/util/UtilityElf.java
+++ b/src/main/java/com/zaxxer/hikari/util/UtilityElf.java
@@ -26,6 +26,8 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  *
@@ -150,6 +152,20 @@ public final class UtilityElf
       }
 
       return -1;
+   }
+
+   /**
+    * Are we running on JDK 8 or above?
+    *
+    * @return true if JDK 8+, false otherwise
+    */
+   public static boolean isJdk8Plus() {
+      Matcher matcher = Pattern.compile("(?:(\\d+(?:\\.?\\d*)))").matcher(System.getProperty("java.version"));
+      if (!matcher.find()) {
+         return false;
+      }
+
+      return Float.parseFloat(matcher.group(1)) > 1.7;
    }
 
    public static final class DefaultThreadFactory implements ThreadFactory {

--- a/src/main/java/com/zaxxer/hikari/util/UtilityElf.java
+++ b/src/main/java/com/zaxxer/hikari/util/UtilityElf.java
@@ -21,6 +21,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.sql.Connection;
+import java.util.Locale;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ThreadFactory;
@@ -125,7 +126,8 @@ public final class UtilityElf
    {
       if (transactionIsolationName != null) {
          try {
-            final String upperName = transactionIsolationName.toUpperCase();
+            // use the english locale to avoid the infamous turkish locale bug
+            final String upperName = transactionIsolationName.toUpperCase(Locale.ENGLISH);
             if (upperName.startsWith("TRANSACTION_")) {
                Field field = Connection.class.getField(upperName);
                return field.getInt(null);

--- a/src/test/java/com/zaxxer/hikari/db/BasicPoolTest.java
+++ b/src/test/java/com/zaxxer/hikari/db/BasicPoolTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2016 Brett Wooldridge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.zaxxer.hikari.db;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import com.zaxxer.hikari.pool.HikariPool;
+import com.zaxxer.hikari.pool.TestElf;
+
+/**
+ * @author brettw
+ *
+ */
+public class BasicPoolTest
+{
+   @Before
+   public void setup() throws SQLException
+   {
+       HikariConfig config = new HikariConfig();
+       config.setMinimumIdle(1);
+       config.setMaximumPoolSize(2);
+       config.setConnectionTestQuery("SELECT 1");
+       config.setDataSourceClassName("org.h2.jdbcx.JdbcDataSource");
+       config.addDataSourceProperty("url", "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1");
+
+       try (HikariDataSource ds = new HikariDataSource(config);
+            Connection conn = ds.getConnection();
+            Statement stmt = conn.createStatement()) {
+          stmt.executeUpdate("DROP TABLE IF EXISTS basic_pool_test");
+          stmt.executeUpdate("CREATE TABLE basic_pool_test ("
+                            + "id INTEGER NOT NULL IDENTITY PRIMARY KEY, "
+                            + "timestamp TIMESTAMP, "
+                            + "string VARCHAR(128), "
+                            + "string_from_number NUMERIC "
+                            + ")");
+       }
+   }
+
+   @Test
+   public void testIdleTimeout() throws InterruptedException, SQLException
+   {
+      HikariConfig config = new HikariConfig();
+      config.setMinimumIdle(5);
+      config.setMaximumPoolSize(10);
+      config.setConnectionTestQuery("SELECT 1");
+      config.setDataSourceClassName("org.h2.jdbcx.JdbcDataSource");
+      config.addDataSourceProperty("url", "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1");
+
+      System.setProperty("com.zaxxer.hikari.housekeeping.periodMs", "1000");
+
+      try (HikariDataSource ds = new HikariDataSource(config)) {
+         System.clearProperty("com.zaxxer.hikari.housekeeping.periodMs");
+
+         TimeUnit.SECONDS.sleep(1);
+
+         HikariPool pool = TestElf.getPool(ds);
+
+         ds.setIdleTimeout(3000);
+
+         Assert.assertSame("Total connections not as expected", 5, pool.getTotalConnections());
+         Assert.assertSame("Idle connections not as expected", 5, pool.getIdleConnections());
+
+         Connection connection = ds.getConnection();
+         Assert.assertNotNull(connection);
+
+         TimeUnit.MILLISECONDS.sleep(1500);
+
+         Assert.assertSame("Second total connections not as expected", 6, pool.getTotalConnections());
+         Assert.assertSame("Second idle connections not as expected", 5, pool.getIdleConnections());
+         connection.close();
+
+         Assert.assertSame("Idle connections not as expected", 6, pool.getIdleConnections());
+
+         TimeUnit.SECONDS.sleep(2);
+
+         Assert.assertSame("Third total connections not as expected", 5, pool.getTotalConnections());
+         Assert.assertSame("Third idle connections not as expected", 5, pool.getIdleConnections());
+      }
+   }
+
+   @Test
+   public void testIdleTimeout2() throws InterruptedException, SQLException
+   {
+      HikariConfig config = new HikariConfig();
+      config.setMaximumPoolSize(50);
+      config.setConnectionTestQuery("SELECT 1");
+      config.setDataSourceClassName("org.h2.jdbcx.JdbcDataSource");
+      config.addDataSourceProperty("url", "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1");
+
+      System.setProperty("com.zaxxer.hikari.housekeeping.periodMs", "1000");
+
+      try (HikariDataSource ds = new HikariDataSource(config)) {
+         System.clearProperty("com.zaxxer.hikari.housekeeping.periodMs");
+
+         TimeUnit.SECONDS.sleep(1);
+
+         HikariPool pool = TestElf.getPool(ds);
+
+         ds.setIdleTimeout(3000);
+
+         Assert.assertSame("Total connections not as expected", 50, pool.getTotalConnections());
+         Assert.assertSame("Idle connections not as expected", 50, pool.getIdleConnections());
+
+         Connection connection = ds.getConnection();
+         Assert.assertNotNull(connection);
+
+         TimeUnit.MILLISECONDS.sleep(1500);
+
+         Assert.assertSame("Second total connections not as expected", 50, pool.getTotalConnections());
+         Assert.assertSame("Second idle connections not as expected", 49, pool.getIdleConnections());
+         connection.close();
+
+         Assert.assertSame("Idle connections not as expected", 50, pool.getIdleConnections());
+
+         TimeUnit.SECONDS.sleep(3);
+
+         Assert.assertSame("Third total connections not as expected", 50, pool.getTotalConnections());
+         Assert.assertSame("Third idle connections not as expected", 50, pool.getIdleConnections());
+      }
+   }
+}

--- a/src/test/java/com/zaxxer/hikari/metrics/prometheus/HikariCPCollectorTest.java
+++ b/src/test/java/com/zaxxer/hikari/metrics/prometheus/HikariCPCollectorTest.java
@@ -1,0 +1,85 @@
+package com.zaxxer.hikari.metrics.prometheus;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import io.prometheus.client.CollectorRegistry;
+import org.junit.Test;
+
+import java.sql.Connection;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class HikariCPCollectorTest {
+   @Test
+   public void noConnection() throws Exception {
+      HikariConfig config = new HikariConfig();
+      config.setPoolName("no_connection");
+      config.setMetricsTrackerFactory(new PrometheusMetricsTrackerFactory());
+      config.setJdbcUrl("jdbc:h2:mem:");
+
+      new HikariDataSource(config);
+
+      assertThat(getValue("hikaricp_active_connections", "no_connection"), is(0.0));
+      assertThat(getValue("hikaricp_idle_connections", "no_connection"), is(0.0));
+      assertThat(getValue("hikaricp_pending_threads", "no_connection"), is(0.0));
+      assertThat(getValue("hikaricp_connections", "no_connection"), is(0.0));
+   }
+
+   @Test
+   public void noConnectionWithoutPoolName() throws Exception {
+      HikariConfig config = new HikariConfig();
+      config.setMetricsTrackerFactory(new PrometheusMetricsTrackerFactory());
+      config.setJdbcUrl("jdbc:h2:mem:");
+
+      new HikariDataSource(config);
+
+      assertThat(getValue("hikaricp_active_connections", "HikariPool-1"), is(0.0));
+      assertThat(getValue("hikaricp_idle_connections", "HikariPool-1"), is(0.0));
+      assertThat(getValue("hikaricp_pending_threads", "HikariPool-1"), is(0.0));
+      assertThat(getValue("hikaricp_connections", "HikariPool-1"), is(0.0));
+   }
+
+   @Test
+   public void connection1() throws Exception {
+      HikariConfig config = new HikariConfig();
+      config.setPoolName("connection1");
+      config.setMetricsTrackerFactory(new PrometheusMetricsTrackerFactory());
+      config.setJdbcUrl("jdbc:h2:mem:");
+
+      HikariDataSource ds = new HikariDataSource(config);
+      Connection connection1 = ds.getConnection();
+
+      assertThat(getValue("hikaricp_active_connections", "connection1"), is(1.0));
+      assertThat(getValue("hikaricp_idle_connections", "connection1"), is(0.0));
+      assertThat(getValue("hikaricp_pending_threads", "connection1"), is(0.0));
+      assertThat(getValue("hikaricp_connections", "connection1"), is(1.0));
+
+      connection1.close();
+   }
+
+   @Test
+   public void connectionClosed() throws Exception {
+      HikariConfig config = new HikariConfig();
+      config.setPoolName("connectionClosed");
+      config.setMetricsTrackerFactory(new PrometheusMetricsTrackerFactory());
+      config.setJdbcUrl("jdbc:h2:mem:");
+      config.setMaximumPoolSize(20);
+
+      HikariDataSource ds = new HikariDataSource(config);
+      Connection connection1 = ds.getConnection();
+      connection1.close();
+
+      assertThat(getValue("hikaricp_active_connections", "connectionClosed"), is(0.0));
+      assertThat(getValue("hikaricp_idle_connections", "connectionClosed"), is(1.0));
+      assertThat(getValue("hikaricp_pending_threads", "connectionClosed"), is(0.0));
+      assertThat(getValue("hikaricp_connections", "connectionClosed"), is(1.0));
+   }
+
+   private double getValue(String name, String poolName) {
+      String[] labelNames = {"pool"};
+      String[] labelValues = {poolName};
+      return CollectorRegistry.defaultRegistry.getSampleValue(name, labelNames, labelValues);
+   }
+
+}

--- a/src/test/java/com/zaxxer/hikari/metrics/prometheus/PrometheusMetricsTrackerTest.java
+++ b/src/test/java/com/zaxxer/hikari/metrics/prometheus/PrometheusMetricsTrackerTest.java
@@ -1,0 +1,60 @@
+package com.zaxxer.hikari.metrics.prometheus;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import io.prometheus.client.CollectorRegistry;
+import org.junit.Test;
+
+import java.sql.Connection;
+import java.sql.SQLTransientConnectionException;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class PrometheusMetricsTrackerTest {
+   @Test
+   public void recordConnectionTimeout() throws Exception {
+      String poolName = "record";
+
+      HikariConfig config = new HikariConfig();
+      config.setPoolName(poolName);
+      config.setMetricsTrackerFactory(new PrometheusMetricsTrackerFactory());
+      config.setJdbcUrl("jdbc:h2:mem:");
+      config.setMaximumPoolSize(1);
+      config.setConnectionTimeout(250);
+
+      String[] labelNames = {"pool"};
+      String[] labelValues = {poolName};
+
+      HikariDataSource hikariDataSource = new HikariDataSource(config);
+      Connection connection = hikariDataSource.getConnection();
+      try {
+         hikariDataSource.getConnection();
+      } catch (SQLTransientConnectionException ignored) {
+      }
+      connection.close();
+
+      assertThat(CollectorRegistry.defaultRegistry.getSampleValue(
+         "hikaricp_connection_timeout_count",
+         labelNames,
+         labelValues), is(1.0));
+      assertThat(CollectorRegistry.defaultRegistry.getSampleValue(
+         "hikaricp_connection_acquired_nanos_count",
+         labelNames,
+         labelValues), is(equalTo(1.0)));
+      assertTrue(CollectorRegistry.defaultRegistry.getSampleValue(
+         "hikaricp_connection_acquired_nanos_sum",
+         labelNames,
+         labelValues) > 0.0);
+      assertThat(CollectorRegistry.defaultRegistry.getSampleValue(
+         "hikaricp_connection_usage_millis_count",
+         labelNames,
+         labelValues), is(equalTo(1.0)));
+      assertTrue(CollectorRegistry.defaultRegistry.getSampleValue(
+         "hikaricp_connection_usage_millis_sum",
+         labelNames,
+         labelValues) > 0.0);
+   }
+}

--- a/src/test/java/com/zaxxer/hikari/pool/ConcurrentCloseConnectionTest.java
+++ b/src/test/java/com/zaxxer/hikari/pool/ConcurrentCloseConnectionTest.java
@@ -1,0 +1,57 @@
+package com.zaxxer.hikari.pool;
+
+import com.zaxxer.hikari.HikariConfig;
+import org.junit.Test;
+
+import com.zaxxer.hikari.HikariDataSource;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+/**
+ * @author Matthew Tambara (matthew.tambara@liferay.com)
+ */
+public class ConcurrentCloseConnectionTest
+{
+   @Test
+   public void testConcurrentClose() throws Exception
+   {
+	  HikariConfig config = new HikariConfig();
+      config.setDataSourceClassName("com.zaxxer.hikari.mocks.StubDataSource");
+
+	  try (HikariDataSource ds = new HikariDataSource(config);
+	      final Connection connection = ds.getConnection()) {
+
+		  ExecutorService executorService = Executors.newFixedThreadPool(10);
+
+		  List<Future> futures = new ArrayList<>();
+
+		  for (int i = 0; i < 500; i++) {
+			  final PreparedStatement preparedStatement =
+				  connection.prepareStatement("");
+
+			  futures.add(executorService.submit(new Callable<Void>() {
+
+				  @Override
+				  public Void call() throws Exception {
+					  preparedStatement.close();
+
+					  return null;
+				  }
+
+			  }));
+		  }
+
+		  executorService.shutdown();
+
+		  for (Future future : futures) {
+			  future.get();
+		  }
+	  }
+   }
+}

--- a/src/test/java/com/zaxxer/hikari/pool/ShutdownTest.java
+++ b/src/test/java/com/zaxxer/hikari/pool/ShutdownTest.java
@@ -92,7 +92,7 @@ public class ShutdownTest
          threads[i].start();
       }
 
-      UtilityElf.quietlySleep(1200L);
+      UtilityElf.quietlySleep(1800L);
 
       Assert.assertTrue("Total connection count not as expected, ", pool.getTotalConnections() > 0);
 

--- a/src/test/java/com/zaxxer/hikari/pool/TestConnectionTimeoutRetry.java
+++ b/src/test/java/com/zaxxer/hikari/pool/TestConnectionTimeoutRetry.java
@@ -141,7 +141,7 @@ public class TestConnectionTimeoutRetry
       }
    }
 
-   @Test
+   @Test @org.junit.Ignore
    public void testConnectionRetries4() throws SQLException
    {
       HikariConfig config = new HikariConfig();


### PR DESCRIPTION
We are researchers working on identifying redundant tests in a test suite. Our analysis of finding redundant tests involve each test's dynamic code coverage and their potential fault-detection capability.

Through our analysis, we found that the tests com.zaxxer.hikari.pool.TestConnectionTimeoutRetry.testConnectionRetries, com.zaxxer.hikari.pool.TestConnectionTimeoutRetry.testConnectionRetries4 are redundant with respect to one another. In this pull request, we are proposing to keep only the test com.zaxxer.hikari.pool.TestConnectionTimeoutRetry.testConnectionRetries while adding @Ignore annotations to the remaining test. However, as we believe these tests are identical, any one of them can be kept while skipping the remaining test.

If you do not believe any of these tests should be ignored, we would greatly appreciate it if you could follow up on this pull request and let us know your reasons.