### PR TITLE
pool.Wait metric doesn't include timed out requests

### DIFF
--- a/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
+++ b/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
@@ -164,6 +164,7 @@ public final class HikariPool extends PoolBase implements HikariPoolMXBean, IBag
             do {
                poolEntry = connectionBag.borrow(timeout, MILLISECONDS);
                if (poolEntry == null) {
+                  metricsTracker.recordBorrowTimeoutStats(startTime);
                   break; // We timed out... break and throw exception
                }
 

--- a/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
+++ b/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
@@ -651,6 +651,8 @@ abstract class PoolBase
 
       default void recordConnectionCreated(long connectionCreatedMillis) {}
 
+      default void recordBorrowTimeoutStats(long startTime) {}
+
       default void recordBorrowStats(final PoolEntry poolEntry, final long startTime) {}
 
       default void recordConnectionTimeout() {}
@@ -683,6 +685,12 @@ abstract class PoolBase
       public void recordConnectionCreated(long connectionCreatedMillis)
       {
          tracker.recordConnectionCreatedMillis(connectionCreatedMillis);
+      }
+
+      @Override
+      public void recordBorrowTimeoutStats(long startTime)
+      {
+         tracker.recordConnectionAcquiredNanos(elapsedNanos(startTime));
       }
 
       @Override

--- a/src/test/java/com/zaxxer/hikari/metrics/prometheus/PrometheusMetricsTrackerTest.java
+++ b/src/test/java/com/zaxxer/hikari/metrics/prometheus/PrometheusMetricsTrackerTest.java
@@ -60,7 +60,7 @@ public class PrometheusMetricsTrackerTest {
          assertThat(CollectorRegistry.defaultRegistry.getSampleValue(
             "hikaricp_connection_acquired_nanos_count",
             labelNames,
-            labelValues), is(equalTo(2.0)));
+            labelValues), is(equalTo(3.0)));
          assertTrue(CollectorRegistry.defaultRegistry.getSampleValue(
             "hikaricp_connection_acquired_nanos_sum",
             labelNames,

--- a/src/test/java/com/zaxxer/hikari/pool/MetricsTrackerTest.java
+++ b/src/test/java/com/zaxxer/hikari/pool/MetricsTrackerTest.java
@@ -1,0 +1,86 @@
+package com.zaxxer.hikari.pool;
+
+import com.zaxxer.hikari.HikariDataSource;
+import com.zaxxer.hikari.metrics.IMetricsTracker;
+import com.zaxxer.hikari.mocks.StubDataSource;
+import org.junit.Test;
+
+import java.sql.Connection;
+import java.sql.SQLTransientConnectionException;
+import java.util.concurrent.TimeUnit;
+
+import static com.zaxxer.hikari.pool.TestElf.newHikariDataSource;
+import static junit.framework.TestCase.fail;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author wvuong@chariotsolutions.com on 2/16/17.
+ */
+public class MetricsTrackerTest
+{
+
+   @Test(expected = SQLTransientConnectionException.class)
+   public void connectionTimeoutIsRecorded() throws Exception
+   {
+      int timeoutMillis = 1000;
+      int timeToCreateNewConnectionMillis = timeoutMillis * 2;
+
+      StubDataSource stubDataSource = new StubDataSource();
+      stubDataSource.setConnectionAcquistionTime(timeToCreateNewConnectionMillis);
+
+      StubMetricsTracker metricsTracker = new StubMetricsTracker();
+
+      try (HikariDataSource ds = newHikariDataSource()) {
+         ds.setMinimumIdle(0);
+         ds.setMaximumPoolSize(1);
+         ds.setConnectionTimeout(timeoutMillis);
+         ds.setDataSource(stubDataSource);
+         ds.setMetricsTrackerFactory((poolName, poolStats) -> metricsTracker);
+
+         try (Connection c = ds.getConnection()) {
+            fail("Connection shouldn't have been successfully created due to configured connection timeout");
+
+         } finally {
+            // assert that connection timeout was measured
+            assertThat(metricsTracker.connectionTimeoutRecorded, is(true));
+            // assert that measured time to acquire connection should be roughly equal or greater than the configured connection timeout time
+            assertTrue(metricsTracker.connectionAcquiredNanos >= TimeUnit.NANOSECONDS.convert(timeoutMillis, TimeUnit.MILLISECONDS));
+         }
+      }
+   }
+
+   private static class StubMetricsTracker implements IMetricsTracker
+   {
+
+      private Long connectionCreatedMillis;
+      private Long connectionAcquiredNanos;
+      private Long connectionBorrowedMillis;
+      private boolean connectionTimeoutRecorded;
+
+      @Override
+      public void recordConnectionCreatedMillis(long connectionCreatedMillis)
+      {
+         this.connectionCreatedMillis = connectionCreatedMillis;
+      }
+
+      @Override
+      public void recordConnectionAcquiredNanos(long elapsedAcquiredNanos)
+      {
+         this.connectionAcquiredNanos = elapsedAcquiredNanos;
+      }
+
+      @Override
+      public void recordConnectionUsageMillis(long elapsedBorrowedMillis)
+      {
+         this.connectionBorrowedMillis = elapsedBorrowedMillis;
+      }
+
+      @Override
+      public void recordConnectionTimeout()
+      {
+         this.connectionTimeoutRecorded = true;
+      }
+   }
+}


### PR DESCRIPTION
We noticed that the pool.Wait metric only captured the timings for successful connection requests and doesn't capture when a connection request times out.

I didn't want to mess with IMetricsTrackerDelegate.recordBorrowStats() so I created recordBorrowTimeoutStats() and implementation in MetricsTrackerDelegate instead.  Feel free to tweak to your liking.