### PR TITLE
Fixing initializationFailTimeout.

### DIFF
--- a/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
+++ b/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
@@ -572,16 +572,10 @@ public final class HikariPool extends PoolBase implements HikariPoolMXBean, IBag
             return;
          }
 
-         if (getLastConnectionFailure() instanceof ConnectionSetupException) {
-            throwPoolInitializationException(getLastConnectionFailure().getCause());
-         }
-
          quietlySleep(SECONDS.toMillis(1));
       } while (elapsedMillis(startTime) < initializationTimeout);
 
-      if (initializationTimeout > 0) {
-         throwPoolInitializationException(getLastConnectionFailure());
-      }
+      throwPoolInitializationException(getLastConnectionFailure());
    }
 
    /**

--- a/src/test/java/com/zaxxer/hikari/pool/TestConnections.java
+++ b/src/test/java/com/zaxxer/hikari/pool/TestConnections.java
@@ -27,7 +27,9 @@ import org.apache.logging.log4j.Level;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
+import javax.sql.DataSource;
 import java.sql.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -36,6 +38,7 @@ import static com.zaxxer.hikari.pool.TestElf.*;
 import static com.zaxxer.hikari.util.UtilityElf.quietlySleep;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.*;
+import static org.mockito.BDDMockito.given;
 
 /**
  * @author Brett Wooldridge
@@ -536,6 +539,28 @@ public class TestConnections
    }
 
    @Test
+   public void testInitializationFailTimeout() throws SQLException
+   {
+      Connection connection = Mockito.mock(Connection.class);
+
+      DataSource dataSource = Mockito.mock(DataSource.class);
+      given(dataSource.getConnection())
+         .willThrow(new SQLException("Simulated exception in getConnection()"))
+         .willReturn(connection);
+
+      HikariConfig config = newHikariConfig();
+      config.setMinimumIdle(1);
+      config.setMaximumPoolSize(2);
+      config.setConnectionTimeout(TimeUnit.SECONDS.toMillis(3));
+      config.setInitializationFailTimeout(TimeUnit.SECONDS.toMillis(2));
+      config.setDataSource(dataSource);
+
+      try (HikariDataSource ds = new HikariDataSource(config)) {
+         assertSame(ds.getConnection().unwrap(Connection.class), connection);
+      }
+   }
+
+   @Test
    public void testInitializationFailure1()
    {
       StubDataSource stubDataSource = new StubDataSource();
@@ -551,7 +576,7 @@ public class TestConnections
          try (Connection ignored = ds.getConnection()) {
             fail("Initialization should have failed");
          }
-         catch (SQLException e) {
+         catch (PoolInitializationException | SQLException e) {
             // passed
          }
       }
@@ -615,7 +640,7 @@ public class TestConnections
          }
       }
       catch (PoolInitializationException e) {
-         assertSame("Simulated exception in createStatement()", e.getCause().getMessage());
+         assertEquals("java.sql.SQLException: Simulated exception in createStatement()", e.getCause().getMessage());
       }
 
       config.setInitializationFailTimeout(0);


### PR DESCRIPTION
An attempt to fix `initializationFailTimeout` which does not work since 3.3.0 after [this change](https://github.com/brettwooldridge/HikariCP/blob/c509ec1a3f1e19769ee69323972f339cf098ff4b/src/main/java/com/zaxxer/hikari/pool/HikariPool.java#L494).