### PR TITLE
Fix init of HikariDataSource, if jdbcUrl was specified not though pro…

### DIFF
--- a/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
+++ b/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
@@ -325,8 +325,12 @@ abstract class PoolBase
 
       DataSource dataSource = config.getDataSource();
       if (dsClassName != null && dataSource == null) {
+         final Properties extendedDataSourceProperties = PropertyElf.copyProperties(dataSourceProperties);
          dataSource = createInstance(dsClassName, DataSource.class);
-         PropertyElf.setTargetFromProperties(dataSource, dataSourceProperties);
+         extendedDataSourceProperties.setProperty("url", jdbcUrl);
+         extendedDataSourceProperties.setProperty("user", username);
+         extendedDataSourceProperties.setProperty("passwords", password);
+         PropertyElf.setTargetFromProperties(dataSource, extendedDataSourceProperties);
       }
       else if (jdbcUrl != null && dataSource == null) {
          dataSource = new DriverDataSource(jdbcUrl, driverClassName, dataSourceProperties, username, password);


### PR DESCRIPTION
…perties, but with setter. In case of DataSourceClassName specified

In case initialisation dataSource with jdbcUrl and DataSourceClassName:
PoolBase ignore data that was set to HicariConfig, not as properties, but as `setX` method.
So enrich properties with HicariConfig getter methods.