### PR TITLE
Bump log4j.version from 2.9.0 to 2.11.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
       <pax.url.version>2.5.2</pax.url.version>
       <postgresql.version>42.1.4</postgresql.version>
       <slf4j.version>1.7.25</slf4j.version>
-      <log4j.version>2.9.0</log4j.version>
+      <log4j.version>2.11.1</log4j.version>
       <commons.csv.version>1.5</commons.csv.version>
       <h2.version>1.4.196</h2.version>
       <junit.version>4.12</junit.version>


### PR DESCRIPTION
Bumps `log4j.version` from 2.9.0 to 2.11.1.

Updates `log4j-slf4j-impl` from 2.9.0 to 2.11.1

Updates `log4j-api` from 2.9.0 to 2.11.1

Updates `log4j-core` from 2.9.0 to 2.11.1

Signed-off-by: dependabot[bot] <support@dependabot.com>