### PR TITLE
Fix setNetworkTimeout throwing during isConnectionAlive

### DIFF
--- a/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
+++ b/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
@@ -181,8 +181,8 @@ abstract class PoolBase
       }
       catch (Exception e) {
          lastConnectionFailure.set(e);
-         logger.warn("{} - Failed to validate connection {} ({}). Possibly consider using a shorter maxLifetime value.",
-                     poolName, connection, e.getMessage());
+         logger.warn("{} - Failed to validate connection {}. Possibly consider using a shorter maxLifetime value.",
+            poolName, connection, e);
          return false;
       }
    }

--- a/src/test/java/com/zaxxer/hikari/mocks/StubConnection.java
+++ b/src/test/java/com/zaxxer/hikari/mocks/StubConnection.java
@@ -47,6 +47,7 @@ public class StubConnection extends StubBaseConnection implements Connection
    public static final AtomicInteger count = new AtomicInteger();
    public static volatile boolean slowCreate;
    public static volatile boolean oldDriver;
+   public static volatile boolean setNetworkTimeoutThrows;
 
    private static long foo;
    private boolean autoCommit;
@@ -471,6 +472,9 @@ public class StubConnection extends StubBaseConnection implements Connection
    /** {@inheritDoc} */
    public void setNetworkTimeout(Executor executor, int milliseconds) throws SQLException
    {
+      if (setNetworkTimeoutThrows) {
+         throw new SQLException("This connection has been closed");
+      }
    }
 
    /** {@inheritDoc} */

--- a/src/test/java/com/zaxxer/hikari/mocks/StubConnection.java
+++ b/src/test/java/com/zaxxer/hikari/mocks/StubConnection.java
@@ -44,10 +44,13 @@ import com.zaxxer.hikari.util.UtilityElf;
  */
 public class StubConnection extends StubBaseConnection implements Connection
 {
+
+   public static final String CONNECTION_CLOSED_ERROR = "This connection has been closed";
+
    public static final AtomicInteger count = new AtomicInteger();
    public static volatile boolean slowCreate;
    public static volatile boolean oldDriver;
-   public static volatile boolean setNetworkTimeoutThrows;
+   public static volatile boolean closed;
 
    private static long foo;
    private boolean autoCommit;
@@ -153,7 +156,7 @@ public class StubConnection extends StubBaseConnection implements Connection
       if (throwException) {
          throw new SQLException();
       }
-      return false;
+      return closed;
    }
 
    /** {@inheritDoc} */
@@ -472,8 +475,8 @@ public class StubConnection extends StubBaseConnection implements Connection
    /** {@inheritDoc} */
    public void setNetworkTimeout(Executor executor, int milliseconds) throws SQLException
    {
-      if (setNetworkTimeoutThrows) {
-         throw new SQLException("This connection has been closed");
+      if (closed) {
+         throw new SQLException(CONNECTION_CLOSED_ERROR);
       }
    }
 


### PR DESCRIPTION
Fixes https://github.com/brettwooldridge/HikariCP/issues/1212

---

Seeing that the Postgres JDBC driver [explicitly checks for closed connections](https://github.com/pgjdbc/pgjdbc/blob/master/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java#L1639) during `setNetworkTimeout`:
```
Caused by: org.postgresql.util.PSQLException: This connection has been closed.
    at org.postgresql.jdbc.PgConnection.*checkClosed*(PgConnection.java:857)
    at org.postgresql.jdbc.PgConnection.setNetworkTimeout(PgConnection.java:1639)
    at com.zaxxer.hikari.pool.PoolBase.setNetworkTimeout(PoolBase.java:552)
    at com.zaxxer.hikari.pool.PoolBase.isConnectionAlive(PoolBase.java:168)
    at com.zaxxer.hikari.pool.HikariPool.getConnection(HikariPool.java:185)
```

and that we're already aware of that when explicitly closing connections in https://github.com/brettwooldridge/HikariCP/blob/dev/src/main/java/com/zaxxer/hikari/pool/PoolBase.java#L143
> connection.close(); // continue with the close even if setNetworkTimeout() throws

and

https://github.com/brettwooldridge/HikariCP/blob/dev/src/main/java/com/zaxxer/hikari/pool/PoolBase.java#L531


----------


I've added a `try` method that delegates to previous one, turning the exception to a boolean
and using it in
* [quietlyCloseConnection](https://github.com/brettwooldridge/HikariCP/blob/dev/src/main/java/com/zaxxer/hikari/pool/PoolBase.java#L137)
* [isConnectionAlive](https://github.com/brettwooldridge/HikariCP/blob/dev/src/main/java/com/zaxxer/hikari/pool/PoolBase.java#L156-L173)

and continue throwing in case of:

* [resetConnectionState](https://github.com/brettwooldridge/HikariCP/blob/dev/src/main/java/com/zaxxer/hikari/pool/PoolBase.java#L234)
* [setupConnection](https://github.com/brettwooldridge/HikariCP/blob/dev/src/main/java/com/zaxxer/hikari/pool/PoolBase.java#L399-L426)

----------

I've separated the failing test to a dedicated commit so that the reviewer can make sure the issue was reproduced.