### PR TITLE
Mask password in JDBC URL

### DIFF
--- a/src/main/java/com/zaxxer/hikari/HikariConfig.java
+++ b/src/main/java/com/zaxxer/hikari/HikariConfig.java
@@ -955,6 +955,9 @@ public class HikariConfig implements HikariConfigMXBean
             else if (prop.matches("scheduledExecutorService|threadFactory") && value == null) {
                value = "internal";
             }
+            else if (prop.contains("jdbcUrl") && value instanceof String) {
+               value = ((String)value).replaceAll("([?&;]password=)[^&#;]*(.*)", "$1<masked>$2");
+            }
             else if (prop.contains("password")) {
                value = "<masked>";
             }


### PR DESCRIPTION
I use HikariCP in my project and set JDBC URL with password property. I found the password in JDBC URL is not masked while directly set password is. I think it's good to mask it as well. Could you consider to merge this change?