### PR TITLE
Load hikari config properties file from classpath.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,8 @@
 HikariCP Changes
 
+Changes in 3.3.2
+ * load hikari properties file from classpath
+
 Changes in 3.3.1
 
  * fixed 1287 set core pool size before max pool size

--- a/src/main/java/com/zaxxer/hikari/HikariConfig.java
+++ b/src/main/java/com/zaxxer/hikari/HikariConfig.java
@@ -137,7 +137,7 @@ public class HikariConfig implements HikariConfigMXBean
    /**
     * Construct a HikariConfig from the specified property file name.  <code>propertyFileName</code>
     * will first be treated as a path in the file-system, and if that fails the
-    * Class.getResourceAsStream(propertyFileName) will be tried.
+    * ClassLoader.getResourceAsStream(propertyFileName) will be tried.
     *
     * @param propertyFileName the name of the property file
     */
@@ -1060,7 +1060,7 @@ public class HikariConfig implements HikariConfigMXBean
    private void loadProperties(String propertyFileName)
    {
       final File propFile = new File(propertyFileName);
-      try (final InputStream is = propFile.isFile() ? new FileInputStream(propFile) : this.getClass().getResourceAsStream(propertyFileName)) {
+      try (final InputStream is = propFile.isFile() ? new FileInputStream(propFile) : this.getClass().getClassLoader().getResourceAsStream(propertyFileName)) {
          if (is != null) {
             Properties props = new Properties();
             props.load(is);

--- a/src/test/java/com/zaxxer/hikari/pool/TestValidation.java
+++ b/src/test/java/com/zaxxer/hikari/pool/TestValidation.java
@@ -37,9 +37,16 @@ public class TestValidation
    @Test
    public void validateLoadProperties()
    {
-      System.setProperty("hikaricp.configurationFile", "/propfile1.properties");
+      System.setProperty("hikaricp.configurationFile", "propfile1.properties");
       HikariConfig config = newHikariConfig();
       System.clearProperty("hikaricp.configurationFile");
+      assertEquals(5, config.getMinimumIdle());
+   }
+
+   @Test
+   public void validateLoadPropertiesFromFile()
+   {
+      HikariConfig config = new HikariConfig("propfile1.properties");
       assertEquals(5, config.getMinimumIdle());
    }
 


### PR DESCRIPTION
If one prefers load properties file from classpath, this(with a slash at the beginning) can be wired:
```
HikariConfig hikariConfig = new HikariConfig("/hikari.config.properties");
```
However, use `ClassLoader.getResourceAsStream` rather than `Class.getResourceAsStream`, the code makes sense:
```
HikariConfig hikariConfig = new HikariConfig("hikari.config.properties");
```