### PR TITLE
Remove hard-coded percentiles for Micrometer metrics

### DIFF
--- a/src/main/java/com/zaxxer/hikari/metrics/micrometer/MicrometerMetricsTracker.java
+++ b/src/main/java/com/zaxxer/hikari/metrics/micrometer/MicrometerMetricsTracker.java
@@ -9,18 +9,42 @@ import io.micrometer.core.instrument.Timer;
 
 import java.util.concurrent.TimeUnit;
 
+/**
+ * {@link IMetricsTracker Metrics tracker} for Micrometer.
+ * HikariCP metrics can be configured in your application by applying a
+ * {@link io.micrometer.core.instrument.config.MeterFilter MeterFilter} to metrics starting with
+ * {@link #HIKARI_METRIC_NAME_PREFIX}. For example, to configure client-side calculated percentiles:
+ *
+ * <blockquote><pre>
+ *     new MeterFilter() {
+ *       &#064;Override
+ *       public DistributionStatisticConfig configure(Meter.Id id, DistributionStatisticConfig config) {
+ *         if (id.getName().startsWith(MicrometerMetricsTracker.HIKARI_METRIC_NAME_PREFIX)) {
+ *           return DistributionStatisticConfig.builder()
+ *               .percentiles(0.5, 0.95)
+ *               .build()
+ *               .merge(config);
+ *            }
+ *         return config;
+ *         }
+ *      };
+ * </pre></blockquote>
+ */
 public class MicrometerMetricsTracker implements IMetricsTracker
 {
-   private static final String METRIC_CATEGORY = "pool";
-   private static final String METRIC_NAME_WAIT = "hikaricp.connections.acquire";
-   private static final String METRIC_NAME_USAGE = "hikaricp.connections.usage";
-   private static final String METRIC_NAME_CONNECT = "hikaricp.connections.creation";
+   /** Prefix used for all HikariCP metric names. */
+   public static final String HIKARI_METRIC_NAME_PREFIX = "hikaricp";
 
-   private static final String METRIC_NAME_TIMEOUT_RATE = "hikaricp.connections.timeout";
-   private static final String METRIC_NAME_TOTAL_CONNECTIONS = "hikaricp.connections";
-   private static final String METRIC_NAME_IDLE_CONNECTIONS = "hikaricp.connections.idle";
-   private static final String METRIC_NAME_ACTIVE_CONNECTIONS = "hikaricp.connections.active";
-   private static final String METRIC_NAME_PENDING_CONNECTIONS = "hikaricp.connections.pending";
+   private static final String METRIC_CATEGORY = "pool";
+   private static final String METRIC_NAME_WAIT = HIKARI_METRIC_NAME_PREFIX + ".connections.acquire";
+   private static final String METRIC_NAME_USAGE = HIKARI_METRIC_NAME_PREFIX + ".connections.usage";
+   private static final String METRIC_NAME_CONNECT = HIKARI_METRIC_NAME_PREFIX + ".connections.creation";
+
+   private static final String METRIC_NAME_TIMEOUT_RATE = HIKARI_METRIC_NAME_PREFIX + ".connections.timeout";
+   private static final String METRIC_NAME_TOTAL_CONNECTIONS = HIKARI_METRIC_NAME_PREFIX + ".connections";
+   private static final String METRIC_NAME_IDLE_CONNECTIONS = HIKARI_METRIC_NAME_PREFIX + ".connections.idle";
+   private static final String METRIC_NAME_ACTIVE_CONNECTIONS = HIKARI_METRIC_NAME_PREFIX + ".connections.active";
+   private static final String METRIC_NAME_PENDING_CONNECTIONS = HIKARI_METRIC_NAME_PREFIX + ".connections.pending";
 
    private final Timer connectionObtainTimer;
    private final Counter connectionTimeoutCounter;

--- a/src/main/java/com/zaxxer/hikari/metrics/micrometer/MicrometerMetricsTracker.java
+++ b/src/main/java/com/zaxxer/hikari/metrics/micrometer/MicrometerMetricsTracker.java
@@ -39,19 +39,16 @@ public class MicrometerMetricsTracker implements IMetricsTracker
    {
       this.connectionObtainTimer = Timer.builder(METRIC_NAME_WAIT)
          .description("Connection acquire time")
-         .publishPercentiles(0.95)
          .tags(METRIC_CATEGORY, poolName)
          .register(meterRegistry);
 
       this.connectionCreation = Timer.builder(METRIC_NAME_CONNECT)
          .description("Connection creation time")
-         .publishPercentiles(0.95)
          .tags(METRIC_CATEGORY, poolName)
          .register(meterRegistry);
 
       this.connectionUsage = Timer.builder(METRIC_NAME_USAGE)
          .description("Connection usage time")
-         .publishPercentiles(0.95)
          .tags(METRIC_CATEGORY, poolName)
          .register(meterRegistry);
 


### PR DESCRIPTION
See following comment from Micrometer maintainer https://github.com/micrometer-metrics/micrometer/issues/91#issuecomment-365780694. The hard-coded client-side percentile in HikariCP will make an extra time series whether the user wants it or not. Ultimately, to configure the percentiles or histogram they want, they will have to use a `MeterFilter`. I've added documentation for how they can do that.

If you don't want the public constant or documentation changes, feel free to take just the commit that removes hard-coded percentiles.

/cc @jkschneider @checketts 