### PR TITLE
Call newInstance on Constructor of driverClass

### DIFF
--- a/src/main/java/com/zaxxer/hikari/HikariConfig.java
+++ b/src/main/java/com/zaxxer/hikari/HikariConfig.java
@@ -486,7 +486,7 @@ public class HikariConfig implements HikariConfigMXBean
       }
 
       try {
-         driverClass.newInstance();
+         driverClass.getConstructor().newInstance();
          this.driverClassName = driverClassName;
       }
       catch (Exception e) {


### PR DESCRIPTION
First of all thanks for all the great work and providing it as open source code :)

I would like to report a problem that @Nikos410 and I have come across while testing JDK 11 with our applications:

`Class.newInstance` is deprecated as of Java 9. Usage should be replaced by calling `Class.get(Declared)Constructor.newInstance` which is backwards compatible. See [java.lang.Class.newInstance](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Class.html#newInstance()) for more information.

tomcat-jdbc also uses this call: https://github.com/apache/tomcat/blob/8053cbfd45ba037228d1b24ef733210204a6dad9/modules/jdbc-pool/src/main/java/org/apache/tomcat/jdbc/pool/PooledConnection.java#L285

Not only is newInstance deprecated but using it also creates a problem testing our applications with JDK11. There even is a comment in the source code of newInstance about possible problems with the current memory model: http://hg.openjdk.java.net/jdk/jdk/file/76072a077ee1/src/java.base/share/classes/java/lang/Class.java#l543
We are experiencing such a problem and can't start using JDK 11 due to this issue. I can explain it in more detail if necessary but don't feel like it is exactly necessary to argue for the removal of a deprecated call.