### PR TITLE
Make idleTimeout reliable

### DIFF
--- a/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
+++ b/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
@@ -772,14 +772,11 @@ public final class HikariPool extends PoolBase implements HikariPoolMXBean, IBag
                logPoolState("Before cleanup ");
                afterPrefix = "After cleanup  ";
 
-               final List<PoolEntry> notInUse = connectionBag.values(STATE_NOT_IN_USE);
-               int toRemove = notInUse.size() - config.getMinimumIdle();
-               for (PoolEntry entry : notInUse) {
-                  if (toRemove > 0 && elapsedMillis(entry.lastAccessed, now) > idleTimeout && connectionBag.reserve(entry)) {
-                     closeConnection(entry, "(connection has passed idleTimeout)");
-                     toRemove--;
-                  }
-               }
+               connectionBag
+                  .values(STATE_NOT_IN_USE)
+                  .stream()
+                  .filter(entry -> elapsedMillis(entry.lastAccessed, now) > idleTimeout && connectionBag.reserve(entry))
+                  .forEach(entry -> closeConnection(entry, "(connection has passed idleTimeout)"));
             }
 
             logPoolState(afterPrefix);

--- a/src/test/java/com/zaxxer/hikari/pool/TestConnections.java
+++ b/src/test/java/com/zaxxer/hikari/pool/TestConnections.java
@@ -677,21 +677,21 @@ public class TestConnections
          Field connectionBagField = HikariPool.class.getDeclaredField("connectionBag");
          connectionBagField.setAccessible(true);
 
-         ConcurrentBag<PoolEntry> firstConnectionBag = (ConcurrentBag<PoolEntry>) connectionBagField.get(pool);
-         List<PoolEntry> firstIdleConnections = firstConnectionBag.values();
+         ConcurrentBag<PoolEntry> connectionBagBeforeIdleTimeout = (ConcurrentBag<PoolEntry>) connectionBagField.get(pool);
+         List<PoolEntry> connectionsBeforeIdleTimeout = connectionBagBeforeIdleTimeout.values();
 
          quietlySleep(TimeUnit.SECONDS.toMillis(2));
 
          assertSame("Second total connections not as expected", 1, pool.getTotalConnections());
          assertSame("Second idle connections not as expected", 1, pool.getIdleConnections());
 
-         ConcurrentBag<PoolEntry> secondConnectionBag = (ConcurrentBag<PoolEntry>) connectionBagField.get(pool);
-         List<PoolEntry> secondIdleConnections = secondConnectionBag.values();
+         ConcurrentBag<PoolEntry> connectionBagAfterIdleTimeout = (ConcurrentBag<PoolEntry>) connectionBagField.get(pool);
+         List<PoolEntry> connectionsAfterIdleTimeout = connectionBagAfterIdleTimeout.values();
 
-         PoolEntry firstIdleConnection = firstIdleConnections.get(0);
-         PoolEntry secondIdleConnection = secondIdleConnections.get(0);
+         PoolEntry connectionBeforeIdleTimeout = connectionsBeforeIdleTimeout.get(0);
+         PoolEntry connectionAfterIdleTimeout = connectionsAfterIdleTimeout.get(0);
 
-         assertNotSame("Idle connections not as expected", firstIdleConnection,secondIdleConnection);
+         assertNotSame("Idle connections not as expected", connectionBeforeIdleTimeout,connectionAfterIdleTimeout);
 
       } finally {
          setConfigUnitTest(false);


### PR DESCRIPTION
Regarding the issue #1128 , IdleTimeout doesn't work as expected when there is no connection needs to be removed. This toRemoved logic is preventing the idle connections have been there for more than idleTimeout to be refreshed. This unreliability becomes a problem when there is also an idleSessionTimeout on the server side. The server is dropping the idle connections whereas hikari is not. Thus   the application picks a connection from the pool which is actually dropped by the server. The idle connection should be evicted, closed and replaced with the newly created one by housekeeping immediately. To avoid this problem, this buggy toRemoved logic is removed.