### PR TITLE
Helpful clarification on .properties location

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,8 @@ ds.setPassword("51mp50n");
 ```
 or property file based:
 ```java
-HikariConfig config = new HikariConfig("some/path/hikari.properties");
+// Examines both filesystem and classpath for .properties file
+HikariConfig config = new HikariConfig("/some/path/hikari.properties");
 HikariDataSource ds = new HikariDataSource(config);
 ```
 Example property file:


### PR DESCRIPTION
The leading slash (which causes the search to start at the root of the classpath) is essential in most cases-rarely would db config be bundled alongside the class of interest in the package structure--I think this clarification in the example will help novices to HikariCP (like me).