### PR TITLE
Make HikariConfig able to retrieve passwords dynamically from a password supplier

### DIFF
--- a/src/main/java/com/zaxxer/hikari/HikariConfig.java
+++ b/src/main/java/com/zaxxer/hikari/HikariConfig.java
@@ -39,6 +39,7 @@ import java.util.TreeSet;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Supplier;
 
 import static com.zaxxer.hikari.util.UtilityElf.getNullIfEmpty;
 import static com.zaxxer.hikari.util.UtilityElf.safeIsAssignableFrom;
@@ -48,6 +49,19 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 @SuppressWarnings({"SameParameterValue", "unused"})
 public class HikariConfig implements HikariConfigMXBean
 {
+   // Password supplier to use when the password is set directly to the configuration instance.
+   private static class StringPasswordSupplier implements Supplier<String> {
+      private final String password;
+
+      public StringPasswordSupplier(String password) {
+         this.password = password;
+      }
+
+      @Override public String get() {
+         return password;
+      }
+   }
+
    private static final Logger LOGGER = LoggerFactory.getLogger(HikariConfig.class);
 
    private static final char[] ID_CHARACTERS = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ".toCharArray();
@@ -70,7 +84,7 @@ public class HikariConfig implements HikariConfigMXBean
    private volatile int maxPoolSize;
    private volatile int minIdle;
    private volatile String username;
-   private volatile String password;
+   private volatile Supplier<String> passwordSupplier = new StringPasswordSupplier(null);
 
    // Properties NOT changeable at runtime
    //
@@ -269,12 +283,33 @@ public class HikariConfig implements HikariConfigMXBean
    }
 
    /**
+    * Get the password supplier to use to provide the password for DataSource.getConnection(user, password) calls.
+    * @return the password supplier or null if there is no supplier or the password has been set directly.
+    */
+   public Supplier<String> getPasswordSupplier()
+   {
+      return (passwordSupplier instanceof StringPasswordSupplier) ? null : passwordSupplier;
+   }
+
+   /**
+    * Set the password supplier to use for DataSource.getConnection(username, password) calls.
+    * @param passwordSupplier the password supplier
+    */
+   public void setPasswordSupplier(Supplier<String> passwordSupplier)
+   {
+      if (passwordSupplier == null) {
+         throw new IllegalArgumentException("passwordSupplier cannot be null");
+      }
+      this.passwordSupplier = passwordSupplier;
+   }
+
+   /**
     * Get the default password to use for DataSource.getConnection(username, password) calls.
     * @return the password
     */
    public String getPassword()
    {
-      return password;
+      return passwordSupplier.get();
    }
 
    /**
@@ -284,7 +319,7 @@ public class HikariConfig implements HikariConfigMXBean
    @Override
    public void setPassword(String password)
    {
-      this.password = password;
+      setPasswordSupplier(new StringPasswordSupplier(password));
    }
 
    /**

--- a/src/test/java/com/zaxxer/hikari/TestHikariConfig.java
+++ b/src/test/java/com/zaxxer/hikari/TestHikariConfig.java
@@ -1,0 +1,56 @@
+/*
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.zaxxer.hikari;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.function.Supplier;
+
+public class TestHikariConfig {
+
+   @Test
+   public void testPasswordAsString()
+   {
+      // default password NULL
+      HikariConfig config = new HikariConfig();
+      Assert.assertNull(config.getPassword());
+      Assert.assertNull(config.getPasswordSupplier());
+
+      // set password NULL
+      config = new HikariConfig();
+      config.setPassword(null);
+      Assert.assertNull(config.getPassword());
+      Assert.assertNull(config.getPasswordSupplier());
+
+      // set password value
+      config = new HikariConfig();
+      config.setPassword("password");
+      Assert.assertEquals("password", config.getPassword());
+      Assert.assertNull(config.getPasswordSupplier());
+   }
+
+   @Test
+   public void testPasswordAsSupplier()
+   {
+      HikariConfig config = new HikariConfig();
+      Supplier<String> supplier = () -> "password";
+      config.setPasswordSupplier(supplier);
+      Assert.assertEquals("password", config.getPassword());
+      Assert.assertEquals(supplier, config.getPasswordSupplier());
+   }
+
+}


### PR DESCRIPTION
#1196 
----
Adds a passwordSupplier property with setter and getter
Refactors the password property to use a built-in passwordSupplier
If setting the password directly, the passwordSupplier property returns NULL
----

This pull request addresses the changes requested by Brett.

My particular use case is using Hashicorp Vault to manage MySQL account passwords... Performing a rotation of the MySQL account passwords in Vault would push the new password to MySQL, the existing connections (created with the old password) will be closed, then Hikari will try to obtain new connections and for that it will call the supplier that will fetch the new password from Vault.

Regarding the issue about the supplier making frequent calls to the system where the password is stored, in our case Vault, calls will be made only when needing to create a new connection, which would typically happen on startup of when an existing connection fails. Said that is up to the supplier implementation to try to be nice by caching if that is acceptable in the specific use case.

