### PR TITLE
Add configuration option to force closing a leaked connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,12 @@ message is logged indicating a possible connection leak.  A value of 0 means lea
 is disabled.  Lowest acceptable value for enabling leak detection is 2000 (2 seconds).
 *Default: 0*
 
+&#10062;``leakDetectionForceClose``<br/>
+This property controls if a connection should be forcibly closed after the leak detection threshold,
+i.e. the connection has been borrowed for too long. If the connection is unexpectedly used again
+you will get a ``SQLException``: "Already closed" or equivalent.
+*Default: false*
+
 &#10145;``dataSource``<br/>
 This property is only available via programmatic configuration or IoC container.  This property
 allows you to directly set the instance of the ``DataSource`` to be wrapped by the pool, rather than

--- a/src/main/java/com/zaxxer/hikari/HikariConfig.java
+++ b/src/main/java/com/zaxxer/hikari/HikariConfig.java
@@ -64,6 +64,7 @@ public class HikariConfig implements HikariConfigMXBean
    private volatile long validationTimeout;
    private volatile long idleTimeout;
    private volatile long leakDetectionThreshold;
+   private volatile boolean leakDetectionForceClose;
    private volatile long maxLifetime;
    private volatile int maxPoolSize;
    private volatile int minIdle;
@@ -646,6 +647,20 @@ public class HikariConfig implements HikariConfigMXBean
    public void setLeakDetectionThreshold(long leakDetectionThresholdMs)
    {
       this.leakDetectionThreshold = leakDetectionThresholdMs;
+   }
+
+
+   /** {@inheritDoc} */
+   @Override
+   public boolean getLeakDetectionForceClose()
+   {
+      return leakDetectionForceClose;
+   }
+
+   /** {@inheritDoc} */
+   @Override
+   public void setLeakDetectionForceClose(boolean leakDetectionForceClose) {
+      this.leakDetectionForceClose = leakDetectionForceClose;
    }
 
    /** {@inheritDoc} */

--- a/src/main/java/com/zaxxer/hikari/HikariConfigMXBean.java
+++ b/src/main/java/com/zaxxer/hikari/HikariConfigMXBean.java
@@ -94,6 +94,22 @@ public interface HikariConfigMXBean
    void setLeakDetectionThreshold(long leakDetectionThresholdMs);
 
    /**
+    * This property controls if a connection should be forcibly closed after the leak detection threshold, i.e. the
+    * connection has been borrowed for too long.
+    *
+    * @return if connections should be forcibly closed after the leak detection threshold
+    */
+   boolean getLeakDetectionForceClose();
+
+   /**
+    * This property controls if a connection should be forcibly closed after the leak detection threshold, i.e. the
+    * connection has been borrowed for too long.
+    *
+    * @param leakDetectionForceClose if connections should be forcibly closed after the leak detection threshold
+    */
+   void setLeakDetectionForceClose(boolean leakDetectionForceClose);
+
+   /**
     * This property controls the maximum lifetime of a connection in the pool. When a connection reaches this
     * timeout, even if recently used, it will be retired from the pool. An in-use connection will never be
     * retired, only when it is idle will it be removed.

--- a/src/main/java/com/zaxxer/hikari/pool/ProxyLeakTaskFactory.java
+++ b/src/main/java/com/zaxxer/hikari/pool/ProxyLeakTaskFactory.java
@@ -28,26 +28,29 @@ class ProxyLeakTaskFactory
 {
    private ScheduledExecutorService executorService;
    private long leakDetectionThreshold;
+   private boolean leakDetectionForceClose;
 
-   ProxyLeakTaskFactory(final long leakDetectionThreshold, final ScheduledExecutorService executorService)
+   ProxyLeakTaskFactory(final long leakDetectionThreshold, final boolean leakDetectionForceClose, final ScheduledExecutorService executorService)
    {
       this.executorService = executorService;
       this.leakDetectionThreshold = leakDetectionThreshold;
+      this.leakDetectionForceClose = leakDetectionForceClose;
    }
 
-   ProxyLeakTask schedule(final PoolEntry poolEntry)
+   ProxyLeakTask schedule(HikariPool pool, final PoolEntry poolEntry)
    {
-      return (leakDetectionThreshold == 0) ? ProxyLeakTask.NO_LEAK : scheduleNewTask(poolEntry);
+      return (leakDetectionThreshold == 0) ? ProxyLeakTask.NO_LEAK : scheduleNewTask(pool, poolEntry);
    }
 
-   void updateLeakDetectionThreshold(final long leakDetectionThreshold)
+   void updateLeakDetectionConfiguration(final long leakDetectionThreshold, final boolean leakDetectionForceClose)
    {
       this.leakDetectionThreshold = leakDetectionThreshold;
+      this.leakDetectionForceClose = leakDetectionForceClose;
    }
 
-   private ProxyLeakTask scheduleNewTask(PoolEntry poolEntry) {
-      ProxyLeakTask task = new ProxyLeakTask(poolEntry);
-      task.schedule(executorService, leakDetectionThreshold);
+   private ProxyLeakTask scheduleNewTask(HikariPool pool, PoolEntry poolEntry) {
+      ProxyLeakTask task = new ProxyLeakTask(pool, poolEntry);
+      task.schedule(executorService, leakDetectionThreshold, leakDetectionForceClose);
 
       return task;
    }


### PR DESCRIPTION
This change introduces a "leakDetectionForceClose" configuration property
to control if a connection should be forcibly closed after the leak
detection threshold.

This allows the pool to recover and makes it more robust.