### PR TITLE
Add OpenTracing support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
       <maven.release.version>2.5.3</maven.release.version>
       <metrics.version>3.2.4</metrics.version>
       <micrometer.version>1.3.2</micrometer.version>
+      <opentracing.version>0.33.0</opentracing.version>
       <simpleclient.version>0.0.26</simpleclient.version>
       <mockito.version>3.2.4</mockito.version>
       <pax.exam.version>4.13.1</pax.exam.version>
@@ -175,6 +176,25 @@
          <version>${simpleclient.version}</version>
          <scope>provided</scope>
          <optional>true</optional>
+      </dependency>
+      <dependency>
+         <groupId>io.opentracing</groupId>
+         <artifactId>opentracing-api</artifactId>
+         <version>${opentracing.version}</version>
+         <scope>provided</scope>
+         <optional>true</optional>
+      </dependency>
+      <dependency>
+         <groupId>io.opentracing</groupId>
+         <artifactId>opentracing-mock</artifactId>
+         <version>${opentracing.version}</version>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>io.opentracing</groupId>
+         <artifactId>opentracing-util</artifactId>
+         <version>${opentracing.version}</version>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>simple-jndi</groupId>

--- a/src/main/java/com/zaxxer/hikari/metrics/IMetricsTracker.java
+++ b/src/main/java/com/zaxxer/hikari/metrics/IMetricsTracker.java
@@ -27,7 +27,7 @@ public interface IMetricsTracker extends AutoCloseable
 
    default void recordConnectionUsageMillis(final long elapsedBorrowedMillis) {}
 
-   default void recordConnectionTimeout() {}
+   default void recordConnectionTimeout(final long elapsedTimeoutNanos) {}
 
    default void recordConnectionRequest() {}
 

--- a/src/main/java/com/zaxxer/hikari/metrics/IMetricsTracker.java
+++ b/src/main/java/com/zaxxer/hikari/metrics/IMetricsTracker.java
@@ -29,6 +29,8 @@ public interface IMetricsTracker extends AutoCloseable
 
    default void recordConnectionTimeout() {}
 
+   default void recordConnectionRequest() {}
+
    @Override
    default void close() {}
 }

--- a/src/main/java/com/zaxxer/hikari/metrics/dropwizard/CodaHaleMetricsTracker.java
+++ b/src/main/java/com/zaxxer/hikari/metrics/dropwizard/CodaHaleMetricsTracker.java
@@ -106,8 +106,9 @@ public final class CodaHaleMetricsTracker implements IMetricsTracker
    }
 
    @Override
-   public void recordConnectionTimeout()
+   public void recordConnectionTimeout(final long elapsedTimeoutNanos)
    {
+      connectionObtainTimer.update(elapsedTimeoutNanos, TimeUnit.NANOSECONDS);
       connectionTimeoutMeter.mark();
    }
 

--- a/src/main/java/com/zaxxer/hikari/metrics/micrometer/MicrometerMetricsTracker.java
+++ b/src/main/java/com/zaxxer/hikari/metrics/micrometer/MicrometerMetricsTracker.java
@@ -139,8 +139,9 @@ public class MicrometerMetricsTracker implements IMetricsTracker
    }
 
    @Override
-   public void recordConnectionTimeout()
+   public void recordConnectionTimeout(final long elapsedTimeoutNanos)
    {
+      recordConnectionAcquiredNanos(elapsedTimeoutNanos);
       connectionTimeoutCounter.increment();
    }
 

--- a/src/main/java/com/zaxxer/hikari/metrics/opentracing/OpenTracingMetricsTracker.java
+++ b/src/main/java/com/zaxxer/hikari/metrics/opentracing/OpenTracingMetricsTracker.java
@@ -1,0 +1,57 @@
+package com.zaxxer.hikari.metrics.opentracing;
+
+import com.zaxxer.hikari.metrics.IMetricsTracker;
+import io.opentracing.Span;
+import io.opentracing.Tracer;
+
+/**
+ * {@link IMetricsTracker Metrics tracker} for OpenTracing.
+ * This tracker records connection request/acquisition/return as logs on the currently active span.
+ */
+public class OpenTracingMetricsTracker implements IMetricsTracker
+{
+   public static final String HIKARI_METRIC_NAME_PREFIX = "hikaricp";
+
+   private final Tracer tracer;
+   private final String poolName;
+
+   public OpenTracingMetricsTracker(Tracer tracer, String poolName)
+   {
+      this.tracer = tracer;
+      this.poolName = poolName;
+   }
+
+   @Override
+   public void recordConnectionAcquiredNanos(long elapsedAcquiredNanos)
+   {
+      logEvent("connection-acquired");
+   }
+
+   @Override
+   public void recordConnectionUsageMillis(long elapsedBorrowedMillis)
+   {
+      logEvent("connection-returned");
+   }
+
+   @Override
+   public void recordConnectionTimeout(long elapsedTimeoutMillis)
+   {
+      logEvent("connection-timeout");
+   }
+
+   @Override
+   public void recordConnectionRequest()
+   {
+      logEvent("connection-requested");
+   }
+
+   private void logEvent(String eventName)
+   {
+      Span span = tracer.scopeManager().activeSpan();
+      if (span == null) {
+         return;
+      }
+
+      span.log(HIKARI_METRIC_NAME_PREFIX + "." + poolName + "." + eventName);
+   }
+}

--- a/src/main/java/com/zaxxer/hikari/metrics/opentracing/OpenTracingMetricsTrackerFactory.java
+++ b/src/main/java/com/zaxxer/hikari/metrics/opentracing/OpenTracingMetricsTrackerFactory.java
@@ -1,0 +1,21 @@
+package com.zaxxer.hikari.metrics.opentracing;
+
+import com.zaxxer.hikari.metrics.IMetricsTracker;
+import com.zaxxer.hikari.metrics.MetricsTrackerFactory;
+import com.zaxxer.hikari.metrics.PoolStats;
+import io.opentracing.Tracer;
+
+public class OpenTracingMetricsTrackerFactory implements MetricsTrackerFactory
+{
+   private final Tracer tracer;
+
+   public OpenTracingMetricsTrackerFactory(Tracer tracer) {
+      this.tracer = tracer;
+   }
+
+   @Override
+   public IMetricsTracker create(String poolName, PoolStats poolStats)
+   {
+      return new OpenTracingMetricsTracker(tracer, poolName);
+   }
+}

--- a/src/main/java/com/zaxxer/hikari/metrics/prometheus/PrometheusHistogramMetricsTracker.java
+++ b/src/main/java/com/zaxxer/hikari/metrics/prometheus/PrometheusHistogramMetricsTracker.java
@@ -91,7 +91,8 @@ class PrometheusHistogramMetricsTracker implements IMetricsTracker
    }
 
    @Override
-   public void recordConnectionTimeout() {
+   public void recordConnectionTimeout(long elapsedTimeoutNanos) {
+      elapsedAcquiredHistogramChild.observe(elapsedTimeoutNanos);
       connectionTimeoutCounterChild.inc();
    }
 }

--- a/src/main/java/com/zaxxer/hikari/metrics/prometheus/PrometheusMetricsTracker.java
+++ b/src/main/java/com/zaxxer/hikari/metrics/prometheus/PrometheusMetricsTracker.java
@@ -96,8 +96,9 @@ class PrometheusMetricsTracker implements IMetricsTracker
    }
 
    @Override
-   public void recordConnectionTimeout()
+   public void recordConnectionTimeout(long elapsedTimeoutNanos)
    {
+      elapsedAcquiredSummaryChild.observe(elapsedTimeoutNanos);
       connectionTimeoutCounterChild.inc();
    }
 

--- a/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
+++ b/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
@@ -193,7 +193,6 @@ public final class HikariPool extends PoolBase implements HikariPoolMXBean, IBag
             }
          } while (timeout > 0L);
 
-         metricsTracker.recordBorrowTimeoutStats(startTime);
          throw createTimeoutException(startTime);
       }
       catch (InterruptedException e) {
@@ -685,7 +684,7 @@ public final class HikariPool extends PoolBase implements HikariPoolMXBean, IBag
    private SQLException createTimeoutException(long startTime)
    {
       logPoolState("Timeout failure ");
-      metricsTracker.recordConnectionTimeout();
+      metricsTracker.recordConnectionTimeout(startTime);
 
       String sqlState = null;
       final Throwable originalException = getLastConnectionFailure();

--- a/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
+++ b/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
@@ -173,7 +173,7 @@ public final class HikariPool extends PoolBase implements HikariPoolMXBean, IBag
    {
       suspendResumeLock.acquire();
       final long startTime = currentTime();
-
+      metricsTracker.recordConnectionRequest();
       try {
          long timeout = hardTimeout;
          do {

--- a/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
+++ b/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
@@ -685,11 +685,9 @@ abstract class PoolBase
 
       default void recordConnectionCreated(long connectionCreatedMillis) {}
 
-      default void recordBorrowTimeoutStats(long startTime) {}
-
       default void recordBorrowStats(final PoolEntry poolEntry, final long startTime) {}
 
-      default void recordConnectionTimeout() {}
+      default void recordConnectionTimeout(long startTime) {}
 
       default void recordConnectionRequest() {}
 
@@ -724,12 +722,6 @@ abstract class PoolBase
       }
 
       @Override
-      public void recordBorrowTimeoutStats(long startTime)
-      {
-         tracker.recordConnectionAcquiredNanos(elapsedNanos(startTime));
-      }
-
-      @Override
       public void recordBorrowStats(final PoolEntry poolEntry, final long startTime)
       {
          final long now = currentTime();
@@ -738,8 +730,8 @@ abstract class PoolBase
       }
 
       @Override
-      public void recordConnectionTimeout() {
-         tracker.recordConnectionTimeout();
+      public void recordConnectionTimeout(long startTime) {
+         tracker.recordConnectionTimeout(elapsedNanos(startTime));
       }
 
       @Override

--- a/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
+++ b/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
@@ -691,6 +691,8 @@ abstract class PoolBase
 
       default void recordConnectionTimeout() {}
 
+      default void recordConnectionRequest() {}
+
       @Override
       default void close() {}
    }
@@ -738,6 +740,11 @@ abstract class PoolBase
       @Override
       public void recordConnectionTimeout() {
          tracker.recordConnectionTimeout();
+      }
+
+      @Override
+      public void recordConnectionRequest() {
+         tracker.recordConnectionRequest();
       }
 
       @Override

--- a/src/test/java/com/zaxxer/hikari/metrics/opentracing/OpenTracingMetricsTrackerTest.java
+++ b/src/test/java/com/zaxxer/hikari/metrics/opentracing/OpenTracingMetricsTrackerTest.java
@@ -1,0 +1,95 @@
+package com.zaxxer.hikari.metrics.opentracing;
+
+import static com.zaxxer.hikari.pool.TestElf.newHikariConfig;
+import static org.junit.Assert.*;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import io.opentracing.Scope;
+import io.opentracing.mock.MockSpan;
+import io.opentracing.mock.MockSpan.LogEntry;
+import io.opentracing.mock.MockTracer;
+import java.sql.Connection;
+import org.junit.Test;
+
+public class OpenTracingMetricsTrackerTest {
+
+   @Test
+   public void testHandlesNoSpanPresent() throws Exception
+   {
+      MockTracer mockTracer = new MockTracer();
+      HikariConfig config = newHikariConfig();
+      config.setMetricsTrackerFactory(new OpenTracingMetricsTrackerFactory(mockTracer));
+      config.setDataSourceClassName("com.zaxxer.hikari.mocks.StubDataSource");
+      config.setMaximumPoolSize(1);
+
+      try (HikariDataSource dataSource = new HikariDataSource(config)) {
+         try (Connection ignored = dataSource.getConnection()) {
+
+         }
+      }
+
+      assertTrue(mockTracer.finishedSpans().isEmpty());
+   }
+
+   @Test
+   public void testLogsEventsOnSpan() throws Exception
+   {
+      MockTracer mockTracer = new MockTracer();
+      HikariConfig config = newHikariConfig();
+      config.setMetricsTrackerFactory(new OpenTracingMetricsTrackerFactory(mockTracer));
+      config.setDataSourceClassName("com.zaxxer.hikari.mocks.StubDataSource");
+      config.setMaximumPoolSize(1);
+
+      MockSpan span = mockTracer.buildSpan("test_span").start();
+
+      try (Scope ignoredScope = mockTracer.activateSpan(span)) {
+         try (HikariDataSource dataSource = new HikariDataSource(config)) {
+            try (Connection ignoredConnection = dataSource.getConnection()) {
+
+            }
+         }
+      }
+
+      span.finish();
+
+      assertLogEvent("hikaricp.testLogsEventsOnSpan.connection-requested", span.logEntries().get(0));
+      assertLogEvent("hikaricp.testLogsEventsOnSpan.connection-acquired", span.logEntries().get(1));
+      assertLogEvent("hikaricp.testLogsEventsOnSpan.connection-returned", span.logEntries().get(2));
+   }
+
+   @Test
+   public void testLogConnectionTimeout() throws Exception
+   {
+      MockTracer mockTracer = new MockTracer();
+      HikariConfig config = newHikariConfig();
+      config.setMetricsTrackerFactory(new OpenTracingMetricsTrackerFactory(mockTracer));
+      config.setDataSourceClassName("com.zaxxer.hikari.mocks.StubDataSource");
+      config.setMaximumPoolSize(1);
+      config.setConnectionTimeout(250);
+
+      MockSpan span = mockTracer.buildSpan("test_span").start();
+
+      try (HikariDataSource dataSource = new HikariDataSource(config)) {
+         try (Connection ignoredConnection1 = dataSource.getConnection()) {
+            try (Scope ignoredScope = mockTracer.activateSpan(span)) {
+               try (Connection ignoredConnection2 = dataSource.getConnection()) {
+
+               } catch (Exception expected) {
+
+               }
+            }
+         }
+      }
+
+      span.finish();
+
+      assertLogEvent("hikaricp.testLogConnectionTimeout.connection-requested", span.logEntries().get(0));
+      assertLogEvent("hikaricp.testLogConnectionTimeout.connection-timeout", span.logEntries().get(1));
+   }
+
+   private void assertLogEvent(String expected, LogEntry logEntry)
+   {
+      assertEquals(expected, logEntry.fields().get("event"));
+   }
+}

--- a/src/test/java/com/zaxxer/hikari/metrics/prometheus/PrometheusMetricsTrackerTest.java
+++ b/src/test/java/com/zaxxer/hikari/metrics/prometheus/PrometheusMetricsTrackerTest.java
@@ -209,7 +209,7 @@ public class PrometheusMetricsTrackerTest
       PrometheusMetricsTrackerFactory prometheusFactory = new PrometheusMetricsTrackerFactory(defaultCollectorRegistry);
       IMetricsTracker prometheusTracker = prometheusFactory.create("testPool", new StubPoolStats(0));
 
-      prometheusTracker.recordConnectionTimeout();
+      prometheusTracker.recordConnectionTimeout(112L);
       prometheusTracker.recordConnectionAcquiredNanos(42L);
       prometheusTracker.recordConnectionUsageMillis(111L);
       prometheusTracker.recordConnectionCreatedMillis(101L);
@@ -219,7 +219,7 @@ public class PrometheusMetricsTrackerTest
          is(1.0));
       assertThat(defaultCollectorRegistry.getSampleValue(
          "hikaricp_connection_acquired_nanos_sum", LABEL_NAMES, labelValues),
-         is(42.0));
+         is(154.0));
       assertThat(defaultCollectorRegistry.getSampleValue(
          "hikaricp_connection_usage_millis_sum", LABEL_NAMES, labelValues),
          is(111.0));

--- a/src/test/java/com/zaxxer/hikari/pool/MetricsTrackerTest.java
+++ b/src/test/java/com/zaxxer/hikari/pool/MetricsTrackerTest.java
@@ -46,7 +46,7 @@ public class MetricsTrackerTest
             // assert that connection timeout was measured
             assertThat(metricsTracker.connectionTimeoutRecorded, is(true));
             // assert that measured time to acquire connection should be roughly equal or greater than the configured connection timeout time
-            assertTrue(metricsTracker.connectionAcquiredNanos >= TimeUnit.NANOSECONDS.convert(timeoutMillis, TimeUnit.MILLISECONDS));
+            assertTrue(metricsTracker.elapsedTimeoutNanos >= TimeUnit.NANOSECONDS.convert(timeoutMillis, TimeUnit.MILLISECONDS));
          }
       }
    }
@@ -58,6 +58,7 @@ public class MetricsTrackerTest
       private Long connectionAcquiredNanos;
       private Long connectionBorrowedMillis;
       private boolean connectionTimeoutRecorded;
+      private long elapsedTimeoutNanos;
 
       @Override
       public void recordConnectionCreatedMillis(long connectionCreatedMillis)
@@ -78,8 +79,9 @@ public class MetricsTrackerTest
       }
 
       @Override
-      public void recordConnectionTimeout()
+      public void recordConnectionTimeout(long elapsedTimeoutNanos)
       {
+         this.elapsedTimeoutNanos = elapsedTimeoutNanos;
          this.connectionTimeoutRecorded = true;
       }
    }


### PR DESCRIPTION
This PR adds an `IMetricsTracker` implementation that logs connection requests/acquisitions/timeouts on the currently active OpenTracing span.

To make this possible, I needed to change on `IMetricsTracker`. Previously, the implementation assumed that every connection timeout should also result in a `recordConnectionAcquiredNanos` call. When logging these events as-is on OpenTracing spans, the logs on the span contain "requested, acquired, timeout", which is incorrect.

This PR moves the recording of "connection acquired" on timeouts to the individual `IMetricsTrackers`. This required a breaking change on `IMetricsTracker` to add the elapsed nanos to `recordConnectionTimeout`.

A non-breaking alternative would be to add `recordBorrowTimeoutStats` to `IMetricsTracker`, but I felt this is exactly the same as `recordConnectionTimeout`, so I went with the breaking change. If `IMetricsTracker` should remain stable, I can change the PR to include the non-breaking alternative.

Fixes https://github.com/brettwooldridge/HikariCP/issues/1499