### PR TITLE
mysql driver's bug on isValid()

### DIFF
--- a/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
+++ b/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
@@ -20,6 +20,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 import java.lang.management.ManagementFactory;
+import java.lang.reflect.Method;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.SQLTransientConnectionException;
@@ -84,6 +85,9 @@ abstract class PoolBase
    private final AtomicReference<Throwable> lastConnectionFailure;
 
    private volatile boolean isValidChecked;
+   private boolean isUsePingValidation;
+
+   private Method ping;
 
    PoolBase(final HikariConfig config)
    {
@@ -144,6 +148,10 @@ abstract class PoolBase
       try {
          try {
             if (isUseJdbc4Validation) {
+               if (isUsePingValidation) {
+                  return testConnectionAliveByPing(connection, (int) MILLISECONDS.toSeconds(Math.max(1000L, validationTimeout)));
+               }
+
                return connection.isValid((int) MILLISECONDS.toSeconds(Math.max(1000L, validationTimeout)));
             }
    
@@ -172,6 +180,16 @@ abstract class PoolBase
          LOGGER.warn("{} - Failed to validate connection {} ({})", poolName, connection, e.getMessage());
          return false;
       }
+   }
+
+   boolean testConnectionAliveByPing(Connection connection, int timeout) throws SQLException {
+      try {
+         this.ping.invoke(connection, new Object[] {Boolean.valueOf(true), timeout});
+      } catch (Exception e) {
+         return false;
+      }
+
+      return true;
    }
 
    Throwable getLastConnectionFailure()
@@ -323,7 +341,25 @@ abstract class PoolBase
          createNetworkTimeoutExecutor(dataSource, dsClassName, jdbcUrl);
       }
 
+      this.isUsePingValidation = shouldUsePingValidation(dataSource, dsClassName, jdbcUrl);
       this.dataSource = dataSource;
+   }
+
+   private boolean shouldUsePingValidation(final DataSource dataSource, final String dsClassName, final String jdbcUrl)
+   {
+      if ((dsClassName != null && dsClassName.contains("Mysql")) ||
+          (jdbcUrl != null && jdbcUrl.contains("mysql")) ||
+          (dataSource != null && dataSource.getClass().getName().contains("Mysql"))) {
+         try {
+            this.ping = UtilityElf.getMethod("com.mysql.jdbc.MySQLConnection", "pingInternal", new Class[] {Boolean.TYPE, Integer.TYPE});
+            return true;
+         }
+         catch (Exception e) {
+            // Ignore
+         }
+      }
+
+      return false;
    }
 
    /**

--- a/src/main/java/com/zaxxer/hikari/util/UtilityElf.java
+++ b/src/main/java/com/zaxxer/hikari/util/UtilityElf.java
@@ -20,6 +20,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.sql.Connection;
 import java.util.Locale;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -184,5 +185,34 @@ public final class UtilityElf
          thread.setDaemon(daemon);
          return thread;
       }
+   }
+
+   public static Class<?> loadClass(String className) {
+      Class clazz = null;
+
+      if (className == null) {
+         return null;
+      }
+
+      try {
+         return Class.forName(className);
+      } catch (ClassNotFoundException e) {
+         ClassLoader ctxClassLoader = Thread.currentThread().getContextClassLoader();
+
+         if (ctxClassLoader != null) {
+            try {
+               clazz = ctxClassLoader.loadClass(className);
+            } catch (ClassNotFoundException ex) {
+            }
+         }
+      }
+
+      return clazz;
+   }
+
+   public static Method getMethod(String className, String methodName, Class[] classes) throws Exception {
+      Class<?> clazz = loadClass(className);
+
+      return clazz.getMethod(methodName, classes);
    }
 }


### PR DESCRIPTION
Hi, if we use mysql driver, in some condition, there will exist huge of "MySQL Statement Cancellation Timer" threads.
How to reproduce:
1. get a connection and execute statement.setQueryTimeout(xxx) to make sure cancelTimmer will start.
2. make sure that server has closed the connection.
3. use isValid() to check whether a connection is alive or not
4. mysql JDBC4Connection call pingInternal(), if failed, will do abortInternal(), and in this method, it will set isClosed true.
5. when close this connection, ConnectionImpl will call realClose(), but if isClosed == true, it will return and cancelTimer is not cancelled.

I do something to fix this bug. When we find datasoure or jdbcURL or dsclassname contains "mysql", we will directly use pingInternal().
pingInternal() is a void method, it throw exception rather than return false, so we catch this exception and do nothing except return false.
(Mysql isValid() catch this exception and set isClosed true. Further details see #JDBC4Connection.isValid(int timeout)). 

All the tests still pass.

# refs : https://bugs.mysql.com/bug.php?id=82500