### PR TITLE
Enable quantiles calculation in prometheus metrics

### DIFF
--- a/src/main/java/com/zaxxer/hikari/metrics/prometheus/PrometheusMetricsTracker.java
+++ b/src/main/java/com/zaxxer/hikari/metrics/prometheus/PrometheusMetricsTracker.java
@@ -17,10 +17,9 @@
 package com.zaxxer.hikari.metrics.prometheus;
 
 import com.zaxxer.hikari.metrics.IMetricsTracker;
-import io.prometheus.client.Collector;
-import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.Counter;
 import io.prometheus.client.Summary;
+
 import java.util.concurrent.TimeUnit;
 
 class PrometheusMetricsTracker implements IMetricsTracker
@@ -30,23 +29,31 @@ class PrometheusMetricsTracker implements IMetricsTracker
       .labelNames("pool")
       .help("Connection timeout total count")
       .register();
-   private static final Summary ELAPSED_ACQUIRED_SUMMARY = Summary.build()
-      .name("hikaricp_connection_acquired_nanos")
-      .labelNames("pool")
-      .help("Connection acquired time (ns)")
-      .register();
-   private static final Summary ELAPSED_BORROWED_SUMMARY = Summary.build()
-      .name("hikaricp_connection_usage_millis")
-      .labelNames("pool")
-      .help("Connection usage (ms)")
-      .register();
-   private static final Summary ELAPSED_CREATION_SUMMARY = Summary.build()
-      .name("hikaricp_connection_creation_millis")
-      .labelNames("pool")
-      .help("Connection creation (ms)")
-      .register();
+
+   private static final Summary ELAPSED_ACQUIRED_SUMMARY =
+      registerSummary("hikaricp_connection_acquired_nanos", "Connection acquired time (ns)");
+
+   private static final Summary ELAPSED_BORROWED_SUMMARY =
+      registerSummary("hikaricp_connection_usage_millis", "Connection usage (ms)");
+
+   private static final Summary ELAPSED_CREATION_SUMMARY =
+      registerSummary("hikaricp_connection_creation_millis", "Connection creation (ms)");
 
    private final Counter.Child connectionTimeoutCounterChild;
+
+   private static Summary registerSummary(String name, String help) {
+      return Summary.build()
+         .name(name)
+         .labelNames("pool")
+         .help(help)
+         .quantile(0.5, 0.05)
+         .quantile(0.95, 0.01)
+         .quantile(0.99, 0.001)
+         .maxAgeSeconds(TimeUnit.MINUTES.toSeconds(5))
+         .ageBuckets(5)
+         .register();
+   }
+
    private final Summary.Child elapsedAcquiredSummaryChild;
    private final Summary.Child elapsedBorrowedSummaryChild;
    private final Summary.Child elapsedCreationSummaryChild;


### PR DESCRIPTION
The current configuration of [summary](https://prometheus.io/docs/concepts/metric_types/#summary) type prometheus metrics in `hikaricp` only provides two values:
- `count` of observations
- `sum` of observed values

for the following metrics:
- connection acquisition time
- connection usage time
- connection creation time

One can derive additional useful metrics based on just these two values:
- `avg` = `sum` / `count`
- `rate` = delta(`count`) / delta(`time`)
- sliding`avg` = delta(`sum`[5m]) / delta(`count`[5m])

Prometheus summaries also support calculation of quantiles that are more useful than averages during analyses. 
I propose to enable the following quantiles calculation in a 5 minute sliding window:
- `0.5` (median) with error of `0.05`
- `0.95` with error of `0.01`
- `0.99` with error of `0.001`

The quantile error values were chosen according to the [paper](https://www.cs.rutgers.edu/~muthu/bquant.pdf).
  