### PR TITLE
Change ScheduledThreadPoolExecutor to ScheduledExecutorService

### DIFF
--- a/src/main/java/com/zaxxer/hikari/HikariConfig.java
+++ b/src/main/java/com/zaxxer/hikari/HikariConfig.java
@@ -25,7 +25,7 @@ import java.lang.reflect.Modifier;
 import java.util.Properties;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 
 import javax.naming.InitialContext;
@@ -90,7 +90,7 @@ public class HikariConfig implements HikariConfigMXBean
    private DataSource dataSource;
    private Properties dataSourceProperties;
    private ThreadFactory threadFactory;
-   private ScheduledThreadPoolExecutor scheduledExecutor;
+   private ScheduledExecutorService scheduledExecutor;
    private MetricsTrackerFactory metricsTrackerFactory;
    private Object metricRegistry;
    private Object healthCheckRegistry;
@@ -718,7 +718,7 @@ public class HikariConfig implements HikariConfigMXBean
     *
     * @return the executor
     */
-   public ScheduledThreadPoolExecutor getScheduledExecutorService()
+   public ScheduledExecutorService getScheduledExecutorService()
    {
       return scheduledExecutor;
    }
@@ -728,7 +728,7 @@ public class HikariConfig implements HikariConfigMXBean
     *
     * @param executor the ScheduledExecutorService
     */
-   public void setScheduledExecutorService(ScheduledThreadPoolExecutor executor)
+   public void setScheduledExecutorService(ScheduledExecutorService executor)
    {
       this.scheduledExecutor = executor;
    }

--- a/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
+++ b/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
@@ -37,6 +37,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadFactory;
@@ -91,7 +92,7 @@ public class HikariPool extends PoolBase implements HikariPoolMXBean, IBagStateL
    private final ProxyLeakTask leakTask;
    private final SuspendResumeLock suspendResumeLock;
 
-   private ScheduledThreadPoolExecutor houseKeepingExecutorService;
+   private ScheduledExecutorService houseKeepingExecutorService;
    private ScheduledFuture<?> houseKeeperTask;
 
    /**
@@ -549,9 +550,10 @@ public class HikariPool extends PoolBase implements HikariPoolMXBean, IBagStateL
       if (config.getScheduledExecutorService() == null) {
          ThreadFactory threadFactory = config.getThreadFactory();
          threadFactory = threadFactory != null ? threadFactory : new DefaultThreadFactory(poolName + " housekeeper", true);
-         this.houseKeepingExecutorService = new ScheduledThreadPoolExecutor(1, threadFactory, new ThreadPoolExecutor.DiscardPolicy());
-         this.houseKeepingExecutorService.setExecuteExistingDelayedTasksAfterShutdownPolicy(false);
-         this.houseKeepingExecutorService.setRemoveOnCancelPolicy(true);
+         ScheduledThreadPoolExecutor newScheduledThreadPoolExecutor = new ScheduledThreadPoolExecutor(1, threadFactory, new ThreadPoolExecutor.DiscardPolicy());
+         newScheduledThreadPoolExecutor.setExecuteExistingDelayedTasksAfterShutdownPolicy(false);
+         newScheduledThreadPoolExecutor.setRemoveOnCancelPolicy(true);
+         this.houseKeepingExecutorService = newScheduledThreadPoolExecutor;
       }
       else {
          this.houseKeepingExecutorService = config.getScheduledExecutorService();


### PR DESCRIPTION
This change is fully backwards compatible.

Using the interface allows support for many more types of executors. This is needed for wrapping, extending, instrumenting, etc. a `ScheduledExecutorService`.