### PR TITLE
test that FastList::clear() sets all elements to null

### DIFF
--- a/src/test/java/com/zaxxer/hikari/util/TestFastList.java
+++ b/src/test/java/com/zaxxer/hikari/util/TestFastList.java
@@ -124,6 +124,10 @@ public class TestFastList
        assertNotEquals(0, list.size());
        list.clear();
        assertEquals(0, list.size());
+       // also check that all elements are now null
+       for (int i = 0; i < 100; i++) {
+           assertEquals(null, list.get(i));
+       }
     }
 
     @Test


### PR DESCRIPTION
`com.zaxxer.hikari.util.FastList::clear()` sets the `size` variable to `0` and also sets all the elements in the `FastList` to `null`. However, `com.zaxxer.hikari.util.TestFastList::testClear()` only checks that `size` is `0`. This PR changes `testClear()` to also check that all elements in the list are set to `null` after calling `clear()`.