### PR TITLE
Adds missing link to Readme href

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The customer's environment imposed a high cost of new connection acquisition, an
 <br/>
 <br/>
 #### You're [probably] doing it wrong.
-<a href=""><img width="200" align="right" src="https://github.com/brettwooldridge/HikariCP/wiki/Postgres_Chart.png"></a>
+<a href="https://github.com/brettwooldridge/HikariCP/wiki/About-Pool-Sizing"><img width="200" align="right" src="https://github.com/brettwooldridge/HikariCP/wiki/Postgres_Chart.png"></a>
 AKA *"What you probably didn't know about connection pool sizing"*.  Watch a video from the Oracle Real-world Performance group, and learn about why connection pools do not need to be sized as large as they often are.  In fact, oversized connection pools have a clear and demonstrable *negative* impact on performance; a 50x difference in the case of the Oracle demonstration.  [Read on to find out](https://github.com/brettwooldridge/HikariCP/wiki/About-Pool-Sizing).
 <br/>
 #### WIX Engineering Analysis


### PR DESCRIPTION
Updates "You're [probably] doing it wrong." image to point to the article.

So that it doesn't lead to a 404 and is the same behavior as the other images in the readme.