### PR TITLE
Use 'requires static' for optional dependencies

### DIFF
--- a/src/main/java11/module-info.java
+++ b/src/main/java11/module-info.java
@@ -1,15 +1,16 @@
 module com.zaxxer.hikari
 {
-   requires hibernate.core;
    requires java.sql;
    requires java.management;
    requires java.naming;
-   requires javassist;
-   requires simpleclient;
    requires slf4j.api;
-   requires metrics.core;
-   requires metrics.healthchecks;
-   requires micrometer.core;
+ 
+   requires static hibernate.core;
+   requires static javassist;
+   requires static micrometer.core;
+   requires static metrics.core;
+   requires static metrics.healthchecks;
+   requires static simpleclient;
 
    exports com.zaxxer.hikari;
    exports com.zaxxer.hikari.hibernate;


### PR DESCRIPTION
Attempting to compile a project that depends on HikariCP results in the following exceptions:
```
java.lang.module.FindException: Module micrometer.core not found, required by com.zaxxer.hikari
java.lang.module.FindException: Module simpleclient not found, required by com.zaxxer.hikari
java.lang.module.FindException: Module javassist not found, required by com.zaxxer.hikari
java.lang.module.FindException: Module hibernate.core not found, required by com.zaxxer.hikari
```
Since all of these are defined as `optional` in the `pom.xml` of HikariCP, it also makes sense to mark them as such in the `module-info.java` file.
See https://nipafx.dev/java-modules-optional-dependencies
