### PR TITLE
Mssql timeout handling

### DIFF
--- a/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
+++ b/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
@@ -77,6 +77,7 @@ abstract class PoolBase
    private int transactionIsolation;
    private Executor netTimeoutExecutor;
    private DataSource dataSource;
+   private String dataSourceClassName;
 
    private final String schema;
    private final boolean isReadOnly;
@@ -340,6 +341,12 @@ abstract class PoolBase
       }
 
       this.dataSource = ds;
+      this.dataSourceClassName = ds.getClass().getName();
+   }
+
+   public String getDataSourceClassName()
+   {
+      return dataSourceClassName;
    }
 
    /**

--- a/src/main/java/com/zaxxer/hikari/pool/ProxyConnection.java
+++ b/src/main/java/com/zaxxer/hikari/pool/ProxyConnection.java
@@ -155,7 +155,7 @@ public abstract class ProxyConnection implements Connection
       for (int depth = 0; delegate != ClosedConnection.CLOSED_CONNECTION && nse != null && depth < 10; depth++) {
          final var sqlState = nse.getSQLState();
          if (sqlState != null && sqlState.startsWith("08")
-             || (nse instanceof SQLTimeoutException && nse.getSQLState().equals("HY008") && nse.getErrorCode() == 0)
+             || (nse instanceof SQLTimeoutException && "HY008".equals(sqlState) && nse.getErrorCode() == 0)
              || ERROR_STATES.contains(sqlState)
              || ERROR_CODES.contains(nse.getErrorCode())) {
 

--- a/src/main/java/com/zaxxer/hikari/pool/ProxyConnection.java
+++ b/src/main/java/com/zaxxer/hikari/pool/ProxyConnection.java
@@ -155,7 +155,7 @@ public abstract class ProxyConnection implements Connection
       for (int depth = 0; delegate != ClosedConnection.CLOSED_CONNECTION && nse != null && depth < 10; depth++) {
          final var sqlState = nse.getSQLState();
          if (sqlState != null && sqlState.startsWith("08")
-             || nse instanceof SQLTimeoutException
+             || (nse instanceof SQLTimeoutException && nse.getSQLState().equals("HY008"))
              || ERROR_STATES.contains(sqlState)
              || ERROR_CODES.contains(nse.getErrorCode())) {
 

--- a/src/main/java/com/zaxxer/hikari/pool/ProxyConnection.java
+++ b/src/main/java/com/zaxxer/hikari/pool/ProxyConnection.java
@@ -155,7 +155,7 @@ public abstract class ProxyConnection implements Connection
       for (int depth = 0; delegate != ClosedConnection.CLOSED_CONNECTION && nse != null && depth < 10; depth++) {
          final var sqlState = nse.getSQLState();
          if (sqlState != null && sqlState.startsWith("08")
-             || (nse instanceof SQLTimeoutException && nse.getSQLState().equals("HY008"))
+             || (nse instanceof SQLTimeoutException && nse.getSQLState().equals("HY008") && nse.getErrorCode() == 0)
              || ERROR_STATES.contains(sqlState)
              || ERROR_CODES.contains(nse.getErrorCode())) {
 

--- a/src/main/java/com/zaxxer/hikari/pool/ProxyConnection.java
+++ b/src/main/java/com/zaxxer/hikari/pool/ProxyConnection.java
@@ -155,7 +155,7 @@ public abstract class ProxyConnection implements Connection
       for (int depth = 0; delegate != ClosedConnection.CLOSED_CONNECTION && nse != null && depth < 10; depth++) {
          final var sqlState = nse.getSQLState();
          if (sqlState != null && sqlState.startsWith("08")
-             || (nse instanceof SQLTimeoutException && nse.getSQLState().equals("HY008") && nse.getErrorCode() == 0)
+             || (nse instanceof SQLTimeoutException && isMicrosoftSqlServer())
              || ERROR_STATES.contains(sqlState)
              || ERROR_CODES.contains(nse.getErrorCode())) {
 
@@ -182,6 +182,12 @@ public abstract class ProxyConnection implements Connection
       }
 
       return sqle;
+   }
+
+   private final boolean isMicrosoftSqlServer()
+   {
+      return getPoolEntry().getPoolBase().getDataSourceClassName()
+         .equals("com.microsoft.sqlserver.jdbc.SQLServerDataSource");
    }
 
    final synchronized void untrackStatement(final Statement statement)

--- a/src/test/java/com/zaxxer/hikari/mocks/StubStatement.java
+++ b/src/test/java/com/zaxxer/hikari/mocks/StubStatement.java
@@ -32,6 +32,7 @@ import java.sql.Statement;
 public class StubStatement implements Statement
 {
    public static volatile boolean oldDriver;
+   public static volatile SQLException throwException;
 
    private static volatile long simulatedQueryTime;
    private boolean closed;
@@ -395,6 +396,10 @@ public class StubStatement implements Statement
    {
       if (closed) {
          throw new SQLException("Statement is closed");
+      } else if (throwException != null) {
+         SQLException toThrow = throwException;
+         throwException = null;
+         throw toThrow;
       }
    }
 }

--- a/src/test/java/com/zaxxer/hikari/pool/TestElf.java
+++ b/src/test/java/com/zaxxer/hikari/pool/TestElf.java
@@ -63,6 +63,18 @@ public final class TestElf
       }
    }
 
+   public static void setDataSourceClassName(HikariPool pool, String value)
+   {
+      try {
+         Field field = PoolBase.class.getDeclaredField("dataSourceClassName");
+         field.setAccessible(true);
+         field.set(pool, value);
+      }
+      catch (Exception e) {
+         throw new RuntimeException(e);
+      }
+   }
+
    static ConcurrentBag<?> getConcurrentBag(final HikariDataSource ds)
    {
       try {


### PR DESCRIPTION
Resolves #1591 & #1388 which are different reports of an issue introduced by the fix in #1308.

We have a unit test that takes a connection from Hikari, then explicitly interrupts that thread, and then assumes it can continue to use the connection - this test fails against Oracle, but works against Postgres (the two DB we principally support).

The problem is caused by this change in :
```
-         if (sqlState != null && sqlState.startsWith("08") || ERROR_STATES.contains(sqlState) || ERROR_CODES.contains(nse.getErrorCode())) {
+         if (sqlState != null && sqlState.startsWith("08")
+             || nse instanceof SQLTimeoutException
+             || ERROR_STATES.contains(sqlState)
+             || ERROR_CODES.contains(nse.getErrorCode())) {
```

I believe this change was too broad and that the original problem is a fault the way MS SQL's driver handles timeouts. The JDK docs describe:

`public class SQLTimeoutException extends SQLTransientException`
The subclass of SQLException thrown when the timeout specified by Statement has expired.

This exception does not correspond to a standard SQLState.

`public class SQLTransientException extends SQLException`
The subclass of SQLException is thrown in situations where a previously failed operation might be able to succeed when the operation is retried without any intervention by application-level functionality.

By these definitions, a SQLTimeoutException should not kill the connection.

**MSSQL**

An SQLTimeoutException doesn't imply a connection problem - the operation "might" succeed on retry. I'd argue MS SQL is doing the wrong thing in closing the connection due to hitting a timeout, but this behaviour is consistent with their documentation of cancelQueryTimeout at https://docs.microsoft.com/en-us/sql/connect/jdbc/setting-the-connection-properties?view=sql-server-ver15:
(Version 6.4+) This property can be used to cancel a queryTimeout set on the connection. Query execution hangs and doesn't throw an exception if the TCP connection to the server is silently dropped. This property is only applicable if 'queryTimeout' is also set on the connection.

*The driver waits the total amount of cancelQueryTimeout + queryTimeout seconds, to drop the connection and close the channel.*

The default value for this property is -1 and behavior is to wait indefinitely.

**Postgres** 

Running our test in against Postgres 13.3 we that Postgres throws a org.postgresql.util.PSQLException - so isn't subject to this problem, because PSQLException extends SQLException.

**Oracle**

From the JDK definition, I'd also argue it is not unreasonable for Oracle to throw SQLTimeoutException on explicit interrupt - though perhaps just SQLTransientException would have been better - given the operation will succeed on retry (as per the JDK spec) and an interruption doesn't necessarily imply a timeout.

In this instance Hikari is incorrectly closing the connection.

*Solution*
Limit the close case to SQLTimeoutException where the JDBC datasource class is MS SQL Server.