### PR TITLE
Handle short in PropertyElf

### DIFF
--- a/src/main/java/com/zaxxer/hikari/util/PropertyElf.java
+++ b/src/main/java/com/zaxxer/hikari/util/PropertyElf.java
@@ -143,6 +143,9 @@ public final class PropertyElf
          else if (paramClass == long.class) {
             writeMethod.invoke(target, Long.parseLong(propValue.toString()));
          }
+         else if (paramClass == short.class) {
+            writeMethod.invoke(target, Short.parseShort(propValue.toString()));
+         }
          else if (paramClass == boolean.class || paramClass == Boolean.class) {
             writeMethod.invoke(target, Boolean.parseBoolean(propValue.toString()));
          }

--- a/src/test/java/com/zaxxer/hikari/mocks/TestObject.java
+++ b/src/test/java/com/zaxxer/hikari/mocks/TestObject.java
@@ -4,6 +4,7 @@ public class TestObject
 {
    private TestObject testObject;
    private String string;
+   private short shortRaw;
 
    public void setTestObject(TestObject testObject)
    {
@@ -23,5 +24,13 @@ public class TestObject
    public String getString()
    {
       return string;
+   }
+
+   public short getShortRaw() {
+      return shortRaw;
+   }
+
+   public void setShortRaw(short shortRaw) {
+      this.shortRaw = shortRaw;
    }
 }

--- a/src/test/java/com/zaxxer/hikari/util/PropertyElfTest.java
+++ b/src/test/java/com/zaxxer/hikari/util/PropertyElfTest.java
@@ -18,9 +18,11 @@ public class PropertyElfTest
       Properties properties = new Properties();
       properties.setProperty("string", "aString");
       properties.setProperty("testObject", "com.zaxxer.hikari.mocks.TestObject");
+      properties.setProperty("shortRaw", "1");
       TestObject testObject = new TestObject();
       PropertyElf.setTargetFromProperties(testObject, properties);
       assertEquals("aString", testObject.getString());
+      assertEquals((short) 1, testObject.getShortRaw());
       assertEquals(com.zaxxer.hikari.mocks.TestObject.class, testObject.getTestObject().getClass());
       assertNotSame(testObject, testObject.getTestObject());
    }


### PR DESCRIPTION
When the dataSource class has a method setX(short Y) then PropertyElf did not handle this case. Added similarly to int/long/boolean handling. Added tests.