### PR TITLE
Avoid creating too many connections in bursty workloads 

### DIFF
--- a/src/main/java/com/zaxxer/hikari/util/ConcurrentBag.java
+++ b/src/main/java/com/zaxxer/hikari/util/ConcurrentBag.java
@@ -316,7 +316,7 @@ public class ConcurrentBag<T extends IConcurrentBagEntry> implements AutoCloseab
     */
    public int getPendingQueue()
    {
-      return synchronizer.getQueueLength();
+      return waiters.get();
    }
 
    /**

--- a/src/test/java/com/zaxxer/hikari/mocks/StubDataSource.java
+++ b/src/test/java/com/zaxxer/hikari/mocks/StubDataSource.java
@@ -16,6 +16,8 @@
 
 package com.zaxxer.hikari.mocks;
 
+import com.zaxxer.hikari.util.UtilityElf;
+
 import java.io.PrintWriter;
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -34,6 +36,7 @@ public class StubDataSource implements DataSource
    private String password;
    private PrintWriter logWriter;
    private SQLException throwException;
+   private int connectionAcquistionTime = 0;
    private int loginTimeout;
 
    public String getUser()
@@ -121,6 +124,9 @@ public class StubDataSource implements DataSource
       if (throwException != null) {
          throw throwException;
       }
+      if (connectionAcquistionTime > 0) {
+         UtilityElf.quietlySleep(connectionAcquistionTime);
+      }
 
       return new StubConnection();
    }
@@ -135,5 +141,9 @@ public class StubDataSource implements DataSource
    public void setThrowException(SQLException e)
    {
       this.throwException = e;
+   }
+
+   public void setConnectionAcquistionTime(int connectionAcquisitionTime) {
+      this.connectionAcquistionTime = connectionAcquisitionTime;
    }
 }

--- a/src/test/java/com/zaxxer/hikari/pool/ConnectionPoolSizeVsThreadsTest.java
+++ b/src/test/java/com/zaxxer/hikari/pool/ConnectionPoolSizeVsThreadsTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (C) 2013, 2014 Brett Wooldridge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package com.zaxxer.hikari.pool;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import com.zaxxer.hikari.mocks.StubDataSource;
+import org.junit.Assert;
+import org.junit.Test;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * @author Matthew Tambara (matthew.tambara@liferay.com)
+ */
+public class ConnectionPoolSizeVsThreadsTest {
+
+   public static final int ITERATIONS = 50_000;
+
+   @Test
+   public void testPoolSizeAboutSameSizeAsThreadCount() throws Exception {
+      {
+         final int threadCount = 50;
+         final Counts counts = testPoolSize(2, 100, threadCount, 1, 0, 20);
+         Assert.assertEquals(threadCount, counts.getTotal(), 2);
+      }
+//      {
+//         final int threadCount = 2;
+//         final Counts counts = testPoolSize(2, 100, threadCount, 1, 0, 20);
+//         Assert.assertEquals(threadCount, counts.getTotal());
+//      }
+   }
+
+   private Counts testPoolSize(int minIdle, int maxPoolSize, int threadCount, final int workTime, final int restTime, int connectionAcquisitionTime) throws Exception {
+      HikariConfig config = new HikariConfig();
+      config.setMinimumIdle(minIdle);
+      config.setMaximumPoolSize(maxPoolSize);
+      config.setInitializationFailTimeout(Long.MAX_VALUE);
+      config.setConnectionTimeout(2500);
+      config.setDataSourceClassName("com.zaxxer.hikari.mocks.StubDataSource");
+
+      final AtomicReference<Exception> ref = new AtomicReference<>(null);
+
+      // Initialize HikariPool with no initial connections and room to grow
+      try (final HikariDataSource ds = new HikariDataSource(config)) {
+         final StubDataSource stubDataSource = ds.unwrap(StubDataSource.class);
+         // connection acquisition takes more than 0 ms in a real system
+         stubDataSource.setConnectionAcquistionTime(connectionAcquisitionTime);
+
+         ExecutorService threadPool = Executors.newFixedThreadPool(threadCount);
+         final int iterationCount = ITERATIONS;
+         final CountDownLatch allThreadsDone = new CountDownLatch(iterationCount);
+         for (int i = 0; i < iterationCount; i++) {
+            threadPool.submit(new Callable<Exception>() {
+               /** {@inheritDoc} */
+               @Override
+               public Exception call() throws Exception {
+                  if (ref.get() == null) {
+                     Connection c2;
+                     try {
+                        if(restTime > 0) {
+                           Thread.sleep(restTime);
+                        }
+                        c2 = ds.getConnection();
+                        if(workTime > 0) {
+                           Thread.sleep(workTime);
+                        }
+                        c2.close();
+                     } catch (Exception e) {
+                        ref.set(e);
+                     }
+                  }
+                  allThreadsDone.countDown();
+                  return null;
+               }
+            });
+         }
+
+         HikariPool pool = TestElf.getPool(ds);
+
+         int maxTotal = pool.getTotalConnections();
+         int maxActive = pool.getActiveConnections();
+         while (allThreadsDone.getCount() > 0) {
+            Thread.sleep(100);
+            maxTotal = Math.max(pool.getTotalConnections(), maxTotal);
+            maxActive = Math.max(pool.getActiveConnections(), maxActive);
+         }
+
+         allThreadsDone.await();
+
+         threadPool.shutdown();
+         threadPool.awaitTermination(30, TimeUnit.SECONDS);
+
+         if (ref.get() != null) {
+            LoggerFactory.getLogger(ConnectionPoolSizeVsThreadsTest.class).error("Task failed", ref.get());
+            Assert.fail("Task failed");
+         }
+
+         return new Counts(maxTotal, maxActive);
+      }
+   }
+
+   private static class Counts {
+      private final int total;
+      private final int active;
+
+      public Counts(int total, int max) {
+         this.total = total;
+         this.active = max;
+      }
+
+      public int getTotal() {
+         return total;
+      }
+
+      public int getActive() {
+         return active;
+      }
+   }
+}

--- a/src/test/java/com/zaxxer/hikari/pool/ConnectionRaceConditionTest.java
+++ b/src/test/java/com/zaxxer/hikari/pool/ConnectionRaceConditionTest.java
@@ -38,6 +38,9 @@ import com.zaxxer.hikari.util.ConcurrentBag;
  */
 public class ConnectionRaceConditionTest
 {
+
+   public static final int ITERATIONS = 10_000;
+
    @Test
    public void testRaceCondition() throws Exception
    {
@@ -55,13 +58,13 @@ public class ConnectionRaceConditionTest
       // Initialize HikariPool with no initial connections and room to grow
       try (final HikariDataSource ds = new HikariDataSource(config)) {
          ExecutorService threadPool = Executors.newFixedThreadPool(2);
-         for (int i = 0; i < 500_000; i++) {
+         for (int i = 0; i < ITERATIONS; i++) {
             threadPool.submit(new Callable<Exception>() {
                /** {@inheritDoc} */
                @Override
                public Exception call() throws Exception
                {
-                  if (ref.get() != null) {
+                  if (ref.get() == null) {
                      Connection c2;
                      try {
                         c2 = ds.getConnection();

--- a/src/test/java/com/zaxxer/hikari/pool/RampUpDown.java
+++ b/src/test/java/com/zaxxer/hikari/pool/RampUpDown.java
@@ -44,6 +44,9 @@ public class RampUpDown
            ds.setIdleTimeout(1000);
            HikariPool pool = TestElf.getPool(ds);
 
+           // wait two housekeeping periods so we don't fail if this part of test runs too quickly
+           Thread.sleep(500);
+
            Assert.assertSame("Total connections not as expected", 5, pool.getTotalConnections());
 
            Connection[] connections = new Connection[ds.getMaximumPoolSize()];


### PR DESCRIPTION
See Issue #774 for backstory. Turns out in a bursty mode where the actual work being done is short it is pretty easy to hit maxPoolSize connections. Once connections are made they are quickly cycled through so they don't appear to age out and the pool will stay at max size while there is a consistent set of work to be done.

See javadoc in middle of PoolEntryCreator for in-depth description of fix. 

Notes
- RaceCondition test was accidently disabled, didn't actually use the pool and had no assertions to check that it was doing anything
- RampUp test was racy and would fail if unlucky
- Main change ended up being pretty simple but I can't 100% convince myself that it is perfect. I agree it is better to make more connections than too few.
- Last commit to switch getPendingQueue() to use the atomic.get() is optional but I think it is more accurate because in a heavily trafficed pool all of the threads are waking up and checking all of the objects (only to be disappointed) most of the time