### PR TITLE
Log uncaught error while acquiring connection

### DIFF
--- a/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
+++ b/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
@@ -482,9 +482,22 @@ public final class HikariPool extends PoolBase implements HikariPoolMXBean, IBag
 
          return poolEntry;
       }
-      catch (Exception e) {
+      catch (SQLException e) {
          if (poolState == POOL_NORMAL) { // we check POOL_NORMAL to avoid a flood of messages if shutdown() is running concurrently
-            LOGGER.debug("{} - Cannot acquire connection from data source", poolName, (e instanceof ConnectionSetupException ? e.getCause() : e));
+            LOGGER.debug("{} - Cannot acquire connection from data source", poolName, e);
+         }
+         return null;
+      }
+      catch (Throwable e) {
+         if (poolState == POOL_NORMAL) { // we check POOL_NORMAL to avoid a flood of messages if shutdown() is running concurrently
+            LOGGER.error("{} - Error thrown while acquiring connection from data source", poolName, (e instanceof ConnectionSetupException ? e.getCause() : e));
+            ConnectionSetupException wrapped;
+            if (e instanceof ConnectionSetupException) {
+               wrapped = (ConnectionSetupException) e;
+            } else {
+               wrapped = new ConnectionSetupException(e);
+            }
+            lastConnectionFailure.set(wrapped);
          }
          return null;
       }

--- a/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
+++ b/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
@@ -58,6 +58,7 @@ abstract class PoolBase
 
    protected volatile String catalog;
    protected final String poolName;
+   protected final AtomicReference<Throwable> lastConnectionFailure;
 
    long connectionTimeout;
    long validationTimeout;
@@ -81,7 +82,6 @@ abstract class PoolBase
 
    private final boolean isUseJdbc4Validation;
    private final boolean isIsolateInternalQueries;
-   private final AtomicReference<Throwable> lastConnectionFailure;
 
    private volatile boolean isValidChecked;
 


### PR DESCRIPTION
Default ThreadPoolExecutor implementation just lets thread being killed without any information.

This patch introduces new class "ListenableThreadPoolExecutor" which can set listener to handle
pre/post execution which ThreadPoolExecutor basically provides the lifecycle of running task.

This patch adds listener to connection adder/closer to log uncaught error before thread is killed.