### PR TITLE
Maintain strong reference to PoolStats for Micrometer gauges

### DIFF
--- a/src/main/java/com/zaxxer/hikari/metrics/micrometer/MicrometerMetricsTracker.java
+++ b/src/main/java/com/zaxxer/hikari/metrics/micrometer/MicrometerMetricsTracker.java
@@ -34,9 +34,13 @@ public class MicrometerMetricsTracker implements IMetricsTracker
    private final Gauge activeConnectionGauge;
    @SuppressWarnings({"FieldCanBeLocal", "unused"})
    private final Gauge pendingConnectionGauge;
+   @SuppressWarnings({"FieldCanBeLocal", "unused"})
+   private final PoolStats poolStats;
 
    MicrometerMetricsTracker(final String poolName, final PoolStats poolStats, final MeterRegistry meterRegistry)
    {
+      this.poolStats = poolStats;
+
       this.connectionObtainTimer = Timer.builder(METRIC_NAME_WAIT)
          .description("Connection acquire time")
          .publishPercentiles(0.95)


### PR DESCRIPTION
Micrometer's gauges were breaking after the `PoolStats` object they weakly referenced was garbage collected. This change holds a strong reference to the `PoolStats` object in `MicrometerMetricsTracker` to avoid this issue.

See http://micrometer.io/docs/concepts#_why_is_my_gauge_reporting_nan_or_disappearing

I noticed that the HikariCP gauges were showing `NaN` for their value sometime after application startup. The recently added documentation in Micrometer linked above helped me track down the issue.