### PR TITLE
Fix compilerArgs option for the maven-compiler-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -366,7 +366,9 @@
                <configuration>
                   <source>1.8</source>
                   <target>1.8</target>
-                  <compilerArgs>-Xlint</compilerArgs>
+                  <compilerArgs>
+                     <arg>-Xlint</arg>
+                  </compilerArgs>
                </configuration>
             </plugin>
 


### PR DESCRIPTION
`-Xlint` should be inside `<arg></arg>` according to the [documentation](https://maven.apache.org/plugins/maven-compiler-plugin/compile-mojo.html#compilerArgs)