### PR TITLE
Remove error log for pool initialization exception

### DIFF
--- a/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
+++ b/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
@@ -590,7 +590,6 @@ public final class HikariPool extends PoolBase implements HikariPoolMXBean, IBag
     */
    private void throwPoolInitializationException(Throwable t)
    {
-      logger.error("{} - Exception during pool initialization.", poolName, t);
       destroyHouseKeepingExecutorService();
       throw new PoolInitializationException(t);
    }


### PR DESCRIPTION
## What
One line change to remove error log for pool initialization exception.

## Why
For a lib, throwing the exception should be sufficient, and it should be the upstream application's responsibility to determine how to handle the exception, whether to log it out or not. In my particular use case, multiple pools are to be initialized when application starts up, the application tolerates some of pools to be failed, printing exception stacks in error log is misleading in this case.