### PR TITLE
Update DriverDataSource to not convert all provided property values to String.

### DIFF
--- a/src/main/java/com/zaxxer/hikari/HikariConfig.java
+++ b/src/main/java/com/zaxxer/hikari/HikariConfig.java
@@ -1105,6 +1105,9 @@ public class HikariConfig implements HikariConfigMXBean
             if ("dataSourceProperties".equals(prop)) {
                var dsProps = PropertyElf.copyProperties(dataSourceProperties);
                dsProps.setProperty("password", "<masked>");
+               if (dsProps.containsKey("privateKey")) {
+                  dsProps.setProperty("privateKey", "<masked>");
+               }
                value = dsProps;
             }
 

--- a/src/main/java/com/zaxxer/hikari/HikariJNDIFactory.java
+++ b/src/main/java/com/zaxxer/hikari/HikariJNDIFactory.java
@@ -45,7 +45,7 @@ public class HikariJNDIFactory implements ObjectFactory
             var element = enumeration.nextElement();
             var type = element.getType();
             if (type.startsWith("dataSource.") || hikariPropSet.contains(type)) {
-               properties.setProperty(type, element.getContent().toString());
+               properties.put(type, element.getContent());
             }
          }
          return createDataSource(properties, nameCtx);

--- a/src/main/java/com/zaxxer/hikari/util/DriverDataSource.java
+++ b/src/main/java/com/zaxxer/hikari/util/DriverDataSource.java
@@ -46,7 +46,7 @@ public final class DriverDataSource implements DataSource
       this.driverProperties = new Properties();
 
       for (var entry : properties.entrySet()) {
-         driverProperties.setProperty(entry.getKey().toString(), entry.getValue().toString());
+         driverProperties.put(entry.getKey().toString(), entry.getValue());
       }
 
       if (username != null) {

--- a/src/main/java/com/zaxxer/hikari/util/PropertyElf.java
+++ b/src/main/java/com/zaxxer/hikari/util/PropertyElf.java
@@ -105,7 +105,7 @@ public final class PropertyElf
    public static Properties copyProperties(final Properties props)
    {
       var copy = new Properties();
-      props.forEach((key, value) -> copy.setProperty(key.toString(), value.toString()));
+      props.forEach((key, value) -> copy.put(key.toString(), value));
       return copy;
    }
 

--- a/src/test/java/com/zaxxer/hikari/pool/TestJNDI.java
+++ b/src/test/java/com/zaxxer/hikari/pool/TestJNDI.java
@@ -44,11 +44,13 @@ public class TestJNDI
       ref.add(new BogusRef("maxLifetime", "30000"));
       ref.add(new BogusRef("maximumPoolSize", "10"));
       ref.add(new BogusRef("dataSource.loginTimeout", "10"));
+      ref.add(new BogusRef("dataSource.nonStringObj", Integer.valueOf(10)));
       Context nameCtx = new BogusContext();
 
       try (HikariDataSource ds = (HikariDataSource) jndi.getObjectInstance(ref, null, nameCtx, null)) {
          assertNotNull(ds);
          assertEquals("foo", getUnsealedConfig(ds).getUsername());
+         assertEquals(ds.getDataSourceProperties().get("nonStringObj"), Integer.valueOf(10));
       }
    }
 
@@ -149,8 +151,8 @@ public class TestJNDI
    {
       private static final long serialVersionUID = 1L;
 
-      private String content;
-      BogusRef(String type, String content)
+      private Object content;
+      BogusRef(String type, Object content)
       {
          super(type);
          this.content = content;

--- a/src/test/java/com/zaxxer/hikari/util/PropertyElfTest.java
+++ b/src/test/java/com/zaxxer/hikari/util/PropertyElfTest.java
@@ -41,4 +41,26 @@ public class PropertyElfTest
          assertEquals("argument type mismatch", e.getCause().getMessage());
       }
    }
+
+   @Test
+   public void copyPropertiesPropValueIsString() {
+      Properties propertiesOrig = new Properties();
+      String stringPropName = "stringProp";
+      String stringPropValue = "aString";
+      propertiesOrig.setProperty(stringPropName, stringPropValue);
+
+      Properties propertiesCopy = PropertyElf.copyProperties(propertiesOrig);
+      assertEquals(stringPropValue, propertiesCopy.getProperty(stringPropName));
+   }
+
+   @Test
+   public void copyPropertiesPropValueIsNonStringObject() {
+      Properties propertiesOrig = new Properties();
+      String propName = "nonStringProp";
+      Integer propValue = 10;
+      propertiesOrig.put(propName, propValue);
+
+      Properties propertiesCopy = PropertyElf.copyProperties(propertiesOrig);
+      assertEquals(propValue, propertiesCopy.get(propName));
+   }
 }


### PR DESCRIPTION
This PR updates DriverDataSource to preserve the original driver property values provided to DriverDataSource's constructor instead of converting all property values to String representations. This addresses issues like those brought up in https://github.com/brettwooldridge/HikariCP/issues/1496 and https://github.com/brettwooldridge/HikariCP/issues/1242 where non-String Object property values are being provided.

This is particularly important for the latter issue of compatibility with the Snowflake JDBC driver, which supports a ["privateKey" property requiring a value of type java.security.PrivateKey](https://github.com/snowflakedb/snowflake-jdbc/blob/master/src/main/java/net/snowflake/client/core/SFSessionProperty.java#L31) but [throws an exception](https://github.com/snowflakedb/snowflake-jdbc/blob/master/src/main/java/net/snowflake/client/core/SFSessionProperty.java#L143) due to DriverDataSource's current behavior of converting the property value to a String representation.

Updates have also been  madeto PropertyElf for consistency, as suggested in comments on an older unmerged PR (https://github.com/brettwooldridge/HikariCP/pull/1557) for this issue.