### PR TITLE
[cleanup] erefactor/EclipseJdt - Simplify lambda expression and metho…

### DIFF
--- a/src/test/java/com/zaxxer/hikari/pool/TestConcurrentBag.java
+++ b/src/test/java/com/zaxxer/hikari/pool/TestConcurrentBag.java
@@ -69,7 +69,7 @@ public class TestConcurrentBag
    @Test
    public void testConcurrentBag() throws Exception
    {
-      try (ConcurrentBag<PoolEntry> bag = new ConcurrentBag<>((x) -> CompletableFuture.completedFuture(Boolean.TRUE))) {
+      try (ConcurrentBag<PoolEntry> bag = new ConcurrentBag<>(x -> CompletableFuture.completedFuture(Boolean.TRUE))) {
          assertEquals(0, bag.values(8).size());
    
          PoolEntry reserved = pool.newPoolEntry();

--- a/src/test/java/com/zaxxer/hikari/util/TomcatConcurrentBagLeakTest.java
+++ b/src/test/java/com/zaxxer/hikari/util/TomcatConcurrentBagLeakTest.java
@@ -112,7 +112,7 @@ public class TomcatConcurrentBagLeakTest
       @SuppressWarnings({"ResultOfMethodCallIgnored"})
       public void createConcurrentBag() throws InterruptedException
       {
-         try (ConcurrentBag<PoolEntry> bag = new ConcurrentBag<>((x) -> CompletableFuture.completedFuture(Boolean.TRUE))) {
+         try (ConcurrentBag<PoolEntry> bag = new ConcurrentBag<>(x -> CompletableFuture.completedFuture(Boolean.TRUE))) {
 
             PoolEntry entry = new PoolEntry();
             bag.add(entry);


### PR DESCRIPTION
…d reference syntax

EclipseJdt cleanup 'SimplifyLambdaExpression' applied by erefactor.

For EclipseJdt see https://www.eclipse.org/eclipse/news/4.18/jdt.php
For erefactor see https://github.com/cal101/erefactor