### PR TITLE
Fix typos detected by github.com/client9/misspell

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Microbenchmarks were created to isolate and measure the overhead of pools using 
 
 #### Spike Demand Pool Comparison
 <a href="https://github.com/brettwooldridge/HikariCP/blob/dev/documents/Welcome-To-The-Jungle.md"><img width="400" align="right" src="https://github.com/brettwooldridge/HikariCP/wiki/Spike-Hikari.png"></a>
-Anaylsis of HikariCP v2.6, in comparison to other pools, in relation to a unique "spike demand" load.
+Analysis of HikariCP v2.6, in comparison to other pools, in relation to a unique "spike demand" load.
 
 The customer's environment imposed a high cost of new connection acquisition, and a requirement for a dynamically-sized pool, but yet a need for responsiveness to request spikes.  Read about the spike demand handling [here](https://github.com/brettwooldridge/HikariCP/blob/dev/documents/Welcome-To-The-Jungle.md).
 <br/>

--- a/documents/Welcome-To-The-Jungle.md
+++ b/documents/Welcome-To-The-Jungle.md
@@ -27,7 +27,7 @@ The constraints are simple:
  * Connection establishment takes 150ms.
  * Query execution takes 2ms.
  * The maximum pool size is 50.
- * The minumum idle connections is 5.
+ * The minimum idle connections is 5.
 
 And the simulation is fairly simple:
  * Everything is quiet, and then ... Boom! ... 50 threads, at once, wanting a connection and to execute a query.

--- a/src/test/java/com/zaxxer/hikari/mocks/MockDataSource.java
+++ b/src/test/java/com/zaxxer/hikari/mocks/MockDataSource.java
@@ -148,7 +148,7 @@ public class MockDataSource implements DataSource
 //            public Void answer(InvocationOnMock invocation) throws Throwable {
 //                return null;
 //            }
-//        }).doThrow(new SQLException("Transaction already commited")).when(mockConnection).commit();
+//        }).doThrow(new SQLException("Transaction already committed")).when(mockConnection).commit();
 
         // Handle Connection.rollback()
 //        doAnswer(new Answer<Void>() {


### PR DESCRIPTION
This pull request fixes the typos in this repository. Although I am not a native English speaker, [misspell](https://github.com/client9/misspell) detected obvious mistakes for us. I've fixed them except for false positives.
