### PR TITLE
Make HikariConfig able to retrieve passwords dynamically from a password supplier

### DIFF
--- a/src/test/java/com/zaxxer/hikari/HikariConfigTest.java
+++ b/src/test/java/com/zaxxer/hikari/HikariConfigTest.java
@@ -1,0 +1,51 @@
+package com.zaxxer.hikari;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+public class HikariConfigTest {
+
+   @Test
+   public void getPasswordReturnsPasswordFromSupplier() {
+      HikariConfig config = new HikariConfig();
+      config.setPasswordSupplier(() -> "supplied-password");
+
+      String password = config.getPassword();
+
+      assertThat(password, is(equalTo("supplied-password")));
+   }
+
+   @Test
+   public void getPasswordReturnsDefaultPassword() {
+      HikariConfig config = new HikariConfig();
+      config.setPassword("default-password");
+
+      String password = config.getPassword();
+
+      assertThat(password, is(equalTo("default-password")));
+   }
+
+   @Test(expected = IllegalStateException.class)
+   public void setPasswordThrowsExceptionWhenSupplierWasProvided() {
+      HikariConfig config = new HikariConfig();
+      config.setPasswordSupplier(() -> "supplied-password");
+
+      config.setPassword("default-password");
+
+      fail("Should have thrown exception");
+   }
+
+   @Test(expected = IllegalStateException.class)
+   public void setPasswordSupplierThrowsExceptionWhenDefaultPasswordWasProvided() {
+      HikariConfig config = new HikariConfig();
+      config.setPassword("default-password");
+
+      config.setPasswordSupplier(() -> "supplied-password");
+
+      fail("Should have thrown exception");
+   }
+}


### PR DESCRIPTION
This patch makes `HikariConfig` able to retrieve passwords from a provided password supplier at runtime when `getPassword` is called. This is useful for scenarios where expiring database passwords are dynamically generated at runtime (e.g. RDS access tokens) and one wants to avoid having to create a new `DataSource` or scheduling a task that periodically updates the password via `HikariConfigMXBean`.