### PR TITLE
Added support for non-default Prometheus CollectorRegistry

### DIFF
--- a/src/main/java/com/zaxxer/hikari/metrics/prometheus/PrometheusMetricsTracker.java
+++ b/src/main/java/com/zaxxer/hikari/metrics/prometheus/PrometheusMetricsTracker.java
@@ -34,17 +34,20 @@ class PrometheusMetricsTracker implements IMetricsTracker
    private final Summary eaSummary;
    private final Summary ebSummary;
    private final Summary ecSummary;
-   private final Collector collector;
 
-   PrometheusMetricsTracker(String poolName, Collector collector)
+   private final Collector collector;
+   private final CollectorRegistry registry;
+
+   PrometheusMetricsTracker(String poolName, Collector collector, CollectorRegistry registry)
    {
       this.collector = collector;
+      this.registry = registry;
 
       ctCounter = Counter.build()
          .name("hikaricp_connection_timeout_count")
          .labelNames("pool")
          .help("Connection timeout count")
-         .register();
+         .register(registry);
 
       this.connectionTimeoutCounter = ctCounter.labels(poolName);
 
@@ -52,32 +55,32 @@ class PrometheusMetricsTracker implements IMetricsTracker
          .name("hikaricp_connection_acquired_nanos")
          .labelNames("pool")
          .help("Connection acquired time (ns)")
-         .register();
+         .register(registry);
       this.elapsedAcquiredSummary = eaSummary.labels(poolName);
 
       ebSummary = Summary.build()
          .name("hikaricp_connection_usage_millis")
          .labelNames("pool")
          .help("Connection usage (ms)")
-         .register();
+         .register(registry);
       this.elapsedBorrowedSummary = ebSummary.labels(poolName);
 
       ecSummary = Summary.build()
             .name("hikaricp_connection_creation_millis")
             .labelNames("pool")
             .help("Connection creation (ms)")
-            .register();
+            .register(registry);
       this.elapsedCreationSummary = ecSummary.labels(poolName);
    }
 
    @Override
    public void close()
    {
-      CollectorRegistry.defaultRegistry.unregister(ctCounter);
-      CollectorRegistry.defaultRegistry.unregister(eaSummary);
-      CollectorRegistry.defaultRegistry.unregister(ebSummary);
-      CollectorRegistry.defaultRegistry.unregister(ecSummary);
-      CollectorRegistry.defaultRegistry.unregister(collector);
+      registry.unregister(ctCounter);
+      registry.unregister(eaSummary);
+      registry.unregister(ebSummary);
+      registry.unregister(ecSummary);
+      registry.unregister(collector);
    }
 
    @Override

--- a/src/main/java/com/zaxxer/hikari/metrics/prometheus/PrometheusMetricsTrackerFactory.java
+++ b/src/main/java/com/zaxxer/hikari/metrics/prometheus/PrometheusMetricsTrackerFactory.java
@@ -21,6 +21,7 @@ import com.zaxxer.hikari.metrics.MetricsTrackerFactory;
 import com.zaxxer.hikari.metrics.PoolStats;
 
 import io.prometheus.client.Collector;
+import io.prometheus.client.CollectorRegistry;
 
 /**
  * <pre>{@code
@@ -30,10 +31,21 @@ import io.prometheus.client.Collector;
  */
 public class PrometheusMetricsTrackerFactory implements MetricsTrackerFactory
 {
+
+   private final CollectorRegistry registry;
+
+   public PrometheusMetricsTrackerFactory() {
+     this(CollectorRegistry.defaultRegistry);
+   }
+
+   public PrometheusMetricsTrackerFactory(CollectorRegistry registry) {
+      this.registry = registry;
+   }
+
    @Override
    public IMetricsTracker create(String poolName, PoolStats poolStats)
    {
-      Collector collector = new HikariCPCollector(poolName, poolStats).register();
-      return new PrometheusMetricsTracker(poolName, collector);
+      Collector collector = new HikariCPCollector(poolName, poolStats).register(registry);
+      return new PrometheusMetricsTracker(poolName, collector, registry);
    }
 }

--- a/src/test/java/com/zaxxer/hikari/metrics/prometheus/HikariCPCollectorTest.java
+++ b/src/test/java/com/zaxxer/hikari/metrics/prometheus/HikariCPCollectorTest.java
@@ -19,17 +19,16 @@ package com.zaxxer.hikari.metrics.prometheus;
 import static com.zaxxer.hikari.pool.TestElf.newHikariConfig;
 import static com.zaxxer.hikari.util.UtilityElf.quietlySleep;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
-
-import java.sql.Connection;
-
-import org.junit.Test;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import com.zaxxer.hikari.mocks.StubConnection;
-
 import io.prometheus.client.CollectorRegistry;
+import org.junit.Test;
+
+import java.sql.Connection;
 
 public class HikariCPCollectorTest {
    @Test
@@ -117,10 +116,32 @@ public class HikariCPCollectorTest {
       }
    }
 
+   @Test
+   public void testThatProperRegistryIsUsed() {
+      HikariConfig config = newHikariConfig();
+      config.setMinimumIdle(0);
+      CollectorRegistry customRegistry = new CollectorRegistry();
+      config.setMetricsTrackerFactory(new PrometheusMetricsTrackerFactory(customRegistry));
+      config.setDataSourceClassName("com.zaxxer.hikari.mocks.StubDataSource");
+
+      StubConnection.slowCreate = true;
+      try (HikariDataSource ds = new HikariDataSource(config)) {
+         assertThat(getValue("hikaricp_active_connections", "noConnection", customRegistry), is(0.0));
+         assertThat(getValue("hikaricp_active_connections", "noConnection"), is(nullValue()));
+      }
+      finally {
+         StubConnection.slowCreate = false;
+      }
+   }
+
    private double getValue(String name, String poolName) {
+     return this.getValue(name, poolName, CollectorRegistry.defaultRegistry);
+   }
+
+   private double getValue(String name, String poolName, CollectorRegistry registry) {
       String[] labelNames = {"pool"};
       String[] labelValues = {poolName};
-      return CollectorRegistry.defaultRegistry.getSampleValue(name, labelNames, labelValues);
+      return registry.getSampleValue(name, labelNames, labelValues);
    }
 
 }

--- a/src/test/java/com/zaxxer/hikari/metrics/prometheus/HikariCPCollectorTest.java
+++ b/src/test/java/com/zaxxer/hikari/metrics/prometheus/HikariCPCollectorTest.java
@@ -117,7 +117,7 @@ public class HikariCPCollectorTest {
    }
 
    @Test
-   public void testThatProperRegistryIsUsed() {
+   public void checkRegistry() {
       HikariConfig config = newHikariConfig();
       config.setMinimumIdle(0);
       CollectorRegistry customRegistry = new CollectorRegistry();
@@ -126,19 +126,19 @@ public class HikariCPCollectorTest {
 
       StubConnection.slowCreate = true;
       try (HikariDataSource ds = new HikariDataSource(config)) {
-         assertThat(getValue("hikaricp_active_connections", "noConnection", customRegistry), is(0.0));
-         assertThat(getValue("hikaricp_active_connections", "noConnection"), is(nullValue()));
+         assertThat(getValue("hikaricp_active_connections", "checkRegistry", customRegistry), is(0.0));
+         assertThat(getValue("hikaricp_active_connections", "checkRegistry"), is(nullValue()));
       }
       finally {
          StubConnection.slowCreate = false;
       }
    }
 
-   private double getValue(String name, String poolName) {
+   private Double getValue(String name, String poolName) {
      return this.getValue(name, poolName, CollectorRegistry.defaultRegistry);
    }
 
-   private double getValue(String name, String poolName, CollectorRegistry registry) {
+   private Double getValue(String name, String poolName, CollectorRegistry registry) {
       String[] labelNames = {"pool"};
       String[] labelValues = {poolName};
       return registry.getSampleValue(name, labelNames, labelValues);


### PR DESCRIPTION
Hey.
This PR introduces a new constructor in `PrometheusMetricsTracker` and a constructor overload in `PrometheusMetricsTrackerFactory` to enable configuration of whatever Promethes `CollectorRegistry` one might want to use. It's completely backwards compatible and shouldn't affect any existing codebase relying on this.