### PR TITLE
Deprecate setMetricRegistry in favour of setMetricsTrackerFactory 

### DIFF
--- a/src/main/java/com/zaxxer/hikari/HikariConfig.java
+++ b/src/main/java/com/zaxxer/hikari/HikariConfig.java
@@ -747,7 +747,9 @@ public class HikariConfig implements HikariConfigMXBean
     * Set a MetricRegistry instance to use for registration of metrics used by HikariCP.
     *
     * @param metricRegistry the MetricRegistry instance to use
+    * @deprecated use {@link #setMetricsTrackerFactory(MetricsTrackerFactory)}
     */
+   @Deprecated
    public void setMetricRegistry(Object metricRegistry)
    {
       if (sealed) throw new IllegalStateException("The configuration of the pool is sealed once started.  Use HikariConfigMXBean for runtime changes.");

--- a/src/main/java/com/zaxxer/hikari/HikariDataSource.java
+++ b/src/main/java/com/zaxxer/hikari/HikariDataSource.java
@@ -224,6 +224,7 @@ public class HikariDataSource extends HikariConfig implements DataSource, Closea
 
    /** {@inheritDoc} */
    @Override
+   @Deprecated
    public void setMetricRegistry(Object metricRegistry)
    {
       boolean isAlreadySet = getMetricRegistry() != null;

--- a/src/main/java/com/zaxxer/hikari/metrics/MetricsTrackerFactory.java
+++ b/src/main/java/com/zaxxer/hikari/metrics/MetricsTrackerFactory.java
@@ -16,6 +16,11 @@
 
 package com.zaxxer.hikari.metrics;
 
+import com.codahale.metrics.MetricRegistry;
+import com.zaxxer.hikari.metrics.dropwizard.CodahaleMetricsTrackerFactory;
+import com.zaxxer.hikari.metrics.micrometer.MicrometerMetricsTrackerFactory;
+import io.micrometer.core.instrument.MeterRegistry;
+
 public interface MetricsTrackerFactory
 {
    /**
@@ -26,4 +31,13 @@ public interface MetricsTrackerFactory
     * @return a IMetricsTracker implementation instance
     */
    IMetricsTracker create(String poolName, PoolStats poolStats);
+
+   static MetricsTrackerFactory from(MetricRegistry metricRegistry) {
+      return new CodahaleMetricsTrackerFactory(metricRegistry);
+   }
+
+   static MetricsTrackerFactory from(MeterRegistry meterRegistry) {
+      return new MicrometerMetricsTrackerFactory(meterRegistry);
+   }
+
 }

--- a/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
+++ b/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
@@ -270,7 +270,9 @@ public final class HikariPool extends PoolBase implements HikariPoolMXBean, IBag
     * method from being called more than once.
     *
     * @param metricRegistry the metrics registry instance to use
+    * @deprecated use {@link #setMetricsTrackerFactory(MetricsTrackerFactory)} instead
     */
+   @Deprecated
    public void setMetricRegistry(Object metricRegistry)
    {
       if (metricRegistry != null && safeIsAssignableFrom(metricRegistry, "com.codahale.metrics.MetricRegistry")) {


### PR DESCRIPTION
Following up on my yesterday's PR #1089. 
Even though it is ok, I think the fact of accepting an Object and then doing tricks to find out wether the library class is in classpath and later on casting the object to correct type are not very nice. 
This is especially not great in light of [Change in dropwizard metrics package name in upcoming v5](https://github.com/dropwizard/metrics/pull/1255). For some time we will need to support both versions. This will add even more complexity in that part of the code. 

That's why I propose to deprecate/delete setMetricRegistry in favour of setMetricsTrackerFactory. Also by providing overloaded static factory methods in the MetricsTrackerFactory interface we won't need to do type checks at all. Users can just use `setMetricsTrackerFactory(from(metricRegistry))` instead of `setMetricRegistry(metricRegistry)` allowing to greatly simplify code around registering metricRegsitry .
This is preliminary PR just to get your feedback. Can update it with complete removal.
WDYT?