### PR TITLE
Expose the stacktrace created when connection is aquired during leak detection

### DIFF
--- a/src/main/java/com/zaxxer/hikari/pool/ProxyConnection.java
+++ b/src/main/java/com/zaxxer/hikari/pool/ProxyConnection.java
@@ -184,6 +184,17 @@ public abstract class ProxyConnection implements Connection
       leakTask.cancel();
    }
 
+   /**
+    * Returns the stacktrace location of where the connection was acquired. If leak detection is not endabled, will
+    * return an empty array.
+    *
+    * @return Array containing StackTraceElement generated when connection was acquired
+    */
+   public StackTraceElement[] getStackTrace()
+   {
+      return leakTask.getStackTrace();
+   }
+
    private synchronized <T extends Statement> T trackStatement(final T statement)
    {
       openStatements.add(statement);

--- a/src/main/java/com/zaxxer/hikari/pool/ProxyLeakTask.java
+++ b/src/main/java/com/zaxxer/hikari/pool/ProxyLeakTask.java
@@ -37,8 +37,9 @@ class ProxyLeakTask implements Runnable
    private ScheduledFuture<?> scheduledFuture;
    private String connectionName;
    private Exception exception;
-   private String threadName; 
+   private String threadName;
    private boolean isLeaked;
+   private static final StackTraceElement[] NO_STACKTRACE = {};
 
    static
    {
@@ -51,6 +52,12 @@ class ProxyLeakTask implements Runnable
 
          @Override
          public void cancel() {}
+
+         @Override
+         public StackTraceElement[] getStackTrace()
+         {
+            return NO_STACKTRACE;
+         }
       };
    }
 
@@ -70,13 +77,18 @@ class ProxyLeakTask implements Runnable
       scheduledFuture = executorService.schedule(this, leakDetectionThreshold, TimeUnit.MILLISECONDS);
    }
 
+   public StackTraceElement[] getStackTrace()
+   {
+      return exception.getStackTrace();
+   }
+
    /** {@inheritDoc} */
    @Override
    public void run()
    {
       isLeaked = true;
 
-      final StackTraceElement[] stackTrace = exception.getStackTrace(); 
+      final StackTraceElement[] stackTrace = exception.getStackTrace();
       final StackTraceElement[] trace = new StackTraceElement[stackTrace.length - 5];
       System.arraycopy(stackTrace, 5, trace, 0, trace.length);
 


### PR DESCRIPTION
Hi Again!
  A small quality of life improvement to allow external users to get to the connection creation stacktrace. This is useful as I have leak detection hooks in my testing framework and when a leaked connection is detected being able to pull the stack trace right from the connection object is very convenient. 

Open to any thoughts or getting this rejected, but figured I'd give it a shot. 

If you are open to this, will add test case and address any feedback. 