### PR TITLE
Upgrade Micrometer to version 1.0.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
       <jndi.version>0.11.4.1</jndi.version>
       <maven.release.version>2.5.3</maven.release.version>
       <metrics.version>3.2.4</metrics.version>
-      <micrometer.version>1.0.0</micrometer.version>
+      <micrometer.version>1.0.11</micrometer.version>
       <simpleclient.version>0.0.26</simpleclient.version>
       <mockito.version>2.23.4</mockito.version>
       <pax.exam.version>4.13.1</pax.exam.version>


### PR DESCRIPTION
Upgrade Micrometer from version 1.0.0 to 1.0.11. Version 1.0.11 is the last patch in the 1.0.x line.

Since Micrometer releases follow semantic versioning (see their [support policy](https://micrometer.io/docs/support)), 1.0.11 should not contain breaking changes.

An upgrade to the latest release (1.3.0) could be considered instead.