### PR TITLE
Allow configuring explicit driver class loader

### DIFF
--- a/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
+++ b/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
@@ -323,7 +323,7 @@ abstract class PoolBase
          PropertyElf.setTargetFromProperties(ds, dataSourceProperties);
       }
       else if (jdbcUrl != null && ds == null) {
-         ds = new DriverDataSource(jdbcUrl, driverClassName, dataSourceProperties, username, password);
+         ds = new DriverDataSource(jdbcUrl, driverClassName, dataSourceProperties, username, password, config.getDriverClassLoader());
       }
       else if (dataSourceJNDI != null && ds == null) {
          try {

--- a/src/main/java/com/zaxxer/hikari/util/DriverDataSource.java
+++ b/src/main/java/com/zaxxer/hikari/util/DriverDataSource.java
@@ -40,7 +40,11 @@ public final class DriverDataSource implements DataSource
    private final Properties driverProperties;
    private Driver driver;
 
-   public DriverDataSource(String jdbcUrl, String driverClassName, Properties properties, String username, String password)
+   public DriverDataSource(String jdbcUrl, String driverClassName, Properties properties, String username, String password) {
+      this(jdbcUrl, driverClassName, properties, username, password, null);
+   }
+
+   public DriverDataSource(String jdbcUrl, String driverClassName, Properties properties, String username, String password, ClassLoader cl)
    {
       this.jdbcUrl = jdbcUrl;
       this.driverProperties = new Properties();
@@ -67,27 +71,36 @@ public final class DriverDataSource implements DataSource
          }
 
          if (driver == null) {
-            LOGGER.warn("Registered driver with driverClassName={} was not found, trying direct instantiation.", driverClassName);
             Class<?> driverClass = null;
-            var threadContextClassLoader = Thread.currentThread().getContextClassLoader();
-            try {
-               if (threadContextClassLoader != null) {
-                  try {
-                     driverClass = threadContextClassLoader.loadClass(driverClassName);
-                     LOGGER.debug("Driver class {} found in Thread context class loader {}", driverClassName, threadContextClassLoader);
-                  }
-                  catch (ClassNotFoundException e) {
-                     LOGGER.debug("Driver class {} not found in Thread context class loader {}, trying classloader {}",
-                                  driverClassName, threadContextClassLoader, this.getClass().getClassLoader());
-                  }
+            if (cl != null) {
+               try {
+                  driverClass = cl.loadClass(driverClassName);
+               } catch (ClassNotFoundException e) {
+                  throw new RuntimeException("Driver " + driverClassName + " not found in explicitly passed class loader, " + cl);
                }
+            }
 
-               if (driverClass == null) {
-                  driverClass = this.getClass().getClassLoader().loadClass(driverClassName);
-                  LOGGER.debug("Driver class {} found in the HikariConfig class classloader {}", driverClassName, this.getClass().getClassLoader());
+            if (driverClass == null) {
+               LOGGER.warn("Registered driver with driverClassName={} was not found, trying direct instantiation.", driverClassName);
+               var threadContextClassLoader = Thread.currentThread().getContextClassLoader();
+               try {
+                  if (threadContextClassLoader != null) {
+                     try {
+                        driverClass = threadContextClassLoader.loadClass(driverClassName);
+                        LOGGER.debug("Driver class {} found in Thread context class loader {}", driverClassName, threadContextClassLoader);
+                     } catch (ClassNotFoundException e) {
+                        LOGGER.debug("Driver class {} not found in Thread context class loader {}, trying classloader {}",
+                           driverClassName, threadContextClassLoader, this.getClass().getClassLoader());
+                     }
+                  }
+
+                  if (driverClass == null) {
+                     driverClass = this.getClass().getClassLoader().loadClass(driverClassName);
+                     LOGGER.debug("Driver class {} found in the HikariConfig class classloader {}", driverClassName, this.getClass().getClassLoader());
+                  }
+               } catch (ClassNotFoundException e) {
+                  LOGGER.debug("Failed to load driver class {} from HikariConfig class classloader {}", driverClassName, this.getClass().getClassLoader());
                }
-            } catch (ClassNotFoundException e) {
-               LOGGER.debug("Failed to load driver class {} from HikariConfig class classloader {}", driverClassName, this.getClass().getClassLoader());
             }
 
             if (driverClass != null) {


### PR DESCRIPTION
For more controlled classloading than was added in https://github.com/brettwooldridge/HikariCP/pull/881

I'm trying to use this to replace `commons-dbcp2` in Jenkins, and neither of the classloading options that are available here work (docs: https://www.jenkins.io/doc/developer/plugin-development/dependencies-and-class-loading/)

Similar issue:
https://github.com/FasterXML/jackson-dataformat-xml/issues/483#issuecomment-873723152

I've tested this in Jenkins and it works.
