### PR TITLE
Check connection has not been closed at first while checking the validity of connection

### DIFF
--- a/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
+++ b/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
@@ -147,6 +147,10 @@ abstract class PoolBase
    boolean isConnectionDead(final Connection connection)
    {
       try {
+         if(connection.isClosed()){
+            return false;
+         }
+
          try {
             setNetworkTimeout(connection, validationTimeout);
 

--- a/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
+++ b/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
@@ -148,7 +148,7 @@ abstract class PoolBase
    {
       try {
          if(connection.isClosed()){
-            return false;
+            return true;
          }
 
          try {


### PR DESCRIPTION
In the current implementation of PoolBase#isConnectionDead(isConnectionAlive) setNetworkTimeout() is called firstly to check the connection validity:
PoolBase#L151

In many JDBC drivers, calling Connection#setNetworkTimeout throws SqlException in the case when a connection is closed.
For example, Postgres JDBC driver throws PSQLException("This connection has been closed.") by calling setNetworkTimeout()
PgConnection#L1622
PgConnection.java#L883

The behavior of isConnectionDead() method looks odd because in the case of apriori closed connection it causes an exception and logging warning.
If a connection is not valid by the result of Connection.isValid method the warning is not logged.
The warning message could be confusing due to the indirect relation between maxLifeTime parameter and closed connections.

The proposal is to check that connection is closed before calling setNetworkTimeout thereby not causing the exception and logging the warning.