### PR TITLE
Expanded javadoc for the default constructor of HikariConfig

### DIFF
--- a/src/main/java/com/zaxxer/hikari/HikariConfig.java
+++ b/src/main/java/com/zaxxer/hikari/HikariConfig.java
@@ -106,6 +106,12 @@ public class HikariConfig implements HikariConfigMXBean
 
    /**
     * Default constructor
+    * <p>
+    * If the System property {@code hikari.configurationFile} is set,
+    * then the default constructor will attempt to load the specified configuration file
+    * <p>
+    * {@link #HikariConfig(String propertyFileName)} can be similarly used
+    * instead of using the system property
     */
    public HikariConfig()
    {


### PR DESCRIPTION
I feel that the javadoc for the default constructor of HikariConfig leaves more to be desired. 
```java
/**
 * Default constructor
 */
public HikariConfig() 
{ 
  ... 
}
```

If you look at the bottom of the method body for the constructor, you will see that if a property "hikari.configurationFile" is set, then it will attempt to load the file referenced by the property.

```java
String systemProp = System.getProperty("hikaricp.configurationFile");
if (systemProp != null) {
   loadProperties(systemProp);
}
```

I feel that this behavior should be made more clear, especially since there is a constructor that specifically performs this action with the provided argument.
```java
public HikariConfig(String propertyFileName)
{
  this();

  loadProperties(propertyFileName);
}
```