### PR TITLE
Refactor/fix Prometheus metrics for multiple connection pools, add unit tests

### DIFF
--- a/src/main/java/com/zaxxer/hikari/metrics/micrometer/MicrometerMetricsTrackerFactory.java
+++ b/src/main/java/com/zaxxer/hikari/metrics/micrometer/MicrometerMetricsTrackerFactory.java
@@ -5,7 +5,8 @@ import com.zaxxer.hikari.metrics.MetricsTrackerFactory;
 import com.zaxxer.hikari.metrics.PoolStats;
 import io.micrometer.core.instrument.MeterRegistry;
 
-public class MicrometerMetricsTrackerFactory implements MetricsTrackerFactory {
+public class MicrometerMetricsTrackerFactory implements MetricsTrackerFactory
+{
 
    private final MeterRegistry registry;
 

--- a/src/main/java/com/zaxxer/hikari/metrics/prometheus/HikariCPCollector.java
+++ b/src/main/java/com/zaxxer/hikari/metrics/prometheus/HikariCPCollector.java
@@ -27,14 +27,16 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
-class HikariCPCollector extends Collector {
+class HikariCPCollector extends Collector
+{
 
    private static final List<String> LABEL_NAMES = Collections.singletonList("pool");
 
    private final Map<String, PoolStats> poolStatsMap = new ConcurrentHashMap<>();
 
    @Override
-   public List<MetricFamilySamples> collect() {
+   public List<MetricFamilySamples> collect()
+   {
       return Arrays.asList(
          createGauge("hikaricp_active_connections", "Active connections",
             PoolStats::getActiveConnections),
@@ -51,16 +53,19 @@ class HikariCPCollector extends Collector {
       );
    }
 
-   void add(String name, PoolStats poolStats) {
+   void add(String name, PoolStats poolStats)
+   {
       poolStatsMap.put(name, poolStats);
    }
 
-   void remove(String name) {
+   void remove(String name)
+   {
       poolStatsMap.remove(name);
    }
 
    private GaugeMetricFamily createGauge(String metric, String help,
-                                         Function<PoolStats, Integer> metricValueFunction) {
+                                         Function<PoolStats, Integer> metricValueFunction)
+   {
       GaugeMetricFamily metricFamily = new GaugeMetricFamily(metric, help, LABEL_NAMES);
       poolStatsMap.forEach((k, v) -> metricFamily.addMetric(
          Collections.singletonList(k),

--- a/src/main/java/com/zaxxer/hikari/metrics/prometheus/HikariCPCollector.java
+++ b/src/main/java/com/zaxxer/hikari/metrics/prometheus/HikariCPCollector.java
@@ -12,13 +12,14 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.zaxxer.hikari.metrics.prometheus;
 
 import com.zaxxer.hikari.metrics.PoolStats;
 import io.prometheus.client.Collector;
 import io.prometheus.client.GaugeMetricFamily;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -50,13 +51,16 @@ class HikariCPCollector extends Collector {
       );
    }
 
-   protected HikariCPCollector add(String name, PoolStats poolStats) {
+   void add(String name, PoolStats poolStats) {
       poolStatsMap.put(name, poolStats);
-      return this;
+   }
+
+   void remove(String name) {
+      poolStatsMap.remove(name);
    }
 
    private GaugeMetricFamily createGauge(String metric, String help,
-      Function<PoolStats, Integer> metricValueFunction) {
+                                         Function<PoolStats, Integer> metricValueFunction) {
       GaugeMetricFamily metricFamily = new GaugeMetricFamily(metric, help, LABEL_NAMES);
       poolStatsMap.forEach((k, v) -> metricFamily.addMetric(
          Collections.singletonList(k),

--- a/src/main/java/com/zaxxer/hikari/metrics/prometheus/PrometheusMetricsTracker.java
+++ b/src/main/java/com/zaxxer/hikari/metrics/prometheus/PrometheusMetricsTracker.java
@@ -28,7 +28,8 @@ import java.util.concurrent.TimeUnit;
 
 import static com.zaxxer.hikari.metrics.prometheus.PrometheusMetricsTrackerFactory.RegistrationStatus.REGISTERED;
 
-class PrometheusMetricsTracker implements IMetricsTracker {
+class PrometheusMetricsTracker implements IMetricsTracker
+{
    private final static Counter CONNECTION_TIMEOUT_COUNTER = Counter.build()
       .name("hikaricp_connection_timeout_total")
       .labelNames("pool")
@@ -55,7 +56,8 @@ class PrometheusMetricsTracker implements IMetricsTracker {
    private final Summary.Child elapsedUsageSummaryChild;
    private final Summary.Child elapsedCreationSummaryChild;
 
-   PrometheusMetricsTracker(String poolName, CollectorRegistry collectorRegistry, HikariCPCollector hikariCPCollector) {
+   PrometheusMetricsTracker(String poolName, CollectorRegistry collectorRegistry, HikariCPCollector hikariCPCollector)
+   {
       registerMetrics(collectorRegistry);
       this.poolName = poolName;
       this.hikariCPCollector = hikariCPCollector;
@@ -65,7 +67,8 @@ class PrometheusMetricsTracker implements IMetricsTracker {
       this.elapsedCreationSummaryChild = ELAPSED_CREATION_SUMMARY.labels(poolName);
    }
 
-   private void registerMetrics(CollectorRegistry collectorRegistry) {
+   private void registerMetrics(CollectorRegistry collectorRegistry)
+   {
       if (registrationStatuses.putIfAbsent(collectorRegistry, REGISTERED) == null) {
          CONNECTION_TIMEOUT_COUNTER.register(collectorRegistry);
          ELAPSED_ACQUIRED_SUMMARY.register(collectorRegistry);
@@ -75,26 +78,31 @@ class PrometheusMetricsTracker implements IMetricsTracker {
    }
 
    @Override
-   public void recordConnectionAcquiredNanos(long elapsedAcquiredNanos) {
+   public void recordConnectionAcquiredNanos(long elapsedAcquiredNanos)
+   {
       elapsedAcquiredSummaryChild.observe(elapsedAcquiredNanos);
    }
 
    @Override
-   public void recordConnectionUsageMillis(long elapsedBorrowedMillis) {
+   public void recordConnectionUsageMillis(long elapsedBorrowedMillis)
+   {
       elapsedUsageSummaryChild.observe(elapsedBorrowedMillis);
    }
 
    @Override
-   public void recordConnectionCreatedMillis(long connectionCreatedMillis) {
+   public void recordConnectionCreatedMillis(long connectionCreatedMillis)
+   {
       elapsedCreationSummaryChild.observe(connectionCreatedMillis);
    }
 
    @Override
-   public void recordConnectionTimeout() {
+   public void recordConnectionTimeout()
+   {
       connectionTimeoutCounterChild.inc();
    }
 
-   private static Summary createSummary(String name, String help) {
+   private static Summary createSummary(String name, String help)
+   {
       return Summary.build()
          .name(name)
          .labelNames("pool")
@@ -108,7 +116,8 @@ class PrometheusMetricsTracker implements IMetricsTracker {
    }
 
    @Override
-   public void close() {
+   public void close()
+   {
       hikariCPCollector.remove(poolName);
       CONNECTION_TIMEOUT_COUNTER.remove(poolName);
       ELAPSED_ACQUIRED_SUMMARY.remove(poolName);

--- a/src/main/java/com/zaxxer/hikari/metrics/prometheus/PrometheusMetricsTracker.java
+++ b/src/main/java/com/zaxxer/hikari/metrics/prometheus/PrometheusMetricsTracker.java
@@ -12,37 +12,89 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.zaxxer.hikari.metrics.prometheus;
 
 import com.zaxxer.hikari.metrics.IMetricsTracker;
+import com.zaxxer.hikari.metrics.prometheus.PrometheusMetricsTrackerFactory.RegistrationStatus;
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.Counter;
 import io.prometheus.client.Summary;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
-class PrometheusMetricsTracker implements IMetricsTracker
-{
-   private final Counter CONNECTION_TIMEOUT_COUNTER = Counter.build()
+import static com.zaxxer.hikari.metrics.prometheus.PrometheusMetricsTrackerFactory.RegistrationStatus.REGISTERED;
+
+class PrometheusMetricsTracker implements IMetricsTracker {
+   private final static Counter CONNECTION_TIMEOUT_COUNTER = Counter.build()
       .name("hikaricp_connection_timeout_total")
       .labelNames("pool")
       .help("Connection timeout total count")
       .create();
 
-   private final Summary ELAPSED_ACQUIRED_SUMMARY =
-      registerSummary("hikaricp_connection_acquired_nanos", "Connection acquired time (ns)");
+   private final static Summary ELAPSED_ACQUIRED_SUMMARY =
+      createSummary("hikaricp_connection_acquired_nanos", "Connection acquired time (ns)");
 
-   private final Summary ELAPSED_BORROWED_SUMMARY =
-      registerSummary("hikaricp_connection_usage_millis", "Connection usage (ms)");
+   private final static Summary ELAPSED_USAGE_SUMMARY =
+      createSummary("hikaricp_connection_usage_millis", "Connection usage (ms)");
 
-   private final Summary ELAPSED_CREATION_SUMMARY =
-      registerSummary("hikaricp_connection_creation_millis", "Connection creation (ms)");
+   private final static Summary ELAPSED_CREATION_SUMMARY =
+      createSummary("hikaricp_connection_creation_millis", "Connection creation (ms)");
+
+   private final static Map<CollectorRegistry, RegistrationStatus> registrationStatuses = new ConcurrentHashMap<>();
+
+   private final String poolName;
+   private final HikariCPCollector hikariCPCollector;
 
    private final Counter.Child connectionTimeoutCounterChild;
 
-   private Summary registerSummary(String name, String help) {
+   private final Summary.Child elapsedAcquiredSummaryChild;
+   private final Summary.Child elapsedUsageSummaryChild;
+   private final Summary.Child elapsedCreationSummaryChild;
+
+   PrometheusMetricsTracker(String poolName, CollectorRegistry collectorRegistry, HikariCPCollector hikariCPCollector) {
+      registerMetrics(collectorRegistry);
+      this.poolName = poolName;
+      this.hikariCPCollector = hikariCPCollector;
+      this.connectionTimeoutCounterChild = CONNECTION_TIMEOUT_COUNTER.labels(poolName);
+      this.elapsedAcquiredSummaryChild = ELAPSED_ACQUIRED_SUMMARY.labels(poolName);
+      this.elapsedUsageSummaryChild = ELAPSED_USAGE_SUMMARY.labels(poolName);
+      this.elapsedCreationSummaryChild = ELAPSED_CREATION_SUMMARY.labels(poolName);
+   }
+
+   private void registerMetrics(CollectorRegistry collectorRegistry) {
+      if (registrationStatuses.putIfAbsent(collectorRegistry, REGISTERED) == null) {
+         CONNECTION_TIMEOUT_COUNTER.register(collectorRegistry);
+         ELAPSED_ACQUIRED_SUMMARY.register(collectorRegistry);
+         ELAPSED_USAGE_SUMMARY.register(collectorRegistry);
+         ELAPSED_CREATION_SUMMARY.register(collectorRegistry);
+      }
+   }
+
+   @Override
+   public void recordConnectionAcquiredNanos(long elapsedAcquiredNanos) {
+      elapsedAcquiredSummaryChild.observe(elapsedAcquiredNanos);
+   }
+
+   @Override
+   public void recordConnectionUsageMillis(long elapsedBorrowedMillis) {
+      elapsedUsageSummaryChild.observe(elapsedBorrowedMillis);
+   }
+
+   @Override
+   public void recordConnectionCreatedMillis(long connectionCreatedMillis) {
+      elapsedCreationSummaryChild.observe(connectionCreatedMillis);
+   }
+
+   @Override
+   public void recordConnectionTimeout() {
+      connectionTimeoutCounterChild.inc();
+   }
+
+   private static Summary createSummary(String name, String help) {
       return Summary.build()
          .name(name)
          .labelNames("pool")
@@ -55,46 +107,12 @@ class PrometheusMetricsTracker implements IMetricsTracker
          .create();
    }
 
-   private final Summary.Child elapsedAcquiredSummaryChild;
-   private final Summary.Child elapsedBorrowedSummaryChild;
-   private final Summary.Child elapsedCreationSummaryChild;
-
-   PrometheusMetricsTracker(String poolName, CollectorRegistry collectorRegistry) {
-      registerMetrics(collectorRegistry);
-      this.connectionTimeoutCounterChild = CONNECTION_TIMEOUT_COUNTER.labels(poolName);
-      this.elapsedAcquiredSummaryChild = ELAPSED_ACQUIRED_SUMMARY.labels(poolName);
-      this.elapsedBorrowedSummaryChild = ELAPSED_BORROWED_SUMMARY.labels(poolName);
-      this.elapsedCreationSummaryChild = ELAPSED_CREATION_SUMMARY.labels(poolName);
-   }
-
-   private void registerMetrics(CollectorRegistry collectorRegistry){
-      CONNECTION_TIMEOUT_COUNTER.register(collectorRegistry);
-      ELAPSED_ACQUIRED_SUMMARY.register(collectorRegistry);
-      ELAPSED_BORROWED_SUMMARY.register(collectorRegistry);
-      ELAPSED_CREATION_SUMMARY.register(collectorRegistry);
-   }
-
    @Override
-   public void recordConnectionAcquiredNanos(long elapsedAcquiredNanos)
-   {
-      elapsedAcquiredSummaryChild.observe(elapsedAcquiredNanos);
-   }
-
-   @Override
-   public void recordConnectionUsageMillis(long elapsedBorrowedMillis)
-   {
-      elapsedBorrowedSummaryChild.observe(elapsedBorrowedMillis);
-   }
-
-   @Override
-   public void recordConnectionCreatedMillis(long connectionCreatedMillis)
-   {
-      elapsedCreationSummaryChild.observe(connectionCreatedMillis);
-   }
-
-   @Override
-   public void recordConnectionTimeout()
-   {
-      connectionTimeoutCounterChild.inc();
+   public void close() {
+      hikariCPCollector.remove(poolName);
+      CONNECTION_TIMEOUT_COUNTER.remove(poolName);
+      ELAPSED_ACQUIRED_SUMMARY.remove(poolName);
+      ELAPSED_USAGE_SUMMARY.remove(poolName);
+      ELAPSED_CREATION_SUMMARY.remove(poolName);
    }
 }

--- a/src/main/java/com/zaxxer/hikari/metrics/prometheus/PrometheusMetricsTrackerFactory.java
+++ b/src/main/java/com/zaxxer/hikari/metrics/prometheus/PrometheusMetricsTrackerFactory.java
@@ -12,33 +12,49 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.zaxxer.hikari.metrics.prometheus;
 
 import com.zaxxer.hikari.metrics.IMetricsTracker;
 import com.zaxxer.hikari.metrics.MetricsTrackerFactory;
 import com.zaxxer.hikari.metrics.PoolStats;
+import io.prometheus.client.Collector;
 import io.prometheus.client.CollectorRegistry;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static com.zaxxer.hikari.metrics.prometheus.PrometheusMetricsTrackerFactory.RegistrationStatus.REGISTERED;
 
 /**
  * <pre>{@code
  * HikariConfig config = new HikariConfig();
  * config.setMetricsTrackerFactory(new PrometheusMetricsTrackerFactory());
  * }</pre>
+ * or
+ * <pre>{@code
+ * config.setMetricsTrackerFactory(new PrometheusMetricsTrackerFactory(new CollectorRegistry()));
+ * }</pre>
  */
 public class PrometheusMetricsTrackerFactory implements MetricsTrackerFactory {
 
-   private HikariCPCollector collector;
+   private final static Map<CollectorRegistry, RegistrationStatus> registrationStatuses = new ConcurrentHashMap<>();
 
-   private CollectorRegistry collectorRegistry;
+   private final HikariCPCollector collector = new HikariCPCollector();
+
+   private final CollectorRegistry collectorRegistry;
+
+   public enum RegistrationStatus {
+      REGISTERED;
+   }
 
    /**
     * Default Constructor. The Hikari metrics are registered to the default
     * collector registry ({@code CollectorRegistry.defaultRegistry}).
     */
    public PrometheusMetricsTrackerFactory() {
-      this.collectorRegistry = CollectorRegistry.defaultRegistry;
+      this(CollectorRegistry.defaultRegistry);
    }
 
    /**
@@ -51,17 +67,14 @@ public class PrometheusMetricsTrackerFactory implements MetricsTrackerFactory {
 
    @Override
    public IMetricsTracker create(String poolName, PoolStats poolStats) {
-      getCollector().add(poolName, poolStats);
-      return new PrometheusMetricsTracker(poolName, this.collectorRegistry);
+      registerCollector(this.collector, this.collectorRegistry);
+      this.collector.add(poolName, poolStats);
+      return new PrometheusMetricsTracker(poolName, this.collectorRegistry, this.collector);
    }
 
-   /**
-    * initialize and register collector if it isn't initialized yet
-    */
-   private HikariCPCollector getCollector() {
-      if (collector == null) {
-         collector = new HikariCPCollector().register(this.collectorRegistry);
+   private void registerCollector(Collector collector, CollectorRegistry collectorRegistry) {
+      if (registrationStatuses.putIfAbsent(collectorRegistry, REGISTERED) == null) {
+         collector.register(collectorRegistry);
       }
-      return collector;
    }
 }

--- a/src/main/java/com/zaxxer/hikari/metrics/prometheus/PrometheusMetricsTrackerFactory.java
+++ b/src/main/java/com/zaxxer/hikari/metrics/prometheus/PrometheusMetricsTrackerFactory.java
@@ -37,7 +37,8 @@ import static com.zaxxer.hikari.metrics.prometheus.PrometheusMetricsTrackerFacto
  * config.setMetricsTrackerFactory(new PrometheusMetricsTrackerFactory(new CollectorRegistry()));
  * }</pre>
  */
-public class PrometheusMetricsTrackerFactory implements MetricsTrackerFactory {
+public class PrometheusMetricsTrackerFactory implements MetricsTrackerFactory
+{
 
    private final static Map<CollectorRegistry, RegistrationStatus> registrationStatuses = new ConcurrentHashMap<>();
 
@@ -45,7 +46,8 @@ public class PrometheusMetricsTrackerFactory implements MetricsTrackerFactory {
 
    private final CollectorRegistry collectorRegistry;
 
-   public enum RegistrationStatus {
+   public enum RegistrationStatus
+   {
       REGISTERED;
    }
 
@@ -53,7 +55,8 @@ public class PrometheusMetricsTrackerFactory implements MetricsTrackerFactory {
     * Default Constructor. The Hikari metrics are registered to the default
     * collector registry ({@code CollectorRegistry.defaultRegistry}).
     */
-   public PrometheusMetricsTrackerFactory() {
+   public PrometheusMetricsTrackerFactory()
+   {
       this(CollectorRegistry.defaultRegistry);
    }
 
@@ -61,18 +64,21 @@ public class PrometheusMetricsTrackerFactory implements MetricsTrackerFactory {
     * Constructor that allows to pass in a {@link CollectorRegistry} to which the
     * Hikari metrics are registered.
     */
-   public PrometheusMetricsTrackerFactory(CollectorRegistry collectorRegistry) {
+   public PrometheusMetricsTrackerFactory(CollectorRegistry collectorRegistry)
+   {
       this.collectorRegistry = collectorRegistry;
    }
 
    @Override
-   public IMetricsTracker create(String poolName, PoolStats poolStats) {
+   public IMetricsTracker create(String poolName, PoolStats poolStats)
+   {
       registerCollector(this.collector, this.collectorRegistry);
       this.collector.add(poolName, poolStats);
       return new PrometheusMetricsTracker(poolName, this.collectorRegistry, this.collector);
    }
 
-   private void registerCollector(Collector collector, CollectorRegistry collectorRegistry) {
+   private void registerCollector(Collector collector, CollectorRegistry collectorRegistry)
+   {
       if (registrationStatuses.putIfAbsent(collectorRegistry, REGISTERED) == null) {
          collector.register(collectorRegistry);
       }

--- a/src/test/java/com/zaxxer/hikari/metrics/dropwizard/CodaHaleMetricsTrackerTest.java
+++ b/src/test/java/com/zaxxer/hikari/metrics/dropwizard/CodaHaleMetricsTrackerTest.java
@@ -1,15 +1,14 @@
 package com.zaxxer.hikari.metrics.dropwizard;
 
-import static org.mockito.Mockito.verify;
-
-import com.zaxxer.hikari.metrics.PoolStats;
+import com.codahale.metrics.MetricRegistry;
+import com.zaxxer.hikari.mocks.StubPoolStats;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import com.codahale.metrics.MetricRegistry;
+import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CodaHaleMetricsTrackerTest {
@@ -21,11 +20,11 @@ public class CodaHaleMetricsTrackerTest {
 
    @Before
    public void setup() {
-      testee = new CodaHaleMetricsTracker("mypool", poolStats(), mockMetricRegistry);
+      testee = new CodaHaleMetricsTracker("mypool", new StubPoolStats(0), mockMetricRegistry);
    }
 
    @Test
-   public void close() throws Exception {
+   public void close() {
       testee.close();
 
       verify(mockMetricRegistry).remove("mypool.pool.Wait");
@@ -38,14 +37,5 @@ public class CodaHaleMetricsTrackerTest {
       verify(mockMetricRegistry).remove("mypool.pool.PendingConnections");
       verify(mockMetricRegistry).remove("mypool.pool.MaxConnections");
       verify(mockMetricRegistry).remove("mypool.pool.MinConnections");
-   }
-
-   private PoolStats poolStats() {
-      return new PoolStats(0) {
-         @Override
-         protected void update() {
-            // do nothing
-         }
-      };
    }
 }

--- a/src/test/java/com/zaxxer/hikari/metrics/dropwizard/CodaHaleMetricsTrackerTest.java
+++ b/src/test/java/com/zaxxer/hikari/metrics/dropwizard/CodaHaleMetricsTrackerTest.java
@@ -11,7 +11,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
-public class CodaHaleMetricsTrackerTest {
+public class CodaHaleMetricsTrackerTest
+{
 
    @Mock
    public MetricRegistry mockMetricRegistry;
@@ -19,12 +20,14 @@ public class CodaHaleMetricsTrackerTest {
    private CodaHaleMetricsTracker testee;
 
    @Before
-   public void setup() {
+   public void setup()
+   {
       testee = new CodaHaleMetricsTracker("mypool", new StubPoolStats(0), mockMetricRegistry);
    }
 
    @Test
-   public void close() {
+   public void close()
+   {
       testee.close();
 
       verify(mockMetricRegistry).remove("mypool.pool.Wait");

--- a/src/test/java/com/zaxxer/hikari/metrics/micrometer/MicrometerMetricsTrackerTest.java
+++ b/src/test/java/com/zaxxer/hikari/metrics/micrometer/MicrometerMetricsTrackerTest.java
@@ -7,19 +7,22 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-public class MicrometerMetricsTrackerTest {
+public class MicrometerMetricsTrackerTest
+{
 
    private MeterRegistry mockMeterRegistry = new SimpleMeterRegistry();
 
    private MicrometerMetricsTracker testee;
 
    @Before
-   public void setup() {
+   public void setup()
+   {
       testee = new MicrometerMetricsTracker("mypool", new StubPoolStats(1000L), mockMeterRegistry);
    }
 
    @Test
-   public void close() {
+   public void close()
+   {
       Assert.assertNotNull(mockMeterRegistry.find("hikaricp.connections.acquire").tag("pool", "mypool").timer());
       Assert.assertNotNull(mockMeterRegistry.find("hikaricp.connections.usage").tag("pool", "mypool").timer());
       Assert.assertNotNull(mockMeterRegistry.find("hikaricp.connections.creation").tag("pool", "mypool").timer());

--- a/src/test/java/com/zaxxer/hikari/metrics/micrometer/MicrometerMetricsTrackerTest.java
+++ b/src/test/java/com/zaxxer/hikari/metrics/micrometer/MicrometerMetricsTrackerTest.java
@@ -1,6 +1,6 @@
 package com.zaxxer.hikari.metrics.micrometer;
 
-import com.zaxxer.hikari.metrics.PoolStats;
+import com.zaxxer.hikari.mocks.StubPoolStats;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.Assert;
@@ -14,17 +14,12 @@ public class MicrometerMetricsTrackerTest {
    private MicrometerMetricsTracker testee;
 
    @Before
-   public void setup(){
-      testee = new MicrometerMetricsTracker("mypool", new PoolStats(1000L) {
-         @Override
-         protected void update() {
-            // nothing
-         }
-      }, mockMeterRegistry);
+   public void setup() {
+      testee = new MicrometerMetricsTracker("mypool", new StubPoolStats(1000L), mockMeterRegistry);
    }
 
    @Test
-   public void close() throws Exception {
+   public void close() {
       Assert.assertNotNull(mockMeterRegistry.find("hikaricp.connections.acquire").tag("pool", "mypool").timer());
       Assert.assertNotNull(mockMeterRegistry.find("hikaricp.connections.usage").tag("pool", "mypool").timer());
       Assert.assertNotNull(mockMeterRegistry.find("hikaricp.connections.creation").tag("pool", "mypool").timer());

--- a/src/test/java/com/zaxxer/hikari/metrics/prometheus/HikariCPCollectorTest.java
+++ b/src/test/java/com/zaxxer/hikari/metrics/prometheus/HikariCPCollectorTest.java
@@ -36,17 +36,20 @@ import com.zaxxer.hikari.mocks.StubConnection;
 
 import io.prometheus.client.CollectorRegistry;
 
-public class HikariCPCollectorTest {
+public class HikariCPCollectorTest
+{
 
    private CollectorRegistry collectorRegistry;
 
    @Before
-   public void setupCollectorRegistry(){
+   public void setupCollectorRegistry()
+   {
       this.collectorRegistry = new CollectorRegistry();
    }
 
    @Test
-   public void noConnection() {
+   public void noConnection()
+   {
       HikariConfig config = newHikariConfig();
       config.setMinimumIdle(0);
       config.setMetricsTrackerFactory(new PrometheusMetricsTrackerFactory(this.collectorRegistry));
@@ -67,7 +70,8 @@ public class HikariCPCollectorTest {
    }
 
    @Test
-   public void noConnectionWithoutPoolName() {
+   public void noConnectionWithoutPoolName()
+   {
       HikariConfig config = new HikariConfig();
       config.setMinimumIdle(0);
       config.setMetricsTrackerFactory(new PrometheusMetricsTrackerFactory(this.collectorRegistry));
@@ -89,7 +93,8 @@ public class HikariCPCollectorTest {
    }
 
    @Test
-   public void connection1() throws Exception {
+   public void connection1() throws Exception
+   {
       HikariConfig config = newHikariConfig();
       config.setMetricsTrackerFactory(new PrometheusMetricsTrackerFactory(this.collectorRegistry));
       config.setDataSourceClassName("com.zaxxer.hikari.mocks.StubDataSource");
@@ -114,7 +119,8 @@ public class HikariCPCollectorTest {
    }
 
    @Test
-   public void connectionClosed() throws Exception {
+   public void connectionClosed() throws Exception
+   {
       HikariConfig config = newHikariConfig();
       config.setMetricsTrackerFactory(new PrometheusMetricsTrackerFactory(this.collectorRegistry));
       config.setDataSourceClassName("com.zaxxer.hikari.mocks.StubDataSource");
@@ -139,7 +145,8 @@ public class HikariCPCollectorTest {
    }
 
    @Test
-   public void poolStatsRemovedAfterShutDown() throws Exception {
+   public void poolStatsRemovedAfterShutDown() throws Exception
+   {
       HikariConfig config = new HikariConfig();
       config.setPoolName("shutDownPool");
       config.setMetricsTrackerFactory(new PrometheusMetricsTrackerFactory(this.collectorRegistry));
@@ -172,7 +179,8 @@ public class HikariCPCollectorTest {
    }
 
    @Test
-   public void testHikariCPCollectorGaugesMetricsInitialization() {
+   public void testHikariCPCollectorGaugesMetricsInitialization()
+   {
       HikariCPCollector hikariCPCollector = new HikariCPCollector();
       hikariCPCollector.add("collectorTestPool", poolStatsWithPredefinedValues());
       List<Collector.MetricFamilySamples> metrics = hikariCPCollector.collect();
@@ -188,13 +196,15 @@ public class HikariCPCollectorTest {
       assertThat(getValue("hikaricp_min_connections", "collectorTestPool"), is(3.0));
    }
 
-   private Double getValue(String name, String poolName) {
+   private Double getValue(String name, String poolName)
+   {
       String[] labelNames = {"pool"};
       String[] labelValues = {poolName};
       return this.collectorRegistry.getSampleValue(name, labelNames, labelValues);
    }
 
-   private PoolStats poolStatsWithPredefinedValues() {
+   private PoolStats poolStatsWithPredefinedValues()
+   {
       return new PoolStats(0) {
          @Override
          protected void update() {

--- a/src/test/java/com/zaxxer/hikari/metrics/prometheus/PrometheusMetricsTrackerFactoryTest.java
+++ b/src/test/java/com/zaxxer/hikari/metrics/prometheus/PrometheusMetricsTrackerFactoryTest.java
@@ -14,15 +14,18 @@ import java.util.List;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-public class PrometheusMetricsTrackerFactoryTest {
+public class PrometheusMetricsTrackerFactoryTest
+{
 
    @After
-   public void clearCollectorRegistry(){
+   public void clearCollectorRegistry()
+   {
       CollectorRegistry.defaultRegistry.clear();
    }
 
    @Test
-   public void registersToProvidedCollectorRegistry() {
+   public void registersToProvidedCollectorRegistry()
+   {
       CollectorRegistry collectorRegistry = new CollectorRegistry();
       PrometheusMetricsTrackerFactory factory = new PrometheusMetricsTrackerFactory(collectorRegistry);
       factory.create("testpool-1", new StubPoolStats(0));
@@ -31,13 +34,15 @@ public class PrometheusMetricsTrackerFactoryTest {
    }
 
    @Test
-   public void registersToDefaultCollectorRegistry() {
+   public void registersToDefaultCollectorRegistry()
+   {
       PrometheusMetricsTrackerFactory factory = new PrometheusMetricsTrackerFactory();
       factory.create("testpool-2", new StubPoolStats(0));
       assertHikariMetricsArePresent(CollectorRegistry.defaultRegistry);
    }
 
-   private void assertHikariMetricsArePresent(CollectorRegistry collectorRegistry) {
+   private void assertHikariMetricsArePresent(CollectorRegistry collectorRegistry)
+   {
       List<String> registeredMetrics = toMetricNames(collectorRegistry.metricFamilySamples());
       assertTrue(registeredMetrics.contains("hikaricp_active_connections"));
       assertTrue(registeredMetrics.contains("hikaricp_idle_connections"));
@@ -47,7 +52,8 @@ public class PrometheusMetricsTrackerFactoryTest {
       assertTrue(registeredMetrics.contains("hikaricp_min_connections"));
    }
 
-   private void assertHikariMetricsAreNotPresent(CollectorRegistry collectorRegistry) {
+   private void assertHikariMetricsAreNotPresent(CollectorRegistry collectorRegistry)
+   {
       List<String> registeredMetrics = toMetricNames(collectorRegistry.metricFamilySamples());
       assertFalse(registeredMetrics.contains("hikaricp_active_connections"));
       assertFalse(registeredMetrics.contains("hikaricp_idle_connections"));
@@ -57,7 +63,8 @@ public class PrometheusMetricsTrackerFactoryTest {
       assertFalse(registeredMetrics.contains("hikaricp_min_connections"));
    }
 
-   private List<String> toMetricNames(Enumeration<Collector.MetricFamilySamples> enumeration) {
+   private List<String> toMetricNames(Enumeration<Collector.MetricFamilySamples> enumeration)
+   {
       List<String> list = new ArrayList<>();
       while (enumeration.hasMoreElements()) {
          list.add(enumeration.nextElement().name);

--- a/src/test/java/com/zaxxer/hikari/metrics/prometheus/PrometheusMetricsTrackerFactoryTest.java
+++ b/src/test/java/com/zaxxer/hikari/metrics/prometheus/PrometheusMetricsTrackerFactoryTest.java
@@ -1,6 +1,7 @@
 package com.zaxxer.hikari.metrics.prometheus;
 
 import com.zaxxer.hikari.metrics.PoolStats;
+import com.zaxxer.hikari.mocks.StubPoolStats;
 import io.prometheus.client.Collector;
 import io.prometheus.client.CollectorRegistry;
 import org.junit.After;
@@ -15,11 +16,16 @@ import static org.junit.Assert.assertTrue;
 
 public class PrometheusMetricsTrackerFactoryTest {
 
+   @After
+   public void clearCollectorRegistry(){
+      CollectorRegistry.defaultRegistry.clear();
+   }
+
    @Test
    public void registersToProvidedCollectorRegistry() {
       CollectorRegistry collectorRegistry = new CollectorRegistry();
       PrometheusMetricsTrackerFactory factory = new PrometheusMetricsTrackerFactory(collectorRegistry);
-      factory.create("testpool-1", poolStats());
+      factory.create("testpool-1", new StubPoolStats(0));
       assertHikariMetricsAreNotPresent(CollectorRegistry.defaultRegistry);
       assertHikariMetricsArePresent(collectorRegistry);
    }
@@ -27,13 +33,8 @@ public class PrometheusMetricsTrackerFactoryTest {
    @Test
    public void registersToDefaultCollectorRegistry() {
       PrometheusMetricsTrackerFactory factory = new PrometheusMetricsTrackerFactory();
-      factory.create("testpool-2", poolStats());
+      factory.create("testpool-2", new StubPoolStats(0));
       assertHikariMetricsArePresent(CollectorRegistry.defaultRegistry);
-   }
-
-   @After
-   public void clearCollectorRegistry(){
-      CollectorRegistry.defaultRegistry.clear();
    }
 
    private void assertHikariMetricsArePresent(CollectorRegistry collectorRegistry) {
@@ -63,14 +64,4 @@ public class PrometheusMetricsTrackerFactoryTest {
       }
       return list;
    }
-
-   private PoolStats poolStats() {
-      return new PoolStats(0) {
-         @Override
-         protected void update() {
-            // do nothing
-         }
-      };
-   }
-
 }

--- a/src/test/java/com/zaxxer/hikari/metrics/prometheus/PrometheusMetricsTrackerTest.java
+++ b/src/test/java/com/zaxxer/hikari/metrics/prometheus/PrometheusMetricsTrackerTest.java
@@ -33,7 +33,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 
-public class PrometheusMetricsTrackerTest {
+public class PrometheusMetricsTrackerTest
+{
 
    private CollectorRegistry defaultCollectorRegistry;
    private CollectorRegistry customCollectorRegistry;
@@ -45,13 +46,15 @@ public class PrometheusMetricsTrackerTest {
    private static final String[] QUANTILE_LABEL_VALUES = new String[]{"0.5", "0.95", "0.99"};
 
    @Before
-   public void setupCollectorRegistry() {
+   public void setupCollectorRegistry()
+   {
       this.defaultCollectorRegistry = new CollectorRegistry();
       this.customCollectorRegistry = new CollectorRegistry();
    }
 
    @Test
-   public void recordConnectionTimeout() throws Exception {
+   public void recordConnectionTimeout() throws Exception
+   {
       HikariConfig config = newHikariConfig();
       config.setMetricsTrackerFactory(new PrometheusMetricsTrackerFactory(defaultCollectorRegistry));
       config.setJdbcUrl("jdbc:h2:mem:");
@@ -76,23 +79,26 @@ public class PrometheusMetricsTrackerTest {
    }
 
    @Test
-   public void connectionAcquisitionMetrics() {
+   public void connectionAcquisitionMetrics()
+   {
       checkSummaryMetricFamily("hikaricp_connection_acquired_nanos");
    }
 
    @Test
-   public void connectionUsageMetrics() {
+   public void connectionUsageMetrics()
+   {
       checkSummaryMetricFamily("hikaricp_connection_usage_millis");
    }
 
    @Test
-   public void connectionCreationMetrics() {
+   public void connectionCreationMetrics()
+   {
       checkSummaryMetricFamily("hikaricp_connection_creation_millis");
    }
 
    @Test
-   public void testMultiplePoolNameWithOneCollectorRegistry() {
-
+   public void testMultiplePoolNameWithOneCollectorRegistry()
+   {
       HikariConfig configFirstPool = newHikariConfig();
       configFirstPool.setMetricsTrackerFactory(new PrometheusMetricsTrackerFactory(defaultCollectorRegistry));
       configFirstPool.setPoolName("first");
@@ -124,8 +130,8 @@ public class PrometheusMetricsTrackerTest {
    }
 
    @Test
-   public void testMultiplePoolNameWithDifferentCollectorRegistries() {
-
+   public void testMultiplePoolNameWithDifferentCollectorRegistries()
+   {
       HikariConfig configFirstPool = newHikariConfig();
       configFirstPool.setMetricsTrackerFactory(new PrometheusMetricsTrackerFactory(defaultCollectorRegistry));
       configFirstPool.setPoolName("first");
@@ -157,8 +163,8 @@ public class PrometheusMetricsTrackerTest {
    }
 
    @Test
-   public void testMetricsRemovedAfterShutDown() {
-
+   public void testMetricsRemovedAfterShutDown()
+   {
       HikariConfig configFirstPool = newHikariConfig();
       configFirstPool.setMetricsTrackerFactory(new PrometheusMetricsTrackerFactory(defaultCollectorRegistry));
       configFirstPool.setPoolName("first");
@@ -197,8 +203,8 @@ public class PrometheusMetricsTrackerTest {
    }
 
    @Test
-   public void testCloseMethod() {
-
+   public void testCloseMethod()
+   {
       String[] labelValues = {"testPool"};
       PrometheusMetricsTrackerFactory prometheusFactory = new PrometheusMetricsTrackerFactory(defaultCollectorRegistry);
       IMetricsTracker prometheusTracker = prometheusFactory.create("testPool", new StubPoolStats(0));
@@ -265,7 +271,8 @@ public class PrometheusMetricsTrackerTest {
          "hikaricp_min_connections", LABEL_NAMES, labelValues));
    }
 
-   private void checkSummaryMetricFamily(String metricName) {
+   private void checkSummaryMetricFamily(String metricName)
+   {
       HikariConfig config = newHikariConfig();
       config.setMetricsTrackerFactory(new PrometheusMetricsTrackerFactory(defaultCollectorRegistry));
       config.setJdbcUrl("jdbc:h2:mem:");

--- a/src/test/java/com/zaxxer/hikari/metrics/prometheus/PrometheusMetricsTrackerTest.java
+++ b/src/test/java/com/zaxxer/hikari/metrics/prometheus/PrometheusMetricsTrackerTest.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.zaxxer.hikari.metrics.prometheus;
 
@@ -28,31 +28,36 @@ import java.sql.SQLTransientConnectionException;
 import static com.zaxxer.hikari.pool.TestElf.newHikariConfig;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 
 public class PrometheusMetricsTrackerTest {
 
-   private CollectorRegistry collectorRegistry;
+   private CollectorRegistry defaultCollectorRegistry;
+   private CollectorRegistry customCollectorRegistry;
 
    private static final String POOL_LABEL_NAME = "pool";
+   private static final String[] LABEL_NAMES = {POOL_LABEL_NAME};
 
    private static final String QUANTILE_LABEL_NAME = "quantile";
    private static final String[] QUANTILE_LABEL_VALUES = new String[]{"0.5", "0.95", "0.99"};
 
+
    @Before
-   public void setupCollectorRegistry(){
-      this.collectorRegistry = new CollectorRegistry();
+   public void setupCollectorRegistry() {
+      this.defaultCollectorRegistry = new CollectorRegistry();
+      this.customCollectorRegistry = new CollectorRegistry();
    }
+
 
    @Test
    public void recordConnectionTimeout() throws Exception {
       HikariConfig config = newHikariConfig();
-      config.setMetricsTrackerFactory(new PrometheusMetricsTrackerFactory(collectorRegistry));
+      config.setMetricsTrackerFactory(new PrometheusMetricsTrackerFactory(defaultCollectorRegistry));
       config.setJdbcUrl("jdbc:h2:mem:");
       config.setMaximumPoolSize(2);
       config.setConnectionTimeout(250);
 
-      String[] labelNames = {POOL_LABEL_NAME};
       String[] labelValues = {config.getPoolName()};
 
       try (HikariDataSource hikariDataSource = new HikariDataSource(config)) {
@@ -63,9 +68,9 @@ public class PrometheusMetricsTrackerTest {
             }
          }
 
-         Double total = collectorRegistry.getSampleValue(
+         Double total = defaultCollectorRegistry.getSampleValue(
             "hikaricp_connection_timeout_total",
-            labelNames,
+            LABEL_NAMES,
             labelValues
          );
          assertThat(total, is(1.0));
@@ -88,63 +93,142 @@ public class PrometheusMetricsTrackerTest {
    }
 
    @Test
-   public void testMultiplePoolName() throws Exception {
-      String[] labelNames = {POOL_LABEL_NAME};
+   public void testMultiplePoolNameWithOneCollectorRegistry() {
 
-      HikariConfig config = newHikariConfig();
-      config.setMetricsTrackerFactory(new PrometheusMetricsTrackerFactory(collectorRegistry));
-      config.setPoolName("first");
-      config.setJdbcUrl("jdbc:h2:mem:");
-      config.setMaximumPoolSize(2);
-      config.setConnectionTimeout(250);
-      String[] labelValues1 = {config.getPoolName()};
+      HikariConfig configFirstPool = newHikariConfig();
+      configFirstPool.setMetricsTrackerFactory(new PrometheusMetricsTrackerFactory(defaultCollectorRegistry));
+      configFirstPool.setPoolName("first");
+      configFirstPool.setJdbcUrl("jdbc:h2:mem:");
+      configFirstPool.setMaximumPoolSize(2);
+      configFirstPool.setConnectionTimeout(250);
 
-      try (HikariDataSource ignored = new HikariDataSource(config)) {
-         assertThat(collectorRegistry.getSampleValue(
+      HikariConfig configSecondPool = newHikariConfig();
+      configSecondPool.setMetricsTrackerFactory(new PrometheusMetricsTrackerFactory(defaultCollectorRegistry));
+      configSecondPool.setPoolName("second");
+      configSecondPool.setJdbcUrl("jdbc:h2:mem:");
+      configSecondPool.setMaximumPoolSize(4);
+      configSecondPool.setConnectionTimeout(250);
+
+      String[] labelValuesFirstPool = {configFirstPool.getPoolName()};
+      String[] labelValuesSecondPool = {configSecondPool.getPoolName()};
+
+      try (HikariDataSource ignoredFirstPool = new HikariDataSource(configFirstPool)) {
+         assertThat(defaultCollectorRegistry.getSampleValue(
             "hikaricp_connection_timeout_total",
-            labelNames,
-            labelValues1), is(0.0));
+            LABEL_NAMES,
+            labelValuesFirstPool), is(0.0));
 
-         CollectorRegistry collectorRegistry2 = new CollectorRegistry();
-         HikariConfig config2 = newHikariConfig();
-         config2.setMetricsTrackerFactory(new PrometheusMetricsTrackerFactory(collectorRegistry2));
-         config2.setPoolName("second");
-         config2.setJdbcUrl("jdbc:h2:mem:");
-         config2.setMaximumPoolSize(4);
-         config2.setConnectionTimeout(250);
-         String[] labelValues2 = {config2.getPoolName()};
-
-         try (HikariDataSource ignored2 = new HikariDataSource(config2)) {
-            assertThat(collectorRegistry2.getSampleValue(
+         try (HikariDataSource ignoredSecondPool = new HikariDataSource(configSecondPool)) {
+            assertThat(defaultCollectorRegistry.getSampleValue(
                "hikaricp_connection_timeout_total",
-               labelNames,
-               labelValues2), is(0.0));
+               LABEL_NAMES,
+               labelValuesSecondPool), is(0.0));
          }
+      }
+   }
+
+   @Test
+   public void testMultiplePoolNameWithDifferentCollectorRegistries() {
+
+      HikariConfig configFirstPool = newHikariConfig();
+      configFirstPool.setMetricsTrackerFactory(new PrometheusMetricsTrackerFactory(defaultCollectorRegistry));
+      configFirstPool.setPoolName("first");
+      configFirstPool.setJdbcUrl("jdbc:h2:mem:");
+      configFirstPool.setMaximumPoolSize(2);
+      configFirstPool.setConnectionTimeout(250);
+
+      HikariConfig configSecondPool = newHikariConfig();
+      configSecondPool.setMetricsTrackerFactory(new PrometheusMetricsTrackerFactory(customCollectorRegistry));
+      configSecondPool.setPoolName("second");
+      configSecondPool.setJdbcUrl("jdbc:h2:mem:");
+      configSecondPool.setMaximumPoolSize(4);
+      configSecondPool.setConnectionTimeout(250);
+
+      String[] labelValuesFirstPool = {configFirstPool.getPoolName()};
+      String[] labelValuesSecondPool = {configSecondPool.getPoolName()};
+
+      try (HikariDataSource ignoredFirstPool = new HikariDataSource(configFirstPool)) {
+         assertThat(defaultCollectorRegistry.getSampleValue(
+            "hikaricp_connection_timeout_total",
+            LABEL_NAMES,
+            labelValuesFirstPool), is(0.0));
+
+         try (HikariDataSource ignoredSecondPool = new HikariDataSource(configSecondPool)) {
+            assertThat(customCollectorRegistry.getSampleValue(
+               "hikaricp_connection_timeout_total",
+               LABEL_NAMES,
+               labelValuesSecondPool), is(0.0));
+         }
+      }
+   }
+
+   @Test
+   public void testMetricsRemovedAfterShutDown() {
+
+      HikariConfig configFirstPool = newHikariConfig();
+      configFirstPool.setMetricsTrackerFactory(new PrometheusMetricsTrackerFactory(defaultCollectorRegistry));
+      configFirstPool.setPoolName("first");
+      configFirstPool.setJdbcUrl("jdbc:h2:mem:");
+      configFirstPool.setMaximumPoolSize(2);
+      configFirstPool.setConnectionTimeout(250);
+
+      HikariConfig configSecondPool = newHikariConfig();
+      configSecondPool.setMetricsTrackerFactory(new PrometheusMetricsTrackerFactory(customCollectorRegistry));
+      configSecondPool.setPoolName("second");
+      configSecondPool.setJdbcUrl("jdbc:h2:mem:");
+      configSecondPool.setMaximumPoolSize(4);
+      configSecondPool.setConnectionTimeout(250);
+
+      String[] labelValuesFirstPool = {configFirstPool.getPoolName()};
+      String[] labelValuesSecondPool = {configSecondPool.getPoolName()};
+
+      try (HikariDataSource ignoredFirstPool = new HikariDataSource(configFirstPool)) {
+         assertThat(defaultCollectorRegistry.getSampleValue(
+            "hikaricp_connection_timeout_total",
+            LABEL_NAMES,
+            labelValuesFirstPool), is(0.0));
+
+         try (HikariDataSource ignoredSecondPool = new HikariDataSource(configSecondPool)) {
+            assertThat(customCollectorRegistry.getSampleValue(
+               "hikaricp_connection_timeout_total",
+               LABEL_NAMES,
+               labelValuesSecondPool), is(0.0));
+         }
+
+         assertNull(defaultCollectorRegistry.getSampleValue(
+            "hikaricp_connection_timeout_total",
+            LABEL_NAMES,
+            labelValuesSecondPool));
+
+         assertThat(defaultCollectorRegistry.getSampleValue(
+            "hikaricp_connection_timeout_total",
+            LABEL_NAMES,
+            labelValuesFirstPool), is(0.0));
       }
    }
 
    private void checkSummaryMetricFamily(String metricName) {
       HikariConfig config = newHikariConfig();
-      config.setMetricsTrackerFactory(new PrometheusMetricsTrackerFactory(collectorRegistry));
+      config.setMetricsTrackerFactory(new PrometheusMetricsTrackerFactory(defaultCollectorRegistry));
       config.setJdbcUrl("jdbc:h2:mem:");
 
       try (HikariDataSource ignored = new HikariDataSource(config)) {
-         Double count = collectorRegistry.getSampleValue(
+         Double count = defaultCollectorRegistry.getSampleValue(
             metricName + "_count",
-            new String[]{POOL_LABEL_NAME},
+            LABEL_NAMES,
             new String[]{config.getPoolName()}
          );
          assertNotNull(count);
 
-         Double sum = collectorRegistry.getSampleValue(
+         Double sum = defaultCollectorRegistry.getSampleValue(
             metricName + "_sum",
-            new String[]{POOL_LABEL_NAME},
+            LABEL_NAMES,
             new String[]{config.getPoolName()}
          );
          assertNotNull(sum);
 
          for (String quantileLabelValue : QUANTILE_LABEL_VALUES) {
-            Double quantileValue = collectorRegistry.getSampleValue(
+            Double quantileValue = defaultCollectorRegistry.getSampleValue(
                metricName,
                new String[]{POOL_LABEL_NAME, QUANTILE_LABEL_NAME},
                new String[]{config.getPoolName(), quantileLabelValue}

--- a/src/test/java/com/zaxxer/hikari/mocks/StubPoolStats.java
+++ b/src/test/java/com/zaxxer/hikari/mocks/StubPoolStats.java
@@ -1,0 +1,17 @@
+package com.zaxxer.hikari.mocks;
+
+import com.zaxxer.hikari.metrics.PoolStats;
+
+public class StubPoolStats extends PoolStats {
+
+   public StubPoolStats(long timeoutMs) {
+      super(timeoutMs);
+   }
+
+   @Override
+   protected void update() {
+      // Do nothing
+   }
+
+
+}

--- a/src/test/java/com/zaxxer/hikari/mocks/StubPoolStats.java
+++ b/src/test/java/com/zaxxer/hikari/mocks/StubPoolStats.java
@@ -2,14 +2,17 @@ package com.zaxxer.hikari.mocks;
 
 import com.zaxxer.hikari.metrics.PoolStats;
 
-public class StubPoolStats extends PoolStats {
+public class StubPoolStats extends PoolStats
+{
 
-   public StubPoolStats(long timeoutMs) {
+   public StubPoolStats(long timeoutMs)
+   {
       super(timeoutMs);
    }
 
    @Override
-   protected void update() {
+   protected void update()
+   {
       // Do nothing
    }
 


### PR DESCRIPTION
Changes:
* Fix "Collector already registered that provides name: hikaricp_connection_timeout_total" error
* Register only one `HikariCPCollector` instance in one `CollectorRegistry` instance
* Add ability to remove metrics when connection pool is shutting down
* Refactor/add unit tests - metrics package

Unfortunately in this PR https://github.com/brettwooldridge/HikariCP/pull/1182 together with the changes was introduced a bug which is preventing of use more than one connection pool with the same collector registry, error example:
```
java.lang.IllegalArgumentException: Collector already registered that provides name: hikaricp_connection_timeout_total
	at io.prometheus.client.CollectorRegistry.register(CollectorRegistry.java:54)
	at io.prometheus.client.Collector.register(Collector.java:139)
	at com.zaxxer.hikari.metrics.prometheus.PrometheusMetricsTracker.registerMetrics(PrometheusMetricsTracker.java:71)
	at com.zaxxer.hikari.metrics.prometheus.PrometheusMetricsTracker.<init>(PrometheusMetricsTracker.java:63)
	at com.zaxxer.hikari.metrics.prometheus.PrometheusMetricsTrackerFactory.create(PrometheusMetricsTrackerFactory.java:55)
	at com.zaxxer.hikari.pool.HikariPool.setMetricsTrackerFactory(HikariPool.java:308)
	at com.zaxxer.hikari.pool.HikariPool.<init>(HikariPool.java:118)
	at com.zaxxer.hikari.HikariDataSource.<init>(HikariDataSource.java:81)
```
The reason of it is a creation of more than on summaries and counter collectors with the same metrics names and attempt to register them into the same collector registries, when we have multiple connection pools.
https://github.com/brettwooldridge/HikariCP/pull/1182/files#diff-18f1b1ed36d7ad9a6057e160ad0d81faL33
https://github.com/brettwooldridge/HikariCP/pull/1182/files#diff-18f1b1ed36d7ad9a6057e160ad0d81faL36
https://github.com/brettwooldridge/HikariCP/pull/1182/files#diff-18f1b1ed36d7ad9a6057e160ad0d81faL39
https://github.com/brettwooldridge/HikariCP/pull/1182/files#diff-18f1b1ed36d7ad9a6057e160ad0d81faL44
https://github.com/brettwooldridge/HikariCP/pull/1182/files#diff-18f1b1ed36d7ad9a6057e160ad0d81faL54

Apart of that I've added ability to deregister metrics collectors when collector pool is shutting down.

Please have a look. Your comments are welcome!