### PR TITLE
Fix for misleading "Connection is not available, request timed out after" messages

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,9 @@
 HikariCP Changes
 
+Changes in 3.4.?
+
+ * Store timestamp with lastConnectionFailure to wrap old (10x of timeout) connection exceptions with additional information to make logs more related to reality.
+
 Changes in 3.4.1
 
  * fix regression caused by 1337, which broke the ability to pass the isolation level by integer
@@ -32,7 +36,7 @@ Changes in 3.3.1
 
 Changes in 3.3.0
 
- * Revert change where Connection.isClosed() was called outside of setNetworkTimeout() block, opening 
+ * Revert change where Connection.isClosed() was called outside of setNetworkTimeout() block, opening
    vulnerability to unacknowledged TCP traffic.
 
  * fixed 1186 limit number of items in the ConcurrentBag's ThreadLocal list to avoid OOM errors in some
@@ -55,7 +59,7 @@ Changes in 3.3.0
 
  * various clean-ups pointed out by sonarcloud.io
 
- * merged 1290 Class.newInstance() is deprecated as of Java 9. Usage should be replaced by calling 
+ * merged 1290 Class.newInstance() is deprecated as of Java 9. Usage should be replaced by calling
    Class.getDeclaredConstructor().newInstance().
 
  * fixed #1305 ensure that ConcurrentBag.add() does not spin under high load, when waiting threads may never
@@ -63,7 +67,7 @@ Changes in 3.3.0
 
  * fixes #1287 when system property blockUntilFilled is set, use multiple threads to fill the pool.
 
- 
+
 Changes in 3.2.0
 
  * check connection closed condition before attempting to set network timeout to avoid spurios exceptions


### PR DESCRIPTION
Currently ```lastConnectionFailure``` is always used as cause for ```Connection is not available, request timed out after``` exception.

But in some cases ```lastConnectionFailure``` could be so old that it become irrelevant. For example, connection adder thread could be hanged for some reason (see https://github.com/pgjdbc/pgjdbc/pull/1584).

We got such issue in production after network split. Due related jdbc-driver issue adder thread was stuck forever in:
```
#15680 daemon prio=5 os_prio=0 cpu=47.27ms elapsed=76351.16s tid=0x00007f4abc0029e0 nid=0x4a93 runnable  [0x00007f4b4b7f6000]
   java.lang.Thread.State: RUNNABLE
        at java.net.SocketInputStream.socketRead0(java.base@11.0.3-internal/Native Method)
        at java.net.SocketInputStream.socketRead(java.base@11.0.3-internal/SocketInputStream.java:115)
        at java.net.SocketInputStream.read(java.base@11.0.3-internal/SocketInputStream.java:168)
        at java.net.SocketInputStream.read(java.base@11.0.3-internal/SocketInputStream.java:140)
        at sun.security.ssl.SSLSocketInputRecord.read(java.base@11.0.3-internal/SSLSocketInputRecord.java:448)
        at sun.security.ssl.SSLSocketInputRecord.decodeInputRecord(java.base@11.0.3-internal/SSLSocketInputRecord.java:237)
        at sun.security.ssl.SSLSocketInputRecord.decode(java.base@11.0.3-internal/SSLSocketInputRecord.java:190)
        at sun.security.ssl.SSLTransport.decode(java.base@11.0.3-internal/SSLTransport.java:108)
        at sun.security.ssl.SSLSocketImpl.decode(java.base@11.0.3-internal/SSLSocketImpl.java:1152)
        at sun.security.ssl.SSLSocketImpl.readHandshakeRecord(java.base@11.0.3-internal/SSLSocketImpl.java:1063)
        at sun.security.ssl.SSLSocketImpl.startHandshake(java.base@11.0.3-internal/SSLSocketImpl.java:402)
        - locked <0x00000007f901bae0> (a sun.security.ssl.TransportContext)
        at org.postgresql.ssl.MakeSSL.convert(MakeSSL.java:62)
        at org.postgresql.core.v3.ConnectionFactoryImpl.enableSSL(ConnectionFactoryImpl.java:389)
        at org.postgresql.core.v3.ConnectionFactoryImpl.openConnectionImpl(ConnectionFactoryImpl.java:160)
        at org.postgresql.core.ConnectionFactory.openConnection(ConnectionFactory.java:49)
        at org.postgresql.jdbc.PgConnection.<init>(PgConnection.java:195)
        at org.postgresql.Driver.makeConnection(Driver.java:452)
        at org.postgresql.Driver.connect(Driver.java:254)
        at com.zaxxer.hikari.util.DriverDataSource.getConnection(DriverDataSource.java:117)
        at com.zaxxer.hikari.util.DriverDataSource.getConnection(DriverDataSource.java:123)
        at com.zaxxer.hikari.pool.PoolBase.newConnection(PoolBase.java:375)
        at com.zaxxer.hikari.pool.PoolBase.newPoolEntry(PoolBase.java:204)
        at com.zaxxer.hikari.pool.HikariPool.createPoolEntry(HikariPool.java:445)
        at com.zaxxer.hikari.pool.HikariPool.access$200(HikariPool.java:72)
        at com.zaxxer.hikari.pool.HikariPool$PoolEntryCreator.call(HikariPool.java:632)
        at com.zaxxer.hikari.pool.HikariPool$PoolEntryCreator.call(HikariPool.java:618)
        at java.util.concurrent.FutureTask.run(java.base@11.0.3-internal/FutureTask.java:264)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@11.0.3-internal/ThreadPoolExecutor.java:1128)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@11.0.3-internal/ThreadPoolExecutor.java:628)
        at java.lang.Thread.run(java.base@11.0.3-internal/Thread.java:834)
```

When network was fixed we were continue to received exceptions about timeout. Like this:

```
java.sql.SQLTransientConnectionException: master - Connection is not available, request timed out after 1000ms.
	at com.zaxxer.hikari.pool.HikariPool.createTimeoutException(HikariPool.java:603)
	at com.zaxxer.hikari.pool.HikariPool.getConnection(HikariPool.java:193)
	at com.zaxxer.hikari.pool.HikariPool.getConnection(HikariPool.java:149)
	at com.zaxxer.hikari.HikariDataSource.getConnection(HikariDataSource.java:112)
        .......
        .......
        .......
        .......
Caused by: org.postgresql.util.PSQLException: This connection has been closed.
	at org.postgresql.jdbc.PgConnection.checkClosed(PgConnection.java:767)
	at org.postgresql.jdbc.PgConnection.setNetworkTimeout(PgConnection.java:1537)
	at com.zaxxer.hikari.pool.PoolBase.setNetworkTimeout(PoolBase.java:551)
	at com.zaxxer.hikari.pool.PoolBase.isConnectionAlive(PoolBase.java:172)
	at com.zaxxer.hikari.pool.HikariPool.getConnection(HikariPool.java:173)
	at com.zaxxer.hikari.pool.HikariPool.getConnection(HikariPool.java:149)
	at com.zaxxer.hikari.HikariDataSource.getConnection(HikariDataSource.java:112)
        .......
        .......
        .......
        .......
```

And this ```PSQLException``` was thrown a day ago... So, now it is totally irrelevant and even *mislead* us.

So, PR adds timestamp for ```lastConnectionFailure``` and wraps cause if it too old. 

Basic case for fresh exception:
```
java.sql.SQLTransientConnectionException: testDataSourceRaisesCorrectErrorOnConnectioAdderHanging - Connection is not available, request timed out after 253ms.
	at com.zaxxer.hikari.pool.HikariPool.createTimeoutException(HikariPool.java:720)
	at com.zaxxer.hikari.pool.HikariPool.getConnection(HikariPool.java:196)
	at com.zaxxer.hikari.pool.HikariPool.getConnection(HikariPool.java:161)
	at com.zaxxer.hikari.HikariDataSource.getConnection(HikariDataSource.java:100)
        .......
        .......
Caused by: java.lang.RuntimeException: Bad thing happens on datasource.
	at com.zaxxer.hikari.pool.TestConnections$StubDataSourceWithErrorSwitch.getConnection(TestConnections.java:789)
	at com.zaxxer.hikari.pool.PoolBase.newConnection(PoolBase.java:367)
	at com.zaxxer.hikari.pool.PoolBase.newPoolEntry(PoolBase.java:215)
	at com.zaxxer.hikari.pool.HikariPool.createPoolEntry(HikariPool.java:473)
	at com.zaxxer.hikari.pool.HikariPool.access$100(HikariPool.java:71)
	at com.zaxxer.hikari.pool.HikariPool$PoolEntryCreator.call(HikariPool.java:750)
	at com.zaxxer.hikari.pool.HikariPool$PoolEntryCreator.call(HikariPool.java:736)
        .......
        .......
```

and for old (10x of timeout) exception:
```
java.sql.SQLTransientConnectionException: testDataSourceRaisesCorrectErrorOnConnectioAdderHanging - Connection is not available, request timed out after 251ms.
	at com.zaxxer.hikari.pool.HikariPool.createTimeoutException(HikariPool.java:720)
	at com.zaxxer.hikari.pool.HikariPool.getConnection(HikariPool.java:196)
	at com.zaxxer.hikari.pool.HikariPool.getConnection(HikariPool.java:161)
	at com.zaxxer.hikari.HikariDataSource.getConnection(HikariDataSource.java:100)
        .......
        .......
Caused by: java.sql.SQLTransientConnectionException: testDataSourceRaisesCorrectErrorOnConnectioAdderHanging - Last known exception is 32259ms old.
	at com.zaxxer.hikari.pool.HikariPool.createTimeoutException(HikariPool.java:712)
	... 28 more
Caused by: java.lang.RuntimeException: Bad thing happens on datasource.
	at com.zaxxer.hikari.pool.TestConnections$StubDataSourceWithErrorSwitch.getConnection(TestConnections.java:789)
	at com.zaxxer.hikari.pool.PoolBase.newConnection(PoolBase.java:367)
	at com.zaxxer.hikari.pool.PoolBase.newPoolEntry(PoolBase.java:215)
	at com.zaxxer.hikari.pool.HikariPool.createPoolEntry(HikariPool.java:473)
	at com.zaxxer.hikari.pool.HikariPool.access$100(HikariPool.java:71)
	at com.zaxxer.hikari.pool.HikariPool$PoolEntryCreator.call(HikariPool.java:750)
	at com.zaxxer.hikari.pool.HikariPool$PoolEntryCreator.call(HikariPool.java:736)
        .......
        .......
```