### PR TITLE
Change the thread pool size to minimumIdle on blocked initialization

### DIFF
--- a/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
+++ b/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
@@ -137,7 +137,7 @@ public final class HikariPool extends PoolBase implements HikariPoolMXBean, IBag
       this.houseKeeperTask = houseKeepingExecutorService.scheduleWithFixedDelay(new HouseKeeper(), 100L, housekeepingPeriodMs, MILLISECONDS);
 
       if (Boolean.getBoolean("com.zaxxer.hikari.blockUntilFilled") && config.getInitializationFailTimeout() > 1) {
-         addConnectionExecutor.setCorePoolSize(Runtime.getRuntime().availableProcessors());
+         addConnectionExecutor.setCorePoolSize(config.getMinimumIdle());
          addConnectionExecutor.setMaximumPoolSize(Runtime.getRuntime().availableProcessors());
 
          final long startTime = currentTime();


### PR DESCRIPTION
Update addConnectionExecutor core pool size from available processors to minimum idle connections configured for performance improvement.

Link to issue [Change the thread pool size to minimumIdle on blocked initialization](https://github.com/brettwooldridge/HikariCP/issues/1375)