### PR TITLE
#1714 support HikariMetricsConfig and hikari.metrics.nameing2 system …

### DIFF
--- a/src/main/java/com/zaxxer/hikari/metrics/HikariMetricsConfig.java
+++ b/src/main/java/com/zaxxer/hikari/metrics/HikariMetricsConfig.java
@@ -1,0 +1,84 @@
+package com.zaxxer.hikari.metrics;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+import com.zaxxer.hikari.util.PropertyElf;
+
+/**
+ * Hikari Metrics Configuration
+ */
+public class HikariMetricsConfig
+{
+   private boolean metricNaming2;
+
+   public HikariMetricsConfig()
+   {
+      metricNaming2 = false;
+      String systemProp = System.getProperty("hikaricp.configurationFile");
+      if (systemProp != null) {
+         loadProperties(systemProp);
+      }
+      String isMetricName2 = System.getProperty("hikari.metrics.naming2");
+      if (isMetricName2 != null) {
+         metricNaming2 = Boolean.parseBoolean(isMetricName2);
+      }
+   }
+
+   /**
+    * Construct a HikariMetricsConfig from the specified properties object.
+    *
+    * @param properties the name of the property file
+    */
+   public HikariMetricsConfig(Properties properties)
+   {
+      this();
+      PropertyElf.setTargetFromProperties(this, properties);
+   }
+
+   /**
+    * Construct a HikariMetricsConfig from the specified property file name.  <code>propertyFileName</code>
+    * will first be treated as a path in the file-system, and if that fails the
+    * Class.getResourceAsStream(propertyFileName) will be tried.
+    *
+    * @param propertyFileName the name of the property file
+    */
+   public HikariMetricsConfig(String propertyFileName)
+   {
+      this();
+
+      loadProperties(propertyFileName);
+   }
+
+   public boolean isMetricNaming2()
+   {
+      return metricNaming2;
+   }
+
+
+   public void setMetricNaming2(boolean isMetricNaming2)
+   {
+      this.metricNaming2 = isMetricNaming2;
+   }
+
+
+   private void loadProperties(String propertyFileName)
+   {
+      final File propFile = new File(propertyFileName);
+      try (final InputStream is = propFile.isFile() ? new FileInputStream(propFile) : this.getClass().getResourceAsStream(propertyFileName)) {
+         if (is != null) {
+            Properties props = new Properties();
+            props.load(is);
+            PropertyElf.setTargetFromProperties(this, props);
+         } else {
+            throw new IllegalArgumentException("Cannot find property file: " + propertyFileName);
+         }
+      }
+      catch (IOException io) {
+         throw new RuntimeException("Failed to read property file", io);
+      }
+   }
+}

--- a/src/main/java/com/zaxxer/hikari/metrics/prometheus/PrometheusMetricsTrackerFactory.java
+++ b/src/main/java/com/zaxxer/hikari/metrics/prometheus/PrometheusMetricsTrackerFactory.java
@@ -16,6 +16,7 @@
 
 package com.zaxxer.hikari.metrics.prometheus;
 
+import com.zaxxer.hikari.metrics.HikariMetricsConfig;
 import com.zaxxer.hikari.metrics.IMetricsTracker;
 import com.zaxxer.hikari.metrics.MetricsTrackerFactory;
 import com.zaxxer.hikari.metrics.PoolStats;
@@ -36,7 +37,7 @@ import static com.zaxxer.hikari.metrics.prometheus.PrometheusMetricsTrackerFacto
  * <pre>{@code
  * config.setMetricsTrackerFactory(new PrometheusMetricsTrackerFactory(new CollectorRegistry()));
  * }</pre>
- *
+ * <p>
  * Note: the internal {@see io.prometheus.client.Summary} requires heavy locks. Consider using
  * {@see PrometheusHistogramMetricsTrackerFactory} if performance plays a role and you don't need the summary per se.
  */
@@ -45,7 +46,7 @@ public class PrometheusMetricsTrackerFactory implements MetricsTrackerFactory
 
    private final static Map<CollectorRegistry, RegistrationStatus> registrationStatuses = new ConcurrentHashMap<>();
 
-   private final HikariCPCollector collector = new HikariCPCollector();
+   private final HikariCPCollector collector;
 
    private final CollectorRegistry collectorRegistry;
 
@@ -69,7 +70,17 @@ public class PrometheusMetricsTrackerFactory implements MetricsTrackerFactory
     */
    public PrometheusMetricsTrackerFactory(CollectorRegistry collectorRegistry)
    {
+      this(collectorRegistry, new HikariMetricsConfig());
+   }
+
+   /**
+    * Constructor that allows to pass in a {@link CollectorRegistry} and a
+    * {@link HikariMetricsConfig} to which the Hikari metrics are registered.
+    */
+   public PrometheusMetricsTrackerFactory(CollectorRegistry collectorRegistry, HikariMetricsConfig config)
+   {
       this.collectorRegistry = collectorRegistry;
+      this.collector = new HikariCPCollector(config);
    }
 
    @Override


### PR DESCRIPTION
…properties to config the prometheus metric name format as "hikari_connections_**" to fix issue #1714