### PR TITLE
[cleanup] erefactor/EclipseJdt - Evaluate without null check

### DIFF
--- a/src/test/java/com/zaxxer/hikari/pool/UnwrapTest.java
+++ b/src/test/java/com/zaxxer/hikari/pool/UnwrapTest.java
@@ -56,7 +56,7 @@ public class UnwrapTest
           assertNotNull(connection);
 
           StubConnection unwrapped = connection.unwrap(StubConnection.class);
-          assertTrue("unwrapped connection is not instance of StubConnection: " + unwrapped, (unwrapped != null && unwrapped instanceof StubConnection));
+          assertTrue("unwrapped connection is not instance of StubConnection: " + unwrapped, (unwrapped instanceof StubConnection));
        }
     }
 


### PR DESCRIPTION
EclipseJdt cleanup 'EvaluateNullable' applied by erefactor.

For EclipseJdt see https://www.eclipse.org/eclipse/news/4.18/jdt.php
For erefactor see https://github.com/cal101/erefactor