### PR TITLE
Fix raise-conditon with MySQL replication driver - set readOnly and autoCommit before setting timeouts for validation

### DIFF
--- a/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
+++ b/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
@@ -332,6 +332,10 @@ abstract class PoolBase
     */
    private void setupConnection(final Connection connection) throws SQLException
    {
+      checkDriverSupport(connection);
+      connection.setReadOnly(isReadOnly);
+      connection.setAutoCommit(isAutoCommit);
+
       if (networkTimeout == UNINITIALIZED) {
          networkTimeout = getAndSetNetworkTimeout(connection, validationTimeout);
       }
@@ -339,10 +343,6 @@ abstract class PoolBase
          setNetworkTimeout(connection, validationTimeout);
       }
 
-      checkDriverSupport(connection);
-
-      connection.setReadOnly(isReadOnly);
-      connection.setAutoCommit(isAutoCommit);
 
       if (transactionIsolation != defaultTransactionIsolation) {
          connection.setTransactionIsolation(transactionIsolation);


### PR DESCRIPTION
This is cause when using MySQL replication driver, the result when default is readOnly, the master connection keeps the validation timeout.