### PR TITLE
Fix: Avoid HikariPool leakage on early close

### DIFF
--- a/src/test/java/com/zaxxer/hikari/datasource/TestCloseDuringLazyInitialization.java
+++ b/src/test/java/com/zaxxer/hikari/datasource/TestCloseDuringLazyInitialization.java
@@ -1,0 +1,51 @@
+package com.zaxxer.hikari.datasource;
+
+import static org.junit.Assert.assertEquals;
+
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import org.junit.Test;
+
+import com.zaxxer.hikari.HikariDataSource;
+
+public class TestCloseDuringLazyInitialization {
+
+    @Test
+    public void testCloseDuringLazyInitialization() throws Exception {
+        HikariDataSource ds = new HikariDataSource();
+        ds.setDataSourceClassName("com.zaxxer.hikari.mocks.StubDataSource");
+
+        ExecutorService executorService = Executors.newFixedThreadPool(2);
+
+        Callable<Void> getConnection = () -> {
+            try {
+                ds.getConnection();
+            } catch (SQLException e) {
+                // might be closed already
+            }
+            return null;
+        };
+
+        Callable<Void> close = () -> {
+            ds.close();
+            return null;
+        };
+
+        List<Future<Void>> futures = executorService.invokeAll(Arrays.asList(getConnection, close));
+        executorService.shutdown();
+
+        for (Future<?> future : futures) {
+            future.get();
+        }
+
+        assertEquals("HikariDataSource was not closed", true, ds.isClosed());
+        assertEquals("HikariPool was not shutdown", false, ds.isRunning());
+    }
+
+}


### PR DESCRIPTION
When using Hikari's lazy pool initialization during getConnection() the initialization is now properly synchronized with the close() of the DataSource.
This avoids situations where the HikariPool is never shutdown when close() on HikariDataSource is called concurrently to the first getConnection() call.

For example earlier the following scenario was possible:
- Two threads T1 and T2 running concurrently
- T1: getConnection() starts HikariPool initialization
- T2: getClose() closes HikariDataSource, but doesn't shutdown pool, as its not yet initialized
- T1: Finalizes HikariPool initialization, which is now never shutdown and never used.