### PR TITLE
update the version for pom demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ _Java 8/9 maven artifact:_
     <dependency>
         <groupId>com.zaxxer</groupId>
         <artifactId>HikariCP</artifactId>
-        <version>3.1.0</version>
+        <version>3.2.0</version>
     </dependency>
 ```
 _Java 7 maven artifact (*maintenance mode*):_


### PR DESCRIPTION
since HikariCP released the v 3.2.0 , why not show the up to date version.