### PR TITLE
chore: fix driver properties issue with only String values

### DIFF
--- a/src/main/java/com/zaxxer/hikari/util/DriverDataSource.java
+++ b/src/main/java/com/zaxxer/hikari/util/DriverDataSource.java
@@ -46,7 +46,7 @@ public final class DriverDataSource implements DataSource
       this.driverProperties = new Properties();
 
       for (Entry<Object, Object> entry : properties.entrySet()) {
-         driverProperties.setProperty(entry.getKey().toString(), entry.getValue().toString());
+         driverProperties.put(entry.getKey().toString(), entry.getValue());
       }
 
       if (username != null) {


### PR DESCRIPTION
This PR fixes:
https://github.com/brettwooldridge/HikariCP/issues/1496

This issue makes a problem with Snowflake Driver when PrivateKey is passing as a String value instead of actual PrivateKey instance here:
https://github.com/snowflakedb/snowflake-jdbc/blob/master/src/main/java/net/snowflake/client/core/SFSessionProperty.java#L143

https://github.com/snowflakedb/snowflake-jdbc/blob/master/src/main/java/net/snowflake/client/core/SFSessionProperty.java#L35

