### PR TITLE
Cancel HouseKeeper task on pool shutdown

### DIFF
--- a/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
+++ b/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadLocalRandom;
@@ -88,6 +89,7 @@ public class HikariPool extends PoolBase implements HikariPoolMXBean, IBagStateL
    private final SuspendResumeLock suspendResumeLock;
 
    private MetricsTrackerDelegate metricsTracker;
+   private ScheduledFuture<?> houseKeeperTask;
 
    /**
     * Construct a HikariPool with the specified configuration.
@@ -131,7 +133,7 @@ public class HikariPool extends PoolBase implements HikariPoolMXBean, IBagStateL
 
       this.leakTask = new ProxyLeakTask(config.getLeakDetectionThreshold(), houseKeepingExecutorService);
 
-      this.houseKeepingExecutorService.scheduleWithFixedDelay(new HouseKeeper(), 100L, HOUSEKEEPING_PERIOD_MS, MILLISECONDS);
+      this.houseKeeperTask = this.houseKeepingExecutorService.scheduleWithFixedDelay(new HouseKeeper(), 100L, HOUSEKEEPING_PERIOD_MS, MILLISECONDS);
    }
 
    /**
@@ -203,6 +205,11 @@ public class HikariPool extends PoolBase implements HikariPoolMXBean, IBagStateL
 
          LOGGER.info("{} - Close initiated...", poolName);
          logPoolState("Before closing ");
+
+         if (houseKeeperTask != null) {
+            houseKeeperTask.cancel(false);
+            houseKeeperTask = null;
+         }
 
          softEvictConnections();
 

--- a/src/test/java/com/zaxxer/hikari/pool/HouseKeeperCleanupTest.java
+++ b/src/test/java/com/zaxxer/hikari/pool/HouseKeeperCleanupTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2013, 2014 Brett Wooldridge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package com.zaxxer.hikari.pool;
+
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import com.zaxxer.hikari.util.UtilityElf;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Martin Stříž (striz@raynet.cz)
+ */
+public class HouseKeeperCleanupTest
+{
+
+   private ScheduledThreadPoolExecutor executor;
+
+   @Before
+   public void before() throws Exception
+   {
+      ThreadFactory threadFactory = new UtilityElf.DefaultThreadFactory("global housekeeper", true);
+
+      executor = new ScheduledThreadPoolExecutor(1, threadFactory, new ThreadPoolExecutor.DiscardPolicy());
+      executor.setExecuteExistingDelayedTasksAfterShutdownPolicy(false);
+      executor.setRemoveOnCancelPolicy(true);
+   }
+
+   @Test
+   public void testHouseKeeperCleanupWithCustomExecutor() throws Exception
+   {
+      HikariConfig config = new HikariConfig();
+      config.setMinimumIdle(0);
+      config.setMaximumPoolSize(10);
+      config.setInitializationFailFast(false);
+      config.setConnectionTimeout(2500);
+      config.setDataSourceClassName("com.zaxxer.hikari.mocks.StubDataSource");
+      config.setScheduledExecutorService(executor);
+
+      HikariConfig config2 = new HikariConfig();
+      config.copyState(config2);
+
+      try (
+         final HikariDataSource ds1 = new HikariDataSource(config);
+         final HikariDataSource ds2 = new HikariDataSource(config2)
+      ) {
+         Assert.assertEquals("Scheduled tasks count not as expected, ", 2, executor.getQueue().size());
+      }
+
+      Assert.assertEquals("Scheduled tasks count not as expected, ", 0, executor.getQueue().size());
+   }
+
+   @After
+   public void after() throws Exception
+   {
+      executor.shutdown();
+      executor.awaitTermination(5, TimeUnit.SECONDS);
+   }
+
+}


### PR DESCRIPTION
Periodic house-keeping task is scheduled during construction of
HikariPool. The resulting scheduled task is not stored and therefore it
is not cancelled during pool shutdown.

With standard behaviour, when executor is managed by HikariPool itself,
it is not an issue, because the executor is shut down on pool shutdown.
But when a custom (long running) scheduled executor is supplied via
setScheduledExecutorService, tasks are kept indefinitely causing a
memory leak.