### PR TITLE
Better place to capture pool.Wait metric

### DIFF
--- a/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
+++ b/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
@@ -164,7 +164,6 @@ public final class HikariPool extends PoolBase implements HikariPoolMXBean, IBag
             do {
                poolEntry = connectionBag.borrow(timeout, MILLISECONDS);
                if (poolEntry == null) {
-                  metricsTracker.recordBorrowTimeoutStats(startTime);
                   break; // We timed out... break and throw exception
                }
 
@@ -178,6 +177,8 @@ public final class HikariPool extends PoolBase implements HikariPoolMXBean, IBag
                   return poolEntry.createProxyConnection(leakTask.schedule(poolEntry), now);
                }
             } while (timeout > 0L);
+
+            metricsTracker.recordBorrowTimeoutStats(startTime);
          }
          catch (InterruptedException e) {
             if (poolEntry != null) {


### PR DESCRIPTION
In retrospect on #825, this is a better place to capture the metric.  In #825, it would only capture the timing if the connection bag returned null but it would not capture the timing if the bag returned an entry and the connection then failed validation or was evicted.  Moving the statement to outside of the do/while will capture both scenarios.