### PR TITLE
Prevent PrometheusHistogramMetricsTracker from registering metrics twice in the same CollectorRegistry

### DIFF
--- a/src/main/java/com/zaxxer/hikari/metrics/prometheus/PrometheusHistogramMetricsTrackerFactory.java
+++ b/src/main/java/com/zaxxer/hikari/metrics/prometheus/PrometheusHistogramMetricsTrackerFactory.java
@@ -27,7 +27,8 @@ import io.prometheus.client.CollectorRegistry;
  * config.setMetricsTrackerFactory(new PrometheusHistogramMetricsTrackerFactory());
  * }</pre>
  */
-public class PrometheusHistogramMetricsTrackerFactory implements MetricsTrackerFactory {
+public class PrometheusHistogramMetricsTrackerFactory implements MetricsTrackerFactory
+{
 
    private HikariCPCollector collector;
 
@@ -50,7 +51,8 @@ public class PrometheusHistogramMetricsTrackerFactory implements MetricsTrackerF
    }
 
    @Override
-   public IMetricsTracker create(String poolName, PoolStats poolStats) {
+   public IMetricsTracker create(String poolName, PoolStats poolStats)
+   {
       getCollector().add(poolName, poolStats);
       return new PrometheusHistogramMetricsTracker(poolName, this.collectorRegistry);
    }
@@ -58,7 +60,8 @@ public class PrometheusHistogramMetricsTrackerFactory implements MetricsTrackerF
    /**
     * initialize and register collector if it isn't initialized yet
     */
-   private HikariCPCollector getCollector() {
+   private HikariCPCollector getCollector()
+   {
       if (collector == null) {
          collector = new HikariCPCollector().register(this.collectorRegistry);
       }

--- a/src/test/java/com/zaxxer/hikari/metrics/prometheus/PrometheusHistogramMetricsTrackerFactoryTest.java
+++ b/src/test/java/com/zaxxer/hikari/metrics/prometheus/PrometheusHistogramMetricsTrackerFactoryTest.java
@@ -1,6 +1,6 @@
 package com.zaxxer.hikari.metrics.prometheus;
 
-import com.zaxxer.hikari.metrics.PoolStats;
+import com.zaxxer.hikari.mocks.StubPoolStats;
 import io.prometheus.client.Collector;
 import io.prometheus.client.CollectorRegistry;
 import org.junit.After;
@@ -13,31 +13,35 @@ import java.util.List;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-public class PrometheusHistogramMetricsTrackerFactoryTest {
+public class PrometheusHistogramMetricsTrackerFactoryTest
+{
+
+   @After
+   public void clearCollectorRegistry()
+   {
+      CollectorRegistry.defaultRegistry.clear();
+   }
 
    @Test
-   public void registersToProvidedCollectorRegistry() {
+   public void registersToProvidedCollectorRegistry()
+   {
       CollectorRegistry collectorRegistry = new CollectorRegistry();
-      PrometheusHistogramMetricsTrackerFactory factory =
-         new PrometheusHistogramMetricsTrackerFactory(collectorRegistry);
-      factory.create("testpool-1", poolStats());
+      PrometheusHistogramMetricsTrackerFactory factory = new PrometheusHistogramMetricsTrackerFactory(collectorRegistry);
+      factory.create("testpool-1", new StubPoolStats(0));
       assertHikariMetricsAreNotPresent(CollectorRegistry.defaultRegistry);
       assertHikariMetricsArePresent(collectorRegistry);
    }
 
    @Test
-   public void registersToDefaultCollectorRegistry() {
+   public void registersToDefaultCollectorRegistry()
+   {
       PrometheusHistogramMetricsTrackerFactory factory = new PrometheusHistogramMetricsTrackerFactory();
-      factory.create("testpool-2", poolStats());
+      factory.create("testpool-2", new StubPoolStats(0));
       assertHikariMetricsArePresent(CollectorRegistry.defaultRegistry);
    }
 
-   @After
-   public void clearCollectorRegistry(){
-      CollectorRegistry.defaultRegistry.clear();
-   }
-
-   private void assertHikariMetricsArePresent(CollectorRegistry collectorRegistry) {
+   private void assertHikariMetricsArePresent(CollectorRegistry collectorRegistry)
+   {
       List<String> registeredMetrics = toMetricNames(collectorRegistry.metricFamilySamples());
       assertTrue(registeredMetrics.contains("hikaricp_active_connections"));
       assertTrue(registeredMetrics.contains("hikaricp_idle_connections"));
@@ -47,7 +51,8 @@ public class PrometheusHistogramMetricsTrackerFactoryTest {
       assertTrue(registeredMetrics.contains("hikaricp_min_connections"));
    }
 
-   private void assertHikariMetricsAreNotPresent(CollectorRegistry collectorRegistry) {
+   private void assertHikariMetricsAreNotPresent(CollectorRegistry collectorRegistry)
+   {
       List<String> registeredMetrics = toMetricNames(collectorRegistry.metricFamilySamples());
       assertFalse(registeredMetrics.contains("hikaricp_active_connections"));
       assertFalse(registeredMetrics.contains("hikaricp_idle_connections"));
@@ -57,21 +62,12 @@ public class PrometheusHistogramMetricsTrackerFactoryTest {
       assertFalse(registeredMetrics.contains("hikaricp_min_connections"));
    }
 
-   private List<String> toMetricNames(Enumeration<Collector.MetricFamilySamples> enumeration) {
+   private List<String> toMetricNames(Enumeration<Collector.MetricFamilySamples> enumeration)
+   {
       List<String> list = new ArrayList<>();
       while (enumeration.hasMoreElements()) {
          list.add(enumeration.nextElement().name);
       }
       return list;
    }
-
-   private PoolStats poolStats() {
-      return new PoolStats(0) {
-         @Override
-         protected void update() {
-            // do nothing
-         }
-      };
-   }
-
 }

--- a/src/test/java/com/zaxxer/hikari/metrics/prometheus/PrometheusHistogramMetricsTrackerTest.java
+++ b/src/test/java/com/zaxxer/hikari/metrics/prometheus/PrometheusHistogramMetricsTrackerTest.java
@@ -18,6 +18,9 @@ package com.zaxxer.hikari.metrics.prometheus;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import com.zaxxer.hikari.metrics.IMetricsTracker;
+import com.zaxxer.hikari.mocks.StubPoolStats;
+
 import io.prometheus.client.CollectorRegistry;
 import org.junit.Before;
 import org.junit.Test;
@@ -117,6 +120,16 @@ public class PrometheusHistogramMetricsTrackerTest {
                labelNames,
                labelValues2), is(0.0));
          }
+      }
+   }
+
+   @Test
+   public void registersMetricsOnlyOnce()
+   {
+      PrometheusHistogramMetricsTrackerFactory factory = new PrometheusHistogramMetricsTrackerFactory(collectorRegistry);
+      try (IMetricsTracker tracker1 = factory.create("pool1", new StubPoolStats(0))) {
+      }
+      try (IMetricsTracker tracker2 = factory.create("pool2", new StubPoolStats(0))) {
       }
    }
 

--- a/src/test/java/com/zaxxer/hikari/metrics/prometheus/PrometheusHistogramMetricsTrackerTest.java
+++ b/src/test/java/com/zaxxer/hikari/metrics/prometheus/PrometheusHistogramMetricsTrackerTest.java
@@ -33,92 +33,118 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 
-public class PrometheusHistogramMetricsTrackerTest {
+public class PrometheusHistogramMetricsTrackerTest
+{
 
-   private CollectorRegistry collectorRegistry;
+   private CollectorRegistry defaultCollectorRegistry;
+   private CollectorRegistry customCollectorRegistry;
 
    private static final String POOL_LABEL_NAME = "pool";
+   private static final String[] LABEL_NAMES = { POOL_LABEL_NAME };
 
    @Before
-   public void setupCollectorRegistry(){
-      this.collectorRegistry = new CollectorRegistry();
+   public void setupCollectorRegistry()
+   {
+      this.defaultCollectorRegistry = new CollectorRegistry();
+      this.customCollectorRegistry = new CollectorRegistry();
    }
 
    @Test
-   public void recordConnectionTimeout() throws Exception {
+   public void recordConnectionTimeout() throws Exception
+   {
       HikariConfig config = newHikariConfig();
-      config.setMetricsTrackerFactory(new PrometheusHistogramMetricsTrackerFactory(collectorRegistry));
+      config.setMetricsTrackerFactory(new PrometheusHistogramMetricsTrackerFactory(defaultCollectorRegistry));
       config.setJdbcUrl("jdbc:h2:mem:");
       config.setMaximumPoolSize(2);
       config.setConnectionTimeout(250);
 
-      String[] labelNames = {POOL_LABEL_NAME};
-      String[] labelValues = {config.getPoolName()};
+      String[] labelValues = { config.getPoolName() };
 
       try (HikariDataSource hikariDataSource = new HikariDataSource(config)) {
-         try (Connection connection1 = hikariDataSource.getConnection();
-              Connection connection2 = hikariDataSource.getConnection()) {
+         try (Connection connection1 = hikariDataSource.getConnection(); Connection connection2 = hikariDataSource.getConnection()) {
             try (Connection connection3 = hikariDataSource.getConnection()) {
-            } catch (SQLTransientConnectionException ignored) {
+            }
+            catch (SQLTransientConnectionException ignored) {
             }
          }
 
-         Double total = collectorRegistry.getSampleValue(
-            "hikaricp_connection_timeout_total",
-            labelNames,
-            labelValues
-         );
+         Double total = defaultCollectorRegistry.getSampleValue("hikaricp_connection_timeout_total", LABEL_NAMES, labelValues);
          assertThat(total, is(1.0));
       }
    }
 
    @Test
-   public void connectionAcquisitionMetrics() {
+   public void connectionAcquisitionMetrics()
+   {
       checkSummaryMetricFamily("hikaricp_connection_acquired_nanos");
    }
 
    @Test
-   public void connectionUsageMetrics() {
+   public void connectionUsageMetrics()
+   {
       checkSummaryMetricFamily("hikaricp_connection_usage_millis");
    }
 
    @Test
-   public void connectionCreationMetrics() {
+   public void connectionCreationMetrics()
+   {
       checkSummaryMetricFamily("hikaricp_connection_creation_millis");
    }
 
    @Test
-   public void testMultiplePoolName() throws Exception {
-      String[] labelNames = {POOL_LABEL_NAME};
+   public void testMultiplePoolNameWithOneCollectorRegistry()
+   {
+      HikariConfig configFirstPool = newHikariConfig();
+      configFirstPool.setMetricsTrackerFactory(new PrometheusHistogramMetricsTrackerFactory(defaultCollectorRegistry));
+      configFirstPool.setPoolName("first");
+      configFirstPool.setJdbcUrl("jdbc:h2:mem:");
+      configFirstPool.setMaximumPoolSize(2);
+      configFirstPool.setConnectionTimeout(250);
 
-      HikariConfig config = newHikariConfig();
-      config.setMetricsTrackerFactory(new PrometheusHistogramMetricsTrackerFactory(collectorRegistry));
-      config.setPoolName("first");
-      config.setJdbcUrl("jdbc:h2:mem:");
-      config.setMaximumPoolSize(2);
-      config.setConnectionTimeout(250);
-      String[] labelValues1 = {config.getPoolName()};
+      HikariConfig configSecondPool = newHikariConfig();
+      configSecondPool.setMetricsTrackerFactory(new PrometheusHistogramMetricsTrackerFactory(defaultCollectorRegistry));
+      configSecondPool.setPoolName("second");
+      configSecondPool.setJdbcUrl("jdbc:h2:mem:");
+      configSecondPool.setMaximumPoolSize(4);
+      configSecondPool.setConnectionTimeout(250);
 
-      try (HikariDataSource ignored = new HikariDataSource(config)) {
-         assertThat(collectorRegistry.getSampleValue(
-            "hikaricp_connection_timeout_total",
-            labelNames,
-            labelValues1), is(0.0));
+      String[] labelValuesFirstPool = { configFirstPool.getPoolName() };
+      String[] labelValuesSecondPool = { configSecondPool.getPoolName() };
 
-         CollectorRegistry collectorRegistry2 = new CollectorRegistry();
-         HikariConfig config2 = newHikariConfig();
-         config2.setMetricsTrackerFactory(new PrometheusHistogramMetricsTrackerFactory(collectorRegistry2));
-         config2.setPoolName("second");
-         config2.setJdbcUrl("jdbc:h2:mem:");
-         config2.setMaximumPoolSize(4);
-         config2.setConnectionTimeout(250);
-         String[] labelValues2 = {config2.getPoolName()};
+      try (HikariDataSource ignoredFirstPool = new HikariDataSource(configFirstPool)) {
+         assertThat(defaultCollectorRegistry.getSampleValue("hikaricp_connection_timeout_total", LABEL_NAMES, labelValuesFirstPool), is(0.0));
 
-         try (HikariDataSource ignored2 = new HikariDataSource(config2)) {
-            assertThat(collectorRegistry2.getSampleValue(
-               "hikaricp_connection_timeout_total",
-               labelNames,
-               labelValues2), is(0.0));
+         try (HikariDataSource ignoredSecondPool = new HikariDataSource(configSecondPool)) {
+            assertThat(defaultCollectorRegistry.getSampleValue("hikaricp_connection_timeout_total", LABEL_NAMES, labelValuesSecondPool), is(0.0));
+         }
+      }
+   }
+
+   @Test
+   public void testMultiplePoolNameWithDifferentCollectorRegistries()
+   {
+      HikariConfig configFirstPool = newHikariConfig();
+      configFirstPool.setMetricsTrackerFactory(new PrometheusHistogramMetricsTrackerFactory(defaultCollectorRegistry));
+      configFirstPool.setPoolName("first");
+      configFirstPool.setJdbcUrl("jdbc:h2:mem:");
+      configFirstPool.setMaximumPoolSize(2);
+      configFirstPool.setConnectionTimeout(250);
+
+      HikariConfig configSecondPool = newHikariConfig();
+      configSecondPool.setMetricsTrackerFactory(new PrometheusHistogramMetricsTrackerFactory(customCollectorRegistry));
+      configSecondPool.setPoolName("second");
+      configSecondPool.setJdbcUrl("jdbc:h2:mem:");
+      configSecondPool.setMaximumPoolSize(4);
+      configSecondPool.setConnectionTimeout(250);
+
+      String[] labelValuesFirstPool = { configFirstPool.getPoolName() };
+      String[] labelValuesSecondPool = { configSecondPool.getPoolName() };
+
+      try (HikariDataSource ignoredFirstPool = new HikariDataSource(configFirstPool)) {
+         assertThat(defaultCollectorRegistry.getSampleValue("hikaricp_connection_timeout_total", LABEL_NAMES, labelValuesFirstPool), is(0.0));
+
+         try (HikariDataSource ignoredSecondPool = new HikariDataSource(configSecondPool)) {
+            assertThat(customCollectorRegistry.getSampleValue("hikaricp_connection_timeout_total", LABEL_NAMES, labelValuesSecondPool), is(0.0));
          }
       }
    }
@@ -126,31 +152,24 @@ public class PrometheusHistogramMetricsTrackerTest {
    @Test
    public void registersMetricsOnlyOnce()
    {
-      PrometheusHistogramMetricsTrackerFactory factory = new PrometheusHistogramMetricsTrackerFactory(collectorRegistry);
+      PrometheusHistogramMetricsTrackerFactory factory = new PrometheusHistogramMetricsTrackerFactory(defaultCollectorRegistry);
       try (IMetricsTracker tracker1 = factory.create("pool1", new StubPoolStats(0))) {
       }
       try (IMetricsTracker tracker2 = factory.create("pool2", new StubPoolStats(0))) {
       }
    }
 
-   private void checkSummaryMetricFamily(String metricName) {
+   private void checkSummaryMetricFamily(String metricName)
+   {
       HikariConfig config = newHikariConfig();
-      config.setMetricsTrackerFactory(new PrometheusHistogramMetricsTrackerFactory(collectorRegistry));
+      config.setMetricsTrackerFactory(new PrometheusHistogramMetricsTrackerFactory(defaultCollectorRegistry));
       config.setJdbcUrl("jdbc:h2:mem:");
 
       try (HikariDataSource ignored = new HikariDataSource(config)) {
-         Double count = collectorRegistry.getSampleValue(
-            metricName + "_count",
-            new String[]{POOL_LABEL_NAME},
-            new String[]{config.getPoolName()}
-         );
+         final String[] labelValues = new String[] { config.getPoolName() };
+         Double count = defaultCollectorRegistry.getSampleValue(metricName + "_count", LABEL_NAMES, labelValues);
          assertNotNull(count);
-
-         Double sum = collectorRegistry.getSampleValue(
-            metricName + "_sum",
-            new String[]{POOL_LABEL_NAME},
-            new String[]{config.getPoolName()}
-         );
+         Double sum = defaultCollectorRegistry.getSampleValue(metricName + "_sum", LABEL_NAMES, labelValues);
          assertNotNull(sum);
       }
    }

--- a/src/test/java/com/zaxxer/hikari/metrics/prometheus/PrometheusMetricsTrackerFactoryTest.java
+++ b/src/test/java/com/zaxxer/hikari/metrics/prometheus/PrometheusMetricsTrackerFactoryTest.java
@@ -1,6 +1,5 @@
 package com.zaxxer.hikari.metrics.prometheus;
 
-import com.zaxxer.hikari.metrics.PoolStats;
 import com.zaxxer.hikari.mocks.StubPoolStats;
 import io.prometheus.client.Collector;
 import io.prometheus.client.CollectorRegistry;


### PR DESCRIPTION
Fixes #1465 and formats code related to `PrometheusHistogramMetricsTracker` according to this project's Eclipse formatter profile.