### PR TITLE
HikariPool - fix major bug with usage of com.zaxxer.hikari.blockUntilFilled in JDK 11 and later

### DIFF
--- a/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
+++ b/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
@@ -138,16 +138,16 @@ public final class HikariPool extends PoolBase implements HikariPoolMXBean, IBag
       this.houseKeeperTask = houseKeepingExecutorService.scheduleWithFixedDelay(new HouseKeeper(), 100L, housekeepingPeriodMs, MILLISECONDS);
 
       if (Boolean.getBoolean("com.zaxxer.hikari.blockUntilFilled") && config.getInitializationFailTimeout() > 1) {
-         addConnectionExecutor.setCorePoolSize(Math.min(16, Runtime.getRuntime().availableProcessors()));
          addConnectionExecutor.setMaximumPoolSize(Math.min(16, Runtime.getRuntime().availableProcessors()));
+         addConnectionExecutor.setCorePoolSize(Math.min(16, Runtime.getRuntime().availableProcessors()));
 
          final long startTime = currentTime();
          while (elapsedMillis(startTime) < config.getInitializationFailTimeout() && getTotalConnections() < config.getMinimumIdle()) {
             quietlySleep(MILLISECONDS.toMillis(100));
          }
 
-         addConnectionExecutor.setCorePoolSize(1);
          addConnectionExecutor.setMaximumPoolSize(1);
+         addConnectionExecutor.setCorePoolSize(1);
       }
    }
 


### PR DESCRIPTION
Due to a change in JDK11 in ThreadPoolExecutor setMaximumPoolSize needs to be done before setCorePoolSize, the current implementation throws IllegalArgumentException and hence prefilling of connections by setting com.zaxxer.hikari.blockUntilFilled is broken.

HikariPool -line 133 - addConnectionExecutor initializes the ThreadPoolExecutor with 1 core and 1 max thread.

Then we get an IllegalArgumentException in line 141while trying to set setCorePoolSize due to check

NOTE: This bug and PR was submitted by some other developers in the past I think, but it's still not fixed.

 if (corePoolSize < 0 || maximumPoolSize < corePoolSize)
            throw new IllegalArgumentException();

 1 < some number of core pools make it throw IllegalArgumentException

Hence setting "com.zaxxer.hikari.blockUntilFilled "  to true and trying to prefill connections fails.
This feature was working fine in JDK 8. Kindly review and merge this pull request.


