### PR TITLE
Enable to create HikariConfig from Map properties

### DIFF
--- a/src/main/java/com/zaxxer/hikari/HikariConfig.java
+++ b/src/main/java/com/zaxxer/hikari/HikariConfig.java
@@ -16,6 +16,10 @@
 
 package com.zaxxer.hikari;
 
+import static com.zaxxer.hikari.util.UtilityElf.getNullIfEmpty;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -40,11 +44,6 @@ import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.health.HealthCheckRegistry;
 import com.zaxxer.hikari.metrics.MetricsTrackerFactory;
 import com.zaxxer.hikari.util.PropertyElf;
-
-import static java.util.concurrent.TimeUnit.MINUTES;
-import static java.util.concurrent.TimeUnit.SECONDS;
-
-import static com.zaxxer.hikari.util.UtilityElf.getNullIfEmpty;
 
 public class HikariConfig implements HikariConfigMXBean
 {
@@ -118,6 +117,16 @@ public class HikariConfig implements HikariConfigMXBean
       if (systemProp != null) {
          loadProperties(systemProp);
       }
+   }
+
+   /**
+    * Construct a HikariConfig from the specified properties object.
+    *
+    * @param properties the name of the property file
+    */
+   public HikariConfig(Properties properties)
+   {
+      this((Map<?, ?>) properties);
    }
 
    /**

--- a/src/main/java/com/zaxxer/hikari/HikariConfig.java
+++ b/src/main/java/com/zaxxer/hikari/HikariConfig.java
@@ -16,10 +16,6 @@
 
 package com.zaxxer.hikari;
 
-import static com.zaxxer.hikari.util.UtilityElf.getNullIfEmpty;
-import static java.util.concurrent.TimeUnit.MINUTES;
-import static java.util.concurrent.TimeUnit.SECONDS;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -44,6 +40,11 @@ import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.health.HealthCheckRegistry;
 import com.zaxxer.hikari.metrics.MetricsTrackerFactory;
 import com.zaxxer.hikari.util.PropertyElf;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import static com.zaxxer.hikari.util.UtilityElf.getNullIfEmpty;
 
 public class HikariConfig implements HikariConfigMXBean
 {

--- a/src/main/java/com/zaxxer/hikari/HikariConfig.java
+++ b/src/main/java/com/zaxxer/hikari/HikariConfig.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.TreeSet;
@@ -121,10 +122,8 @@ public class HikariConfig implements HikariConfigMXBean
 
    /**
     * Construct a HikariConfig from the specified properties object.
-    *
-    * @param properties the name of the property file
     */
-   public HikariConfig(Properties properties)
+   public HikariConfig(Map<?, ?> properties)
    {
       this();
       PropertyElf.setTargetFromProperties(this, properties);

--- a/src/main/java/com/zaxxer/hikari/util/PropertyElf.java
+++ b/src/main/java/com/zaxxer/hikari/util/PropertyElf.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -42,7 +43,7 @@ public final class PropertyElf
 
    private static final Pattern GETTER_PATTERN = Pattern.compile("(get|is)[A-Z].+");
 
-   public static void setTargetFromProperties(final Object target, final Properties properties)
+   public static void setTargetFromProperties(final Object target, final Map<?, ?> properties)
    {
       if (target == null || properties == null) {
          return;

--- a/src/main/java/com/zaxxer/hikari/util/PropertyElf.java
+++ b/src/main/java/com/zaxxer/hikari/util/PropertyElf.java
@@ -43,6 +43,10 @@ public final class PropertyElf
 
    private static final Pattern GETTER_PATTERN = Pattern.compile("(get|is)[A-Z].+");
 
+   public static void setTargetFromProperties(final Object target, final Properties properties) {
+      setTargetFromProperties(target, (Map<?, ?>) properties);
+   }
+
    public static void setTargetFromProperties(final Object target, final Map<?, ?> properties)
    {
       if (target == null || properties == null) {


### PR DESCRIPTION
A small enhancement for the `HikariConfig` API: since the `Properties` class already implements `Map<Object, Object>`, there is almost nothing to change.