### PR TITLE
Removing test redundant for com.zaxxer.hikari.pool.TestConnectionTimeoutRetry.testConnectionRetries

### DIFF
--- a/src/test/java/com/zaxxer/hikari/pool/TestConnectionTimeoutRetry.java
+++ b/src/test/java/com/zaxxer/hikari/pool/TestConnectionTimeoutRetry.java
@@ -141,7 +141,7 @@ public class TestConnectionTimeoutRetry
       }
    }
 
-   @Test
+   @Test @org.junit.Ignore
    public void testConnectionRetries4() throws SQLException
    {
       HikariConfig config = new HikariConfig();


### PR DESCRIPTION
We are researchers working on identifying redundant tests in a test suite. Our analysis of finding redundant tests involve each test's dynamic code coverage and their potential fault-detection capability.

Through our analysis, we found that the tests com.zaxxer.hikari.pool.TestConnectionTimeoutRetry.testConnectionRetries, com.zaxxer.hikari.pool.TestConnectionTimeoutRetry.testConnectionRetries4 are redundant with respect to one another. In this pull request, we are proposing to keep only the test com.zaxxer.hikari.pool.TestConnectionTimeoutRetry.testConnectionRetries while adding @Ignore annotations to the remaining test. However, as we believe these tests are identical, any one of them can be kept while skipping the remaining test.

If you do not believe any of these tests should be ignored, we would greatly appreciate it if you could follow up on this pull request and let us know your reasons.