### PR TITLE
Clarify javadoc of HikariConfig.setPoolName

### DIFF
--- a/src/main/java/com/zaxxer/hikari/HikariConfig.java
+++ b/src/main/java/com/zaxxer/hikari/HikariConfig.java
@@ -771,8 +771,8 @@ public class HikariConfig implements HikariConfigMXBean
    }
 
    /**
-    * Set the name of the connection pool.  This is primarily used for the MBean
-    * to uniquely identify the pool configuration.
+    * Set the name of the connection pool.  This is primarily used in logging and JMX management consoles
+    * to identify pools and pool configurations
     *
     * @param poolName the name of the connection pool to use
     */


### PR DESCRIPTION
Clarification of the javadoc. Pretty much copied from the description in README.md