### PR TITLE
Fixed: connection wouldnt close if logger throws Error

### DIFF
--- a/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
+++ b/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
@@ -139,12 +139,12 @@ abstract class PoolBase
             catch (SQLException e) {
                // ignore
             }
-            finally {
+         } finally {
+            try {
                connection.close(); // continue with the close even if setNetworkTimeout() throws
+            } catch (Exception e) {
+               logger.debug("{} - Closing connection {} failed", poolName, connection, e);
             }
-         }
-         catch (Exception e) {
-            logger.debug("{} - Closing connection {} failed", poolName, connection, e);
          }
       }
    }


### PR DESCRIPTION
When we use hikaripool in our app at some (now it is undefined) reason, our log rotating throws NoClassDefFoundError so connection was never closed and hikari create 130 connections to database while app was runned. this code will fix it .

our logs:

```
2021-03-24 20:28:15.120 DEBUG 10557 --- [nnection closer] c.z.h.p.PoolBase                         : HikariPool-1 - Closing connection org.postgresql.jdbc.PgConnection@1d8bcd32: (connection has passed maxLifetime)
Exception in thread "HikariPool-1 connection closer" java.lang.NoClassDefFoundError: org/apache/logging/log4j/core/pattern/NotANumber
	at org.apache.logging.log4j.core.appender.rolling.AbstractRolloverStrategy.getEligibleFiles(AbstractRolloverStrategy.java:93)
	at org.apache.logging.log4j.core.appender.rolling.AbstractRolloverStrategy.getEligibleFiles(AbstractRolloverStrategy.java:86)
	at org.apache.logging.log4j.core.appender.rolling.DefaultRolloverStrategy.purgeAscending(DefaultRolloverStrategy.java:414)
	at org.apache.logging.log4j.core.appender.rolling.DefaultRolloverStrategy.purge(DefaultRolloverStrategy.java:401)
	at org.apache.logging.log4j.core.appender.rolling.DefaultRolloverStrategy.rollover(DefaultRolloverStrategy.java:530)
	at org.apache.logging.log4j.core.appender.rolling.RollingFileManager.rollover(RollingFileManager.java:427)
	at org.apache.logging.log4j.core.appender.rolling.RollingFileManager.rollover(RollingFileManager.java:339)
	at org.apache.logging.log4j.core.appender.rolling.RollingFileManager.checkRollover(RollingFileManager.java:273)
	at org.apache.logging.log4j.core.appender.RollingFileAppender.append(RollingFileAppender.java:311)
	at org.apache.logging.log4j.core.config.AppenderControl.tryCallAppender(AppenderControl.java:156)
	at org.apache.logging.log4j.core.config.AppenderControl.callAppender0(AppenderControl.java:129)
	at org.apache.logging.log4j.core.config.AppenderControl.callAppenderPreventRecursion(AppenderControl.java:120)
	at org.apache.logging.log4j.core.config.AppenderControl.callAppender(AppenderControl.java:84)
	at org.apache.logging.log4j.core.config.LoggerConfig.callAppenders(LoggerConfig.java:543)
	at org.apache.logging.log4j.core.config.LoggerConfig.processLogEvent(LoggerConfig.java:502)
	at org.apache.logging.log4j.core.config.LoggerConfig.log(LoggerConfig.java:485)
	at org.apache.logging.log4j.core.config.LoggerConfig.log(LoggerConfig.java:460)
	at org.apache.logging.log4j.core.config.AwaitCompletionReliabilityStrategy.log(AwaitCompletionReliabilityStrategy.java:82)
	at org.apache.logging.log4j.core.Logger.log(Logger.java:161)
	at org.apache.logging.log4j.spi.AbstractLogger.tryLogMessage(AbstractLogger.java:2198)
	at org.apache.logging.log4j.spi.AbstractLogger.logMessageTrackRecursion(AbstractLogger.java:2152)
	at org.apache.logging.log4j.spi.AbstractLogger.logMessageSafely(AbstractLogger.java:2135)
	at org.apache.logging.log4j.spi.AbstractLogger.logMessage(AbstractLogger.java:2022)
	at org.apache.logging.log4j.spi.AbstractLogger.logIfEnabled(AbstractLogger.java:1891)
	at org.apache.logging.slf4j.Log4jLogger.debug(Log4jLogger.java:134)
	at com.zaxxer.hikari.pool.PoolBase.quietlyCloseConnection(PoolBase.java:130)
	at com.zaxxer.hikari.pool.HikariPool.lambda$closeConnection$1(HikariPool.java:447)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
2021-03-24 20:28:15.133 DEBUG 10557 --- [onnection adder] c.z.h.p.HikariPool                       : HikariPool-1 - Added connection org.postgresql.jdbc.PgConnection@5524324d
```

code fails at line:
`logger.debug("{} - Closing connection {}: {}", poolName, connection, closureReason);`
and method close() on connection was never executed.