### PR TITLE
Fixed ClassNotFoundException when com.codahale.metrics.MetricRegistry is not in the classpath

### DIFF
--- a/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
+++ b/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
@@ -272,10 +272,10 @@ public final class HikariPool extends PoolBase implements HikariPoolMXBean, IBag
 
    public void setMetricRegistry(Object metricRegistry)
    {
-      if (metricRegistry instanceof MetricRegistry) {
+      if (metricRegistry.getClass().getName().equals("com.codahale.metrics.MetricRegistry")) {
          setMetricsTrackerFactory(new CodahaleMetricsTrackerFactory((MetricRegistry) metricRegistry));
       }
-      else if (metricRegistry instanceof MeterRegistry) {
+      else if (metricRegistry.getClass().getName().equals("io.micrometer.core.instrument.MeterRegistry")) {
          setMetricsTrackerFactory(new MicrometerMetricsTrackerFactory((MeterRegistry) metricRegistry));
       }
       else {

--- a/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
+++ b/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
@@ -272,10 +272,10 @@ public final class HikariPool extends PoolBase implements HikariPoolMXBean, IBag
 
    public void setMetricRegistry(Object metricRegistry)
    {
-      if (metricRegistry.getClass().getName().equals("com.codahale.metrics.MetricRegistry")) {
+      if (metricRegistry.getClass().getName().contains("MetricRegistry")) {
          setMetricsTrackerFactory(new CodahaleMetricsTrackerFactory((MetricRegistry) metricRegistry));
       }
-      else if (metricRegistry.getClass().getName().equals("io.micrometer.core.instrument.MeterRegistry")) {
+      else if (metricRegistry.getClass().getName().contains("MeterRegistry")) {
          setMetricsTrackerFactory(new MicrometerMetricsTrackerFactory((MeterRegistry) metricRegistry));
       }
       else {


### PR DESCRIPTION
ClassNotFoundException is thrown during `DataSource#getConnection()` when `io.dropwizard.metrics:metrics-core`  is not available in the class path.