### PR TITLE
Performance improvement for constrained cases threads > pool size

### DIFF
--- a/src/main/java/com/zaxxer/hikari/pool/PoolEntry.java
+++ b/src/main/java/com/zaxxer/hikari/pool/PoolEntry.java
@@ -44,7 +44,11 @@ final class PoolEntry implements IConcurrentBagEntry
    Connection connection;
    long lastAccessed;
    long lastBorrowed;
+
+   //should be used with -XX:-RestrictContended JVM arg
+   @sun.misc.Contended
    private volatile int state;
+
    private volatile boolean evict;
 
    private volatile ScheduledFuture<?> endOfLife;


### PR DESCRIPTION
Performance improvement for constrained cases when number of threads much more than pool size.

ConcurrentBag will not signal another waiter after free resource if another thread already has stolen it.
This reduce context switches but make pool a little bit more unfair.

Added   @sun.misc.Contended for PoolEntry state. This reduse possible false sharing.

This changes increase performance of pool for 5-30%.

**Some benchmark results on Core i7 4 cores (8 with HT) with -XX:-RestrictContended JVM param and maxPoolSize = 8**

**_100 threads / maxPoolSize = 8_**

 _JMH 1.17.2 (released 23 days ago)
 VM version: JDK 1.8.0_92, VM 25.92-b14
 VM invoker: C:\Program Files\Java\jre1.8.0_92\bin\java.exe
 VM options: -server -XX:-RestrictContended -XX:+AggressiveOpts -XX:+UseFastAccessorMethods -Xms1096m -Xmx1096m
 Warmup: 3 iterations, 1 s each
 Measurement: 6 iterations, 1 s each
 Timeout: 10 min per iteration
 Threads: 100 threads, will synchronize iterations
 Benchmark mode: Throughput, ops/time
 Benchmark: com.zaxxer.hikari.benchmark.ConnectionBench.cycleCnnection
 Parameters: (jdbcUrl = jdbc:stub, maxPoolSize = 8, pool = hikari)_

2.5.2 version
 Run complete. Total time: 00:10:35
Benchmark                       (jdbcUrl)  (maxPoolSize)  (pool)   Mode  Cnt       Score      Error   Units
ConnectionBench.cycleCnnection  jdbc:stub              8  hikari  thrpt   48   20748,432 ▒ 1282,185  ops/ms
StatementBench.cycleStatement   jdbc:stub              8  hikari  thrpt   48  131634,185 ▒ 5463,157  ops/ms

**this new version**
 Run complete. Total time: 00:10:48
Benchmark                       (jdbcUrl)  (maxPoolSize)  (pool)   Mode  Cnt       Score      Error   Units
ConnectionBench.cycleCnnection  jdbc:stub              8  hikari  thrpt   48   **27079,295** ▒ **1077,770**  ops/ms
StatementBench.cycleStatement   jdbc:stub              8  hikari  thrpt   48  136371,239 ▒ 8264,813  ops/ms

**_64 threads / maxPoolSize = 8_**

2.5.2 version
 Run complete. Total time: 00:06:38

Benchmark                       (jdbcUrl)  (maxPoolSize)  (pool)   Mode  Cnt       Score      Error   Units
ConnectionBench.cycleCnnection  jdbc:stub              8  hikari  thrpt   48   20348,462 ▒ 1739,307  ops/ms
StatementBench.cycleStatement   jdbc:stub              8  hikari  thrpt   48  125352,538 ▒ 2392,916  ops/ms

**this new version**
 Run complete. Total time: 00:06:46

Benchmark                       (jdbcUrl)  (maxPoolSize)  (pool)   Mode  Cnt       Score      Error   Units
ConnectionBench.cycleCnnection  jdbc:stub              8  hikari  thrpt   48   **26591,769** ▒  **997,099**  ops/ms
StatementBench.cycleStatement   jdbc:stub              8  hikari  thrpt   48  132026,574 ▒ 3027,153  ops/ms