### PR TITLE
Unwrap chained exceptions.

### DIFF
--- a/src/main/java/com/zaxxer/hikari/pool/ProxyConnection.java
+++ b/src/main/java/com/zaxxer/hikari/pool/ProxyConnection.java
@@ -160,7 +160,7 @@ public abstract class ProxyConnection implements Connection
             delegate = ClosedConnection.CLOSED_CONNECTION;
          }
 
-         nse = sqle.getNextException();
+         nse = nse.getNextException();
       }
 
       return sqle;


### PR DESCRIPTION
Calling sqle.getNextException() will return the same exception as sqle is never reassigned in the loop. 