### PR TITLE
Improve message about failed setLoginTimeout by showing exception type

### DIFF
--- a/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
+++ b/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
@@ -610,7 +610,7 @@ abstract class PoolBase
             dataSource.setLoginTimeout(Math.max(1, (int) MILLISECONDS.toSeconds(500L + connectionTimeout)));
          }
          catch (Exception e) {
-            logger.info("{} - Failed to set login timeout for data source. ({})", poolName, e.getMessage());
+            logger.info("{} - Failed to set login timeout for data source. ({})", poolName, e.toString());
          }
       }
    }


### PR DESCRIPTION
Current message about failing setLoginTimeout can be confusing.
For example when using Spring [AbstractDataSource](https://github.com/spring-projects/spring-framework/blob/master/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/AbstractDataSource.java) - message in logs will looks like this:
```
Failed to set login timeout for data source. (setLoginTimeout)
```
From this message it's very hard to understand what was cause of failing method.
I propose to replace `e.getMessage()` with `e.toString()` because `toString` will print exception class name too. And log will look like this:
```
Failed to set login timeout for data source. (java.lang.UnsupportedOperationException: setLoginTimeout)
```