### PR TITLE
Introduce factory for leak detection tasks

### DIFF
--- a/src/main/java/com/zaxxer/hikari/pool/ProxyLeakTaskFactory.java
+++ b/src/main/java/com/zaxxer/hikari/pool/ProxyLeakTaskFactory.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2013, 2014 Brett Wooldridge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.zaxxer.hikari.pool;
+
+import java.util.concurrent.ScheduledExecutorService;
+
+/**
+ * A factory for {@link ProxyLeakTask} Runnables that are scheduled in the future to report leaks.
+ *
+ * @author Brett Wooldridge
+ * @author Andreas Brenk
+ */
+class ProxyLeakTaskFactory
+{
+   private ScheduledExecutorService executorService;
+   private long leakDetectionThreshold;
+
+   ProxyLeakTaskFactory(final long leakDetectionThreshold, final ScheduledExecutorService executorService)
+   {
+      this.executorService = executorService;
+      this.leakDetectionThreshold = leakDetectionThreshold;
+   }
+
+   ProxyLeakTask schedule(final PoolEntry poolEntry)
+   {
+      return (leakDetectionThreshold == 0) ? ProxyLeakTask.NO_LEAK : scheduleNewTask(poolEntry);
+   }
+
+   void updateLeakDetectionThreshold(final long leakDetectionThreshold)
+   {
+      this.leakDetectionThreshold = leakDetectionThreshold;
+   }
+
+   private ProxyLeakTask scheduleNewTask(PoolEntry poolEntry) {
+      ProxyLeakTask task = new ProxyLeakTask(poolEntry);
+      task.schedule(executorService, leakDetectionThreshold);
+
+      return task;
+   }
+}


### PR DESCRIPTION
This change splits off a ProxyLeakTaskFactory from the ProxyLeakTask class
so that scheduling the task is done after its constructor completes. This
prevents publishing the tasks "this" reference during construction.

See ["Safe construction techniques" by Brian Goetz](https://www.ibm.com/developerworks/java/library/j-jtp0618/index.html).