### PR TITLE
Do not evict on SQLTimeoutException by default

### DIFF
--- a/src/main/java/com/zaxxer/hikari/SQLExceptionOverride.java
+++ b/src/main/java/com/zaxxer/hikari/SQLExceptionOverride.java
@@ -1,14 +1,19 @@
 package com.zaxxer.hikari;
 
 import java.sql.SQLException;
+import java.sql.SQLTimeoutException;
 
 /**
- * Users can implement this interface to override the default SQLException handling
- * of HikariCP.  By the time an instance of this interface is invoked HikariCP has
- * already made a determination to evict the Connection from the pool.
+ * Users can implement this interface to override the default SQLException eviction handling of HikariCP.
+ * By the time an instance of this interface is invoked HikariCP has already made a determination the connection is a
+ * candidate to evict from the pool.
  *
- * If the {@link #adjudicate(SQLException)} method returns {@link Override#CONTINUE_EVICT} the eviction will occur, but if the
- * method returns {@link Override#DO_NOT_EVICT} the eviction will be elided.
+ * If the {@link #adjudicate(SQLException)} method returns {@link Override#CONTINUE_EVICT} the eviction will occur, but
+ * if the method returns {@link Override#DO_NOT_EVICT} the eviction will be elided.
+ *
+ * If an implementation isn't provided in the connection pool configuration, HikariCP will install a default
+ * instance that does not evict if the exception is derived from #SQLTimeoutException, otherwise the eviction will
+ * proceed.
  */
 public interface SQLExceptionOverride {
    enum Override {
@@ -25,6 +30,6 @@ public interface SQLExceptionOverride {
     */
    default Override adjudicate(final SQLException sqlException)
    {
-      return Override.CONTINUE_EVICT;
+      return sqlException instanceof SQLTimeoutException ? Override.DO_NOT_EVICT : Override.CONTINUE_EVICT;
    }
 }

--- a/src/main/java/com/zaxxer/hikari/pool/ProxyConnection.java
+++ b/src/main/java/com/zaxxer/hikari/pool/ProxyConnection.java
@@ -16,6 +16,7 @@
 
 package com.zaxxer.hikari.pool;
 
+import com.zaxxer.hikari.SQLExceptionOverride;
 import com.zaxxer.hikari.util.FastList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,6 +43,8 @@ public abstract class ProxyConnection implements Connection
    static final int DIRTY_BIT_CATALOG    = 0b001000;
    static final int DIRTY_BIT_NETTIMEOUT = 0b010000;
    static final int DIRTY_BIT_SCHEMA     = 0b100000;
+
+   private final static SQLExceptionOverride DEFAULT_SQLEXCEPTION_OVERRIDE = new SQLExceptionOverride() {};
 
    private static final Logger LOGGER;
    private static final Set<String> ERROR_STATES;
@@ -159,7 +162,9 @@ public abstract class ProxyConnection implements Connection
              || ERROR_STATES.contains(sqlState)
              || ERROR_CODES.contains(nse.getErrorCode())) {
 
-            if (exceptionOverride != null && exceptionOverride.adjudicate(nse) == DO_NOT_EVICT) {
+
+            if ((exceptionOverride != null
+               ? exceptionOverride.adjudicate(nse) : DEFAULT_SQLEXCEPTION_OVERRIDE.adjudicate(nse)) == DO_NOT_EVICT) {
                break;
             }
 

--- a/src/test/java/com/zaxxer/hikari/mocks/StubStatement.java
+++ b/src/test/java/com/zaxxer/hikari/mocks/StubStatement.java
@@ -32,6 +32,7 @@ import java.sql.Statement;
 public class StubStatement implements Statement
 {
    public static volatile boolean oldDriver;
+   public static volatile SQLException throwException;
 
    private static volatile long simulatedQueryTime;
    private boolean closed;
@@ -395,6 +396,10 @@ public class StubStatement implements Statement
    {
       if (closed) {
          throw new SQLException("Statement is closed");
+      } else if (throwException != null) {
+         SQLException toThrow = throwException;
+         throwException = null;
+         throw toThrow;
       }
    }
 }


### PR DESCRIPTION
Resolves #1591 & #1388 which are different reports of an issue introduced by the fix in #1308.

The JDK defines:

```
public class SQLTimeoutException extends SQLTransientException
The subclass of SQLException thrown when the timeout specified by Statement has expired.

This exception does not correspond to a standard SQLState.

public class SQLTransientException extends SQLException
The subclass of SQLException is thrown in situations where a previously failed operation might be able to succeed when the operation is retried without any intervention by application-level functionality.
```

By definition then, `SQLTimeoutExceptions` should not result in eviction/nor connection close. Oracle throws `SQLTimeoutException` on statement timeout, and also when a thread waiting on results is explicitly interrupted. The latter case is particularly problematic where `autoCommit` is enabled, as the connection close will unexpectedly commit the transaction before user code can roll it back. 

If the current behaviour to evict on `SQLTimeoutException` is desired, that remains possible by providing a class name implementing the existing `SQLExceptionOverride`, however this should definitely not be the default.