### PR TITLE
Read Only connection has nothing to do with transaction. it is just hint

### DIFF
--- a/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
+++ b/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
@@ -156,7 +156,7 @@ abstract class PoolBase
             statement.execute(config.getConnectionTestQuery());
          }
 
-         if (isIsolateInternalQueries && !isReadOnly && !isAutoCommit) {
+         if (isIsolateInternalQueries && !isAutoCommit) {
             connection.rollback();
          }
 
@@ -502,7 +502,7 @@ abstract class PoolBase
             statement.execute(sql);
          }
 
-         if (isIsolateInternalQueries && !isReadOnly && !isAutoCommit) {
+         if (isIsolateInternalQueries && !isAutoCommit) {
             if (isCommit) {
                connection.commit();
             }

--- a/src/main/java/com/zaxxer/hikari/pool/ProxyConnection.java
+++ b/src/main/java/com/zaxxer/hikari/pool/ProxyConnection.java
@@ -231,7 +231,7 @@ public abstract class ProxyConnection implements Connection
          leakTask.cancel();
 
          try {
-            if (isCommitStateDirty && !isAutoCommit && !isReadOnly) {
+            if (isCommitStateDirty && !isAutoCommit) {
                delegate.rollback();
                lastAccess = clockSource.currentTime();
                LOGGER.debug("{} - Executed rollback on connection {} due to dirty commit state on close().", poolEntry.getPoolName(), delegate);


### PR DESCRIPTION
Also isIsolateInternalQueries check must be removed (ignore parameter).
see https://docs.oracle.com/javase/7/docs/api/java/sql/Connection.html#setReadOnly(boolean)
and https://docs.oracle.com/javase/7/docs/api/java/sql/Connection.html#setAutoCommit(boolean)
Note: related issue # 674