### PR TITLE
Change what character is used for microseconds

### DIFF
--- a/src/main/java/com/zaxxer/hikari/util/ClockSource.java
+++ b/src/main/java/com/zaxxer/hikari/util/ClockSource.java
@@ -125,7 +125,7 @@ public interface ClockSource
 
    TimeUnit[] TIMEUNITS_DESCENDING = {DAYS, HOURS, MINUTES, SECONDS, MILLISECONDS, MICROSECONDS, NANOSECONDS};
 
-   String[] TIMEUNIT_DISPLAY_VALUES = {"ns", "μs", "ms", "s", "m", "h", "d"};
+   String[] TIMEUNIT_DISPLAY_VALUES = {"ns", "µs", "ms", "s", "m", "h", "d"};
 
    /**
     * Factory class used to create a platform-specific ClockSource.

--- a/src/test/java/com/zaxxer/hikari/util/ClockSourceTest.java
+++ b/src/test/java/com/zaxxer/hikari/util/ClockSourceTest.java
@@ -55,6 +55,6 @@ public class ClockSourceTest
 
       final long eTime3 = DAYS.toNanos(4) + HOURS.toNanos(19) + MINUTES.toNanos(55) + SECONDS.toNanos(23) + MILLISECONDS.toNanos(777) + MICROSECONDS.toNanos(0) + NANOSECONDS.toNanos(982);
       String ds3 = nsSource.elapsedDisplayString(sTime2, eTime3);
-      Assert.assertEquals("1d10h31m5s204ms676μs159ns", ds3);
+      Assert.assertEquals("1d10h31m5s204ms676µs159ns", ds3);
    }
 }


### PR DESCRIPTION
Currently, it uses GREEK SMALL LETTER MU (U+03BC), which doesn't display in the command prompt on Windows. After this commit, it uses MICRO SIGN (U+00B5).