### PR TITLE
Removed some maturity wrinkles :)

### DIFF
--- a/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
+++ b/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
@@ -181,11 +181,9 @@ public final class HikariPool extends PoolBase implements HikariPoolMXBean, IBag
          } while (timeout > 0L);
 
          metricsTracker.recordBorrowTimeoutStats(startTime);
+         metricsTracker.recordConnectionTimeout();
       }
       catch (InterruptedException e) {
-         if (poolEntry != null) {
-            poolEntry.recycle(startTime);
-         }
          Thread.currentThread().interrupt();
          throw new SQLException(poolName + " - Interrupted during connection acquisition", e);
       }
@@ -596,7 +594,6 @@ public final class HikariPool extends PoolBase implements HikariPoolMXBean, IBag
    private SQLException createTimeoutException(long startTime)
    {
       logPoolState("Timeout failure ");
-      metricsTracker.recordConnectionTimeout();
 
       String sqlState = null;
       final Throwable originalException = getLastConnectionFailure();


### PR DESCRIPTION
1. isConnectionAlive() if connection is invalid/broken, avoid delay
caused by calls (and probably more exception) on connection to be
closed.
2. getConection() removed dead code. poolEntry is always null if
connectionBag.borrow() throws InterruptedException.
probably metricsTracker.recordBorrowTimeoutStats(startTime);
and      metricsTracker.recordConnectionTimeout() are same/ should be
one call?