### PR TITLE
Fixes #1012 Local MBean name part should be key-property list

### DIFF
--- a/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
+++ b/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
@@ -274,8 +274,8 @@ abstract class PoolBase
       try {
          final MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
 
-         final ObjectName beanConfigName = new ObjectName("com.zaxxer.hikari:type=PoolConfig (" + poolName + ")");
-         final ObjectName beanPoolName = new ObjectName("com.zaxxer.hikari:type=Pool (" + poolName + ")");
+         final ObjectName beanConfigName = new ObjectName("com.zaxxer.hikari:type=PoolConfig,name=" + poolName);
+         final ObjectName beanPoolName = new ObjectName("com.zaxxer.hikari:type=Pool,name=" + poolName);
          if (register) {
             if (!mBeanServer.isRegistered(beanConfigName)) {
                mBeanServer.registerMBean(config, beanConfigName);

--- a/src/test/java/com/zaxxer/hikari/pool/TestMBean.java
+++ b/src/test/java/com/zaxxer/hikari/pool/TestMBean.java
@@ -20,6 +20,7 @@ import com.zaxxer.hikari.HikariConfigMXBean;
 import com.zaxxer.hikari.HikariDataSource;
 import com.zaxxer.hikari.HikariPoolMXBean;
 import com.zaxxer.hikari.mocks.StubDataSource;
+import java.util.Hashtable;
 import org.junit.Test;
 
 import javax.management.JMX;
@@ -71,7 +72,10 @@ public class TestMBean
          TimeUnit.SECONDS.sleep(1);
 
          MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
-         ObjectName poolName = new ObjectName("com.zaxxer.hikari:type=Pool (testMBeanReporting)");
+         Hashtable<String, String> properties = new Hashtable<>(2);
+         properties.put("type", "Pool");
+         properties.put("name", "testMBeanReporting");
+         ObjectName poolName = new ObjectName("com.zaxxer.hikari", properties);
          HikariPoolMXBean hikariPoolMXBean = JMX.newMXBeanProxy(mBeanServer, poolName, HikariPoolMXBean.class);
 
          assertEquals(0, hikariPoolMXBean.getActiveConnections());


### PR DESCRIPTION
This will break client code that depend on the current JMX bean naming, which is an issue if we consider bean naming to be part of the API.

If the renaming is a problem, we could register the same beans twice, but at the cost of clutter.

This allows less fragile querying of JMX beans:

Current

* Single object query: ```new ObjectName("com.zaxxer.hikari:type=Pool (testMBeanReporting)")```
* All objects: ```new ObjectName("com.zaxxer.hikari:type=*")```

New

* Single object query: ```new ObjectName("com.zaxxer.hikari:type=Pool,name=testMBeanReporting")```
* All objects: ```new ObjectName("com.zaxxer.hikari:type=*,name=*")``` or, less explicitly, ```new ObjectName("com.zaxxer.hikari:*")``` 

Additionally, some additional queries become easier to do:

* All beans for a pool: ```new ObjectName("com.zaxxer.hikari:type=*,name=testMBeanReporting")```
* All Pool beans for all pools: ```new ObjectName("com.zaxxer.hikari:type=Pool,name=*")```

The properties based query API also works as intended. (Used in the unit test)
