### PR TITLE
allow to pass in a prometheus CollectorRegistry (fixes #1181)

### DIFF
--- a/src/main/java/com/zaxxer/hikari/metrics/prometheus/PrometheusMetricsTrackerFactory.java
+++ b/src/main/java/com/zaxxer/hikari/metrics/prometheus/PrometheusMetricsTrackerFactory.java
@@ -38,7 +38,7 @@ public class PrometheusMetricsTrackerFactory implements MetricsTrackerFactory {
     * collector registry ({@code CollectorRegistry.defaultRegistry}).
     */
    public PrometheusMetricsTrackerFactory() {
-
+      this.collectorRegistry = CollectorRegistry.defaultRegistry;
    }
 
    /**
@@ -52,7 +52,7 @@ public class PrometheusMetricsTrackerFactory implements MetricsTrackerFactory {
    @Override
    public IMetricsTracker create(String poolName, PoolStats poolStats) {
       getCollector().add(poolName, poolStats);
-      return new PrometheusMetricsTracker(poolName);
+      return new PrometheusMetricsTracker(poolName, this.collectorRegistry);
    }
 
    /**
@@ -60,11 +60,7 @@ public class PrometheusMetricsTrackerFactory implements MetricsTrackerFactory {
     */
    private HikariCPCollector getCollector() {
       if (collector == null) {
-         if (this.collectorRegistry == null) {
-            collector = new HikariCPCollector().register();
-         } else {
-            collector = new HikariCPCollector().register(this.collectorRegistry);
-         }
+         collector = new HikariCPCollector().register(this.collectorRegistry);
       }
       return collector;
    }

--- a/src/main/java/com/zaxxer/hikari/metrics/prometheus/PrometheusMetricsTrackerFactory.java
+++ b/src/main/java/com/zaxxer/hikari/metrics/prometheus/PrometheusMetricsTrackerFactory.java
@@ -19,6 +19,7 @@ package com.zaxxer.hikari.metrics.prometheus;
 import com.zaxxer.hikari.metrics.IMetricsTracker;
 import com.zaxxer.hikari.metrics.MetricsTrackerFactory;
 import com.zaxxer.hikari.metrics.PoolStats;
+import io.prometheus.client.CollectorRegistry;
 
 /**
  * <pre>{@code
@@ -28,7 +29,25 @@ import com.zaxxer.hikari.metrics.PoolStats;
  */
 public class PrometheusMetricsTrackerFactory implements MetricsTrackerFactory {
 
-   private static HikariCPCollector collector;
+   private HikariCPCollector collector;
+
+   private CollectorRegistry collectorRegistry;
+
+   /**
+    * Default Constructor. The Hikari metrics are registered to the default
+    * collector registry ({@code CollectorRegistry.defaultRegistry}).
+    */
+   public PrometheusMetricsTrackerFactory() {
+
+   }
+
+   /**
+    * Constructor that allows to pass in a {@link CollectorRegistry} to which the
+    * Hikari metrics are registered.
+    */
+   public PrometheusMetricsTrackerFactory(CollectorRegistry collectorRegistry) {
+      this.collectorRegistry = collectorRegistry;
+   }
 
    @Override
    public IMetricsTracker create(String poolName, PoolStats poolStats) {
@@ -41,7 +60,11 @@ public class PrometheusMetricsTrackerFactory implements MetricsTrackerFactory {
     */
    private HikariCPCollector getCollector() {
       if (collector == null) {
-         collector = new HikariCPCollector().register();
+         if (this.collectorRegistry == null) {
+            collector = new HikariCPCollector().register();
+         } else {
+            collector = new HikariCPCollector().register(this.collectorRegistry);
+         }
       }
       return collector;
    }

--- a/src/test/java/com/zaxxer/hikari/metrics/prometheus/HikariCPCollectorTest.java
+++ b/src/test/java/com/zaxxer/hikari/metrics/prometheus/HikariCPCollectorTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertThat;
 
 import java.sql.Connection;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import com.zaxxer.hikari.HikariConfig;
@@ -32,11 +33,20 @@ import com.zaxxer.hikari.mocks.StubConnection;
 import io.prometheus.client.CollectorRegistry;
 
 public class HikariCPCollectorTest {
+
+   private CollectorRegistry collectorRegistry;
+
+   @Before
+   public void setupCollectorRegistry(){
+      this.collectorRegistry = new CollectorRegistry();
+   }
+
+
    @Test
    public void noConnection() throws Exception {
       HikariConfig config = newHikariConfig();
       config.setMinimumIdle(0);
-      config.setMetricsTrackerFactory(new PrometheusMetricsTrackerFactory());
+      config.setMetricsTrackerFactory(new PrometheusMetricsTrackerFactory(this.collectorRegistry));
       config.setDataSourceClassName("com.zaxxer.hikari.mocks.StubDataSource");
 
       StubConnection.slowCreate = true;
@@ -57,7 +67,7 @@ public class HikariCPCollectorTest {
    public void noConnectionWithoutPoolName() throws Exception {
       HikariConfig config = new HikariConfig();
       config.setMinimumIdle(0);
-      config.setMetricsTrackerFactory(new PrometheusMetricsTrackerFactory());
+      config.setMetricsTrackerFactory(new PrometheusMetricsTrackerFactory(this.collectorRegistry));
       config.setDataSourceClassName("com.zaxxer.hikari.mocks.StubDataSource");
 
       StubConnection.slowCreate = true;
@@ -78,7 +88,7 @@ public class HikariCPCollectorTest {
    @Test
    public void connection1() throws Exception {
       HikariConfig config = newHikariConfig();
-      config.setMetricsTrackerFactory(new PrometheusMetricsTrackerFactory());
+      config.setMetricsTrackerFactory(new PrometheusMetricsTrackerFactory(this.collectorRegistry));
       config.setDataSourceClassName("com.zaxxer.hikari.mocks.StubDataSource");
       config.setMaximumPoolSize(1);
 
@@ -103,7 +113,7 @@ public class HikariCPCollectorTest {
    @Test
    public void connectionClosed() throws Exception {
       HikariConfig config = newHikariConfig();
-      config.setMetricsTrackerFactory(new PrometheusMetricsTrackerFactory());
+      config.setMetricsTrackerFactory(new PrometheusMetricsTrackerFactory(this.collectorRegistry));
       config.setDataSourceClassName("com.zaxxer.hikari.mocks.StubDataSource");
       config.setMaximumPoolSize(1);
 
@@ -128,7 +138,7 @@ public class HikariCPCollectorTest {
    private double getValue(String name, String poolName) {
       String[] labelNames = {"pool"};
       String[] labelValues = {poolName};
-      return CollectorRegistry.defaultRegistry.getSampleValue(name, labelNames, labelValues);
+      return this.collectorRegistry.getSampleValue(name, labelNames, labelValues);
    }
 
 }

--- a/src/test/java/com/zaxxer/hikari/metrics/prometheus/PrometheusMetricsTrackerFactoryTest.java
+++ b/src/test/java/com/zaxxer/hikari/metrics/prometheus/PrometheusMetricsTrackerFactoryTest.java
@@ -1,0 +1,76 @@
+package com.zaxxer.hikari.metrics.prometheus;
+
+import com.zaxxer.hikari.metrics.PoolStats;
+import io.prometheus.client.Collector;
+import io.prometheus.client.CollectorRegistry;
+import org.junit.After;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class PrometheusMetricsTrackerFactoryTest {
+
+   @Test
+   public void registersToProvidedCollectorRegistry() {
+      CollectorRegistry collectorRegistry = new CollectorRegistry();
+      PrometheusMetricsTrackerFactory factory = new PrometheusMetricsTrackerFactory(collectorRegistry);
+      factory.create("testpool-1", poolStats());
+      assertHikariMetricsAreNotPresent(CollectorRegistry.defaultRegistry);
+      assertHikariMetricsArePresent(collectorRegistry);
+   }
+
+   @Test
+   public void registersToDefaultCollectorRegistry() {
+      PrometheusMetricsTrackerFactory factory = new PrometheusMetricsTrackerFactory();
+      factory.create("testpool-2", poolStats());
+      assertHikariMetricsArePresent(CollectorRegistry.defaultRegistry);
+   }
+
+   @After
+   public void clearCollectorRegistry(){
+      CollectorRegistry.defaultRegistry.clear();
+   }
+
+   private void assertHikariMetricsArePresent(CollectorRegistry collectorRegistry) {
+      List<String> registeredMetrics = toMetricNames(collectorRegistry.metricFamilySamples());
+      assertTrue(registeredMetrics.contains("hikaricp_active_connections"));
+      assertTrue(registeredMetrics.contains("hikaricp_idle_connections"));
+      assertTrue(registeredMetrics.contains("hikaricp_pending_threads"));
+      assertTrue(registeredMetrics.contains("hikaricp_connections"));
+      assertTrue(registeredMetrics.contains("hikaricp_max_connections"));
+      assertTrue(registeredMetrics.contains("hikaricp_min_connections"));
+   }
+
+   private void assertHikariMetricsAreNotPresent(CollectorRegistry collectorRegistry) {
+      List<String> registeredMetrics = toMetricNames(collectorRegistry.metricFamilySamples());
+      assertFalse(registeredMetrics.contains("hikaricp_active_connections"));
+      assertFalse(registeredMetrics.contains("hikaricp_idle_connections"));
+      assertFalse(registeredMetrics.contains("hikaricp_pending_threads"));
+      assertFalse(registeredMetrics.contains("hikaricp_connections"));
+      assertFalse(registeredMetrics.contains("hikaricp_max_connections"));
+      assertFalse(registeredMetrics.contains("hikaricp_min_connections"));
+   }
+
+   private List<String> toMetricNames(Enumeration<Collector.MetricFamilySamples> enumeration) {
+      List<String> list = new ArrayList<>();
+      while (enumeration.hasMoreElements()) {
+         list.add(enumeration.nextElement().name);
+      }
+      return list;
+   }
+
+   private PoolStats poolStats() {
+      return new PoolStats(0) {
+         @Override
+         protected void update() {
+            // do nothing
+         }
+      };
+   }
+
+}


### PR DESCRIPTION
Added a constructor to `PrometheusMetricsTrackerFactory` that allows to pass in a `CollectorRegistry` instance.

Removed the `static` modifier from the collector field since with the new constructor you may theoretically have more than one instance of the factory using a different `CollectorRegistry` instance each.

fixes #1181 