### PR TITLE
Remove redundant explicit imports

### DIFF
--- a/src/main/java/com/zaxxer/hikari/metrics/dropwizard/CodahaleHealthChecker.java
+++ b/src/main/java/com/zaxxer/hikari/metrics/dropwizard/CodahaleHealthChecker.java
@@ -18,8 +18,6 @@ package com.zaxxer.hikari.metrics.dropwizard;
 
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.Properties;
-import java.util.SortedMap;
 import java.util.concurrent.TimeUnit;
 
 import com.codahale.metrics.MetricRegistry;

--- a/src/main/java/com/zaxxer/hikari/util/DriverDataSource.java
+++ b/src/main/java/com/zaxxer/hikari/util/DriverDataSource.java
@@ -21,8 +21,6 @@ import java.sql.Driver;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
-import java.util.Enumeration;
-import java.util.Map.Entry;
 import java.util.Properties;
 
 import javax.sql.DataSource;


### PR DESCRIPTION
### What this PR does:

According to [openjdk](https://openjdk.java.net/projects/amber/LVTIstyle.html), The type of the variable is inferred from the type of the initializer. So, I removed some `import` statements that has not been shown in the codes as a variable type anymore.

Thanks.

### References
https://developer.oracle.com/java/jdk-10-local-variable-type-inference.html
https://openjdk.java.net/projects/amber/LVTIstyle.html