### PR TITLE
Fix checkDefaultIsolation; proper fallback to default value

### DIFF
--- a/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
+++ b/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
@@ -476,7 +476,7 @@ abstract class PoolBase
    private void checkDefaultIsolation(final Connection connection) throws SQLException
    {
       try {
-         defaultTransactionIsolation = connection.getTransactionIsolation();
+         transactionIsolation = connection.getTransactionIsolation();
          if (transactionIsolation == -1) {
             transactionIsolation = defaultTransactionIsolation;
          }


### PR DESCRIPTION
It seems that the `checkDefaultIsolation` incorrectly assigned the return value of `connection.getTransactionIsolation` to `defaultTransactionIsolation` as opposed to `defaultTransactionIsolation`. This makes this function fail if the `getTransactionIsolation` returns `-1`.