### PR TITLE
Programmatically connection initializer

### DIFF
--- a/src/main/java/com/zaxxer/hikari/HikariConfig.java
+++ b/src/main/java/com/zaxxer/hikari/HikariConfig.java
@@ -22,11 +22,13 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.sql.Connection;
 import java.util.Properties;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadFactory;
+import java.util.function.Consumer;
 
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
@@ -94,6 +96,7 @@ public class HikariConfig implements HikariConfigMXBean
    private Object metricRegistry;
    private Object healthCheckRegistry;
    private Properties healthCheckProperties;
+   private Consumer<Connection> connectionInitializer;
 
    /**
     * Default constructor
@@ -904,4 +907,15 @@ public class HikariConfig implements HikariConfigMXBean
          }
       }
    }
+
+   public Consumer<Connection> getConnectionInitializer()
+   {
+      return connectionInitializer;
+   }
+
+   public void setConnectionInitializer(Consumer<Connection> connectionInitializer)
+   {
+      this.connectionInitializer = connectionInitializer;
+   }
+
 }

--- a/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
+++ b/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
@@ -30,6 +30,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
@@ -146,14 +147,14 @@ abstract class PoolBase
             if (isUseJdbc4Validation) {
                return connection.isValid((int) MILLISECONDS.toSeconds(Math.max(1000L, validationTimeout)));
             }
-   
+
             setNetworkTimeout(connection, validationTimeout);
-   
+
             try (Statement statement = connection.createStatement()) {
                if (isNetworkTimeoutSupported != TRUE) {
                   setQueryTimeout(statement, (int) MILLISECONDS.toSeconds(Math.max(1000L, validationTimeout)));
                }
-   
+
                statement.execute(config.getConnectionTestQuery());
             }
          }
@@ -241,7 +242,7 @@ abstract class PoolBase
    /**
     * Register MBeans for HikariConfig and HikariPool.
     *
-    * @param pool a HikariPool instance
+    * @param hikariPool a HikariPool instance
     */
    void registerMBeans(final HikariPool hikariPool)
    {
@@ -298,7 +299,6 @@ abstract class PoolBase
    /**
     * Create/initialize the underlying DataSource.
     *
-    * @return a DataSource instance
     */
    private void initializeDataSource()
    {
@@ -383,6 +383,11 @@ abstract class PoolBase
       }
 
       executeSql(connection, config.getConnectionInitSql(), true);
+
+      Consumer<Connection> connectionInitializer = config.getConnectionInitializer();
+      if (connectionInitializer != null) {
+         connectionInitializer.accept(connection);
+      }
 
       setNetworkTimeout(connection, networkTimeout);
    }
@@ -635,7 +640,7 @@ abstract class PoolBase
 
       /**
        * @param poolEntry
-       * @param now
+       * @param startTime
        */
       void recordBorrowStats(final PoolEntry poolEntry, final long startTime)
       {


### PR DESCRIPTION
I use JDBC feature for SQL types in Oracle 11g. So, I need to register mappings (typeName -> JavaClass) for every connection once. My use-case:
```
HikariConfig hikariConfig = new HikariConfig();
...
hikariConfig.setConnectionInitializer(connection -> {
    try {
        Map<String, Class<?>> typeMap = connection.getTypeMap();
        for (Class<?> classToRegister : findOracleTypeClasses()) {
            if (SQLData.class.isAssignableFrom(classToRegister)) {
                try {
                    SQLData sqlData = (SQLData) classToRegister.newInstance();
                    String sqlTypeName = sqlData.getSQLTypeName();
                    typeMap.put(sqlTypeName, classToRegister);
                    log.info("SQLType ({}) registered as {}", sqlTypeName, classToRegister);
                } catch (ReflectiveOperationException e) {
                    throw new ConnectionInitializationException("Persistent " + classToRegister + " doesn't have default constructor", e);
                } catch (SQLException e) {
                    throw new ConnectionInitializationException("Getting SQLTypeName of persistent " + classToRegister + " failed", e);
                }
            }
        }
    } catch (SQLException e) {
        log.error("Couldn't initialize connection", e);
        throw new ConnectionInitializationException(e);
    }
});
```