### PR TITLE
Flush ObjectStream before calling toByteArray on underlying ByteArrayOutputStream

### DIFF
--- a/src/test/java/com/zaxxer/hikari/pool/TestConcurrentBag.java
+++ b/src/test/java/com/zaxxer/hikari/pool/TestConcurrentBag.java
@@ -92,6 +92,7 @@ public class TestConcurrentBag
          bag.requite(reserved);
    
          bag.remove(notinuse);
+         ps.flush();
          assertTrue(new String(baos.toByteArray()).contains("not borrowed or reserved"));
    
          bag.unreserve(notinuse);

--- a/src/test/java/com/zaxxer/hikari/pool/TestValidation.java
+++ b/src/test/java/com/zaxxer/hikari/pool/TestValidation.java
@@ -161,6 +161,7 @@ public class TestValidation
       config.setMinimumIdle(5);
       config.setIdleTimeout(TimeUnit.SECONDS.toMillis(5));
       config.validate();
+      ps.flush();
       assertTrue(new String(baos.toByteArray()).contains("less than 10000ms"));
    }
 
@@ -178,6 +179,7 @@ public class TestValidation
       config.setIdleTimeout(TimeUnit.MINUTES.toMillis(3));
       config.validate();
 
+      ps.flush();
       String s = new String(baos.toByteArray());
       assertTrue("idleTimeout is close to or more than maxLifetime, disabling it." + s + "*", s.contains("is close to or more than maxLifetime"));
    }


### PR DESCRIPTION
When an `ObjectStream` instance wraps an underlying `ByteArrayOutputStream` instance, it is recommended to flush or close the `ObjectStream` before invoking the underlying instances's `toByteArray()`.
It is good practice to call `flush`/`close` explicitly as mentioned, for example, [here](http://stackoverflow.com/questions/2984538/how-to-use-bytearrayoutputstream-and-dataoutputstream-simultaneously-java).
This pull request adds a call to the `flush` method before calls to the `toByteArray` methods.