### PR TITLE
Modified "Make HikariConfig able to retrieve passwords dynamically from a password supplier"

### DIFF
--- a/src/test/java/com/zaxxer/hikari/HikariConfigTest.java
+++ b/src/test/java/com/zaxxer/hikari/HikariConfigTest.java
@@ -1,0 +1,60 @@
+package com.zaxxer.hikari;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+public class HikariConfigTest {
+   @Test
+   public void getPasswordReturnsPasswordFromSupplier() {
+      HikariConfig config = new HikariConfig();
+      config.setPasswordSupplier(() -> "supplied-password");
+
+      String password = config.getPassword();
+
+      assertThat(password, is(equalTo("supplied-password")));
+   }
+
+   @Test
+   public void getPasswordReturnsDefaultPassword() {
+      HikariConfig config = new HikariConfig();
+      config.setPassword("default-password");
+
+      String password = config.getPassword();
+
+      assertThat(password, is(equalTo("default-password")));
+   }
+
+   @Test(expected = IllegalStateException.class)
+   public void setPasswordThrowsExceptionWhenSupplierWasProvided() {
+      HikariConfig config = new HikariConfig();
+      config.setPasswordSupplier(() -> "supplied-password");
+
+      config.setPassword("default-password");
+
+      fail("Should have thrown exception");
+   }
+
+   @Test
+   public void changePasswordSupplierReturnsNewPassword() {
+      HikariConfig config = new HikariConfig();
+      config.setPassword("default-password");
+
+      config.setPasswordSupplier(() -> "supplied-password");
+      String password = config.getPassword();
+
+      assertThat(password, is(equalTo("supplied-password")));
+   }
+
+   @Test
+   public void getPasswordWithoutSupplierReturnsNull() {
+      HikariConfig config = new HikariConfig();
+
+      String password = config.getPassword();
+
+      assertThat(password, is(equalTo(null)));
+   }
+}


### PR DESCRIPTION
It's a modified PR from https://github.com/brettwooldridge/HikariCP/pull/1196/files. To avoid maintaining password and password supplier both together, this PR makes password setting more generic. Try to keep the simplicity while adding more extensibility for more db settings