### PR TITLE
Add transaction level enum

### DIFF
--- a/src/main/java/com/zaxxer/hikari/HikariConfig.java
+++ b/src/main/java/com/zaxxer/hikari/HikariConfig.java
@@ -18,6 +18,7 @@ package com.zaxxer.hikari;
 
 import com.codahale.metrics.health.HealthCheckRegistry;
 import com.zaxxer.hikari.metrics.MetricsTrackerFactory;
+import com.zaxxer.hikari.util.IsolationLevel;
 import com.zaxxer.hikari.util.PropertyElf;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -838,6 +839,17 @@ public class HikariConfig implements HikariConfigMXBean
    {
       checkIfSealed();
       this.transactionIsolationName = isolationLevel;
+   }
+
+   /**
+    * Set the default transaction isolation level with the <code>IsolationLevel</code> enum.
+    *
+    * @param isolationLevel the name of the isolation level
+    */
+   public void setTransactionIsolation(IsolationLevel isolationLevel)
+   {
+      checkIfSealed();
+      this.transactionIsolationName = isolationLevel.getLevelName();
    }
 
    /**

--- a/src/main/java/com/zaxxer/hikari/HikariConfig.java
+++ b/src/main/java/com/zaxxer/hikari/HikariConfig.java
@@ -849,7 +849,7 @@ public class HikariConfig implements HikariConfigMXBean
    public void setTransactionIsolation(IsolationLevel isolationLevel)
    {
       checkIfSealed();
-      this.transactionIsolationName = isolationLevel.getLevelName();
+      this.transactionIsolationName = isolationLevel.name();
    }
 
    /**

--- a/src/main/java/com/zaxxer/hikari/util/IsolationLevel.java
+++ b/src/main/java/com/zaxxer/hikari/util/IsolationLevel.java
@@ -16,22 +16,28 @@
 
 package com.zaxxer.hikari.util;
 
-public enum IsolationLevel
-{
-   TRANSACTION_NONE(0),
-   TRANSACTION_READ_UNCOMMITTED(1),
-   TRANSACTION_READ_COMMITTED(2),
-   TRANSACTION_REPEATABLE_READ(4),
-   TRANSACTION_SERIALIZABLE(8),
-   TRANSACTION_SQL_SERVER_SNAPSHOT_ISOLATION_LEVEL(4096);
+public enum IsolationLevel {
+   TRANSACTION_NONE(0, "TRANSACTION_NONE"),
+   TRANSACTION_READ_UNCOMMITTED(1, "TRANSACTION_READ_UNCOMMITTED"),
+   TRANSACTION_READ_COMMITTED(2, "TRANSACTION_READ_COMMITTED"),
+   TRANSACTION_REPEATABLE_READ(4, "TRANSACTION_REPEATABLE_READ"),
+   TRANSACTION_SERIALIZABLE(8, "TRANSACTION_SERIALIZABLE"),
+   TRANSACTION_SQL_SERVER_SNAPSHOT_ISOLATION_LEVEL(4096,
+      "TRANSACTION_SQL_SERVER_SNAPSHOT_ISOLATION_LEVEL");
 
    private final int levelId;
+   private final String levelName;
 
-   IsolationLevel(int levelId) {
+   IsolationLevel(int levelId, String levelName) {
       this.levelId = levelId;
+      this.levelName = levelName;
    }
 
    public int getLevelId() {
       return levelId;
+   }
+
+   public String getLevelName() {
+      return levelName;
    }
 }

--- a/src/main/java/com/zaxxer/hikari/util/IsolationLevel.java
+++ b/src/main/java/com/zaxxer/hikari/util/IsolationLevel.java
@@ -16,7 +16,8 @@
 
 package com.zaxxer.hikari.util;
 
-public enum IsolationLevel {
+public enum IsolationLevel
+{
    TRANSACTION_NONE(0),
    TRANSACTION_READ_UNCOMMITTED(1),
    TRANSACTION_READ_COMMITTED(2),
@@ -33,5 +34,4 @@ public enum IsolationLevel {
    public int getLevelId() {
       return levelId;
    }
-
 }

--- a/src/main/java/com/zaxxer/hikari/util/IsolationLevel.java
+++ b/src/main/java/com/zaxxer/hikari/util/IsolationLevel.java
@@ -17,27 +17,21 @@
 package com.zaxxer.hikari.util;
 
 public enum IsolationLevel {
-   TRANSACTION_NONE(0, "TRANSACTION_NONE"),
-   TRANSACTION_READ_UNCOMMITTED(1, "TRANSACTION_READ_UNCOMMITTED"),
-   TRANSACTION_READ_COMMITTED(2, "TRANSACTION_READ_COMMITTED"),
-   TRANSACTION_REPEATABLE_READ(4, "TRANSACTION_REPEATABLE_READ"),
-   TRANSACTION_SERIALIZABLE(8, "TRANSACTION_SERIALIZABLE"),
-   TRANSACTION_SQL_SERVER_SNAPSHOT_ISOLATION_LEVEL(4096,
-      "TRANSACTION_SQL_SERVER_SNAPSHOT_ISOLATION_LEVEL");
+   TRANSACTION_NONE(0),
+   TRANSACTION_READ_UNCOMMITTED(1),
+   TRANSACTION_READ_COMMITTED(2),
+   TRANSACTION_REPEATABLE_READ(4),
+   TRANSACTION_SERIALIZABLE(8),
+   TRANSACTION_SQL_SERVER_SNAPSHOT_ISOLATION_LEVEL(4096);
 
    private final int levelId;
-   private final String levelName;
 
-   IsolationLevel(int levelId, String levelName) {
+   IsolationLevel(int levelId) {
       this.levelId = levelId;
-      this.levelName = levelName;
    }
 
    public int getLevelId() {
       return levelId;
    }
 
-   public String getLevelName() {
-      return levelName;
-   }
 }

--- a/src/test/java/com/zaxxer/hikari/pool/ConnectionStateTest.java
+++ b/src/test/java/com/zaxxer/hikari/pool/ConnectionStateTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import com.zaxxer.hikari.util.IsolationLevel;
 import com.zaxxer.hikari.util.UtilityElf;
 
 public class ConnectionStateTest
@@ -86,6 +87,18 @@ public class ConnectionStateTest
       HikariConfig config = newHikariConfig();
       config.setDataSourceClassName("com.zaxxer.hikari.mocks.StubDataSource");
       config.setTransactionIsolation("TRANSACTION_REPEATABLE_READ");
+      config.validate();
+
+      int transactionIsolation = UtilityElf.getTransactionIsolation(config.getTransactionIsolation());
+      assertSame(Connection.TRANSACTION_REPEATABLE_READ, transactionIsolation);
+   }
+
+   @Test
+   public void testIsolationEnum() throws Exception
+   {
+      HikariConfig config = newHikariConfig();
+      config.setDataSourceClassName("com.zaxxer.hikari.mocks.StubDataSource");
+      config.setTransactionIsolation(IsolationLevel.TRANSACTION_REPEATABLE_READ);
       config.validate();
 
       int transactionIsolation = UtilityElf.getTransactionIsolation(config.getTransactionIsolation());


### PR DESCRIPTION
Would it be nice to add an override to `HikariConfig.setTransactionLevel()` that let's you use the `IsolationLevel` enum instead of having to type out the isolation level yourself?

Please let me know if this is viable at all. If it is I'm very interested in discussing how this can be solved in an even better way.