### PR TITLE
Log statement passing along wrong number of arguments

### DIFF
--- a/src/main/java/com/zaxxer/hikari/metrics/prometheus/PrometheusMetricsTracker.java
+++ b/src/main/java/com/zaxxer/hikari/metrics/prometheus/PrometheusMetricsTracker.java
@@ -17,11 +17,8 @@
 package com.zaxxer.hikari.metrics.prometheus;
 
 import com.zaxxer.hikari.metrics.IMetricsTracker;
-import io.prometheus.client.Collector;
-import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.Counter;
 import io.prometheus.client.Summary;
-import java.util.concurrent.TimeUnit;
 
 class PrometheusMetricsTracker implements IMetricsTracker
 {

--- a/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
+++ b/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
@@ -476,7 +476,7 @@ public final class HikariPool extends PoolBase implements HikariPoolMXBean, IBag
       }
       catch (Exception e) {
          if (poolState == POOL_NORMAL) { // we check POOL_NORMAL to avoid a flood of messages if shutdown() is running concurrently
-            LOGGER.debug("{} - Cannot acquire connection from data source", poolName, (e instanceof ConnectionSetupException ? e.getCause() : e));
+            LOGGER.debug(String.format("{%s - Cannot acquire connection from data source", poolName), (e instanceof ConnectionSetupException ? e.getCause() : e));
          }
          return null;
       }


### PR DESCRIPTION
Hello to all.

I was checking some of the source code and this error popped up in Intellij.

This log statements is passing along the wrong number of parameters.
When passing along a `Throwable` parameters, the calls from the LOGGER class only ever have 2 arguments: the already formatted String, and the Throwable. As can be seen in the source code of the LOGGER object.

I copied the permalinks from version 1.7.25:

The code that was actually being called: https://github.com/qos-ch/slf4j/blob/a81440ea36676f3b090f5a4ccba70d17c7b80f6e/slf4j-api/src/main/java/org/slf4j/Logger.java#L255

The code being called after this change: https://github.com/qos-ch/slf4j/blob/a81440ea36676f3b090f5a4ccba70d17c7b80f6e/slf4j-api/src/main/java/org/slf4j/Logger.java#L280

I used a String.format() to fix it, not sure if that's optimal.

Also, this one file had unused imports, removed them.