### PR TITLE
Add GraalVM native-image configuration

### DIFF
--- a/native/access-filter.json
+++ b/native/access-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "includeClasses": "**"
+    },
+    {
+      "excludeClasses": "org.apache.logging.log4j.**"
+    }
+  ]
+}

--- a/native/caller-filter.json
+++ b/native/caller-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "com.zaxxer.hikari.**"
+    }
+  ]
+}

--- a/native/user-code-filter.json
+++ b/native/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "com.zaxxer.hikari.**"
+    }
+  ]
+}

--- a/pom.xml
+++ b/pom.xml
@@ -250,6 +250,9 @@
          <resource>
             <directory>target/classes</directory>
          </resource>
+         <resource>
+            <directory>src/main/resources</directory>
+         </resource>
       </resources>
 
       <plugins>
@@ -653,6 +656,31 @@
                <scope>test</scope>
             </dependency>
          </dependencies>
+      </profile>
+
+      <profile>
+         <id>native</id>
+         <build>
+            <plugins>
+               <plugin>
+                  <groupId>org.graalvm.buildtools</groupId>
+                  <artifactId>native-maven-plugin</artifactId>
+                  <version>0.9.13</version>
+                  <extensions>true</extensions>
+                  <configuration>
+                     <agent>
+                        <options>
+                           <option>experimental-conditional-config-part</option>
+                        </options>
+                        <options name="test">
+                           <option>access-filter-file=${project.basedir}/native/access-filter.json</option>
+                           <option>caller-filter-file=${project.basedir}/native/caller-filter.json</option>
+                        </options>
+                     </agent>
+                  </configuration>
+               </plugin>
+            </plugins>
+         </build>
       </profile>
    </profiles>
 </project>

--- a/run-tests-with-agent.sh
+++ b/run-tests-with-agent.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+echo "Running tests..."
+mvn clean test -Pnative -Dagent=true -Dmaven.test.failure.ignore=true -Djacoco.skip=true
+
+echo "Post-processing native-image files"
+INPUT_DIR=(target/native/agent-output/test/session-*)
+OUTPUT_DIR="src/main/resources/META-INF/native-image/com.zaxxer/HikariCP"
+mkdir -p "$OUTPUT_DIR"
+native-image-configure generate-conditional --user-code-filter=native/user-code-filter.json --input-dir="$INPUT_DIR" --output-dir="$OUTPUT_DIR"

--- a/src/main/resources/META-INF/native-image/com.zaxxer/HikariCP/jni-config.json
+++ b/src/main/resources/META-INF/native-image/com.zaxxer/HikariCP/jni-config.json
@@ -1,0 +1,20 @@
+[
+  {
+    "name": "java.lang.ClassLoader",
+    "methods": [
+      {
+        "name": "getPlatformClassLoader",
+        "parameterTypes": []
+      },
+      {
+        "name": "loadClass",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "jdk.internal.loader.ClassLoaders$PlatformClassLoader"
+  }
+]

--- a/src/main/resources/META-INF/native-image/com.zaxxer/HikariCP/predefined-classes-config.json
+++ b/src/main/resources/META-INF/native-image/com.zaxxer/HikariCP/predefined-classes-config.json
@@ -1,0 +1,8 @@
+[
+  {
+    "type":"agent-extracted",
+    "classes":[
+    ]
+  }
+]
+

--- a/src/main/resources/META-INF/native-image/com.zaxxer/HikariCP/proxy-config.json
+++ b/src/main/resources/META-INF/native-image/com.zaxxer/HikariCP/proxy-config.json
@@ -1,0 +1,10 @@
+[
+  {
+    "condition": {
+      "typeReachable": "com.zaxxer.hikari.pool.ProxyConnection$ClosedConnection"
+    },
+    "interfaces": [
+      "java.sql.Connection"
+    ]
+  }
+]

--- a/src/main/resources/META-INF/native-image/com.zaxxer/HikariCP/reflect-config.json
+++ b/src/main/resources/META-INF/native-image/com.zaxxer/HikariCP/reflect-config.json
@@ -1,0 +1,485 @@
+[
+  {
+    "condition": {
+      "typeReachable": "com.zaxxer.hikari.util.ConcurrentBag"
+    },
+    "name": "[Lcom.zaxxer.hikari.util.ConcurrentBag$IConcurrentBagEntry;"
+  },
+  {
+    "condition": {
+      "typeReachable": "com.zaxxer.hikari.pool.PoolEntry"
+    },
+    "name": "[Ljava.sql.Statement;"
+  },
+  {
+    "condition": {
+      "typeReachable": "com.zaxxer.hikari.util.FastList"
+    },
+    "name": "[Ljava.sql.Statement;"
+  },
+  {
+    "condition": {
+      "typeReachable": "com.zaxxer.hikari.HikariConfig"
+    },
+    "name": "com.zaxxer.hikari.HikariConfig",
+    "allDeclaredFields": true,
+    "queryAllPublicMethods": true,
+    "methods": [
+      {
+        "name": "setAutoCommit",
+        "parameterTypes": [
+          "boolean"
+        ]
+      },
+      {
+        "name": "setConnectionTestQuery",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "setDataSourceClassName",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "setMinimumIdle",
+        "parameterTypes": [
+          "int"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.zaxxer.hikari.HikariJNDIFactory"
+    },
+    "name": "com.zaxxer.hikari.HikariConfig",
+    "queryAllPublicMethods": true,
+    "methods": [
+      {
+        "name": "setDataSourceJNDI",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "setDriverClassName",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "setJdbcUrl",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "setMaxLifetime",
+        "parameterTypes": [
+          "long"
+        ]
+      },
+      {
+        "name": "setMaximumPoolSize",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "setPassword",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "setUsername",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.zaxxer.hikari.hibernate.HikariConfigurationUtil"
+    },
+    "name": "com.zaxxer.hikari.HikariConfig",
+    "queryAllPublicMethods": true,
+    "methods": [
+      {
+        "name": "setAutoCommit",
+        "parameterTypes": [
+          "boolean"
+        ]
+      },
+      {
+        "name": "setConnectionTestQuery",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "setDataSourceClassName",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.zaxxer.hikari.util.PropertyElf"
+    },
+    "name": "com.zaxxer.hikari.HikariConfig",
+    "methods": [
+      {
+        "name": "getCatalog",
+        "parameterTypes": []
+      },
+      {
+        "name": "getConnectionInitSql",
+        "parameterTypes": []
+      },
+      {
+        "name": "getConnectionTestQuery",
+        "parameterTypes": []
+      },
+      {
+        "name": "getConnectionTimeout",
+        "parameterTypes": []
+      },
+      {
+        "name": "getDataSource",
+        "parameterTypes": []
+      },
+      {
+        "name": "getDataSourceClassName",
+        "parameterTypes": []
+      },
+      {
+        "name": "getDataSourceJNDI",
+        "parameterTypes": []
+      },
+      {
+        "name": "getDataSourceProperties",
+        "parameterTypes": []
+      },
+      {
+        "name": "getDriverClassName",
+        "parameterTypes": []
+      },
+      {
+        "name": "getHealthCheckProperties",
+        "parameterTypes": []
+      },
+      {
+        "name": "getHealthCheckRegistry",
+        "parameterTypes": []
+      },
+      {
+        "name": "getIdleTimeout",
+        "parameterTypes": []
+      },
+      {
+        "name": "getJdbcUrl",
+        "parameterTypes": []
+      },
+      {
+        "name": "getLeakDetectionThreshold",
+        "parameterTypes": []
+      },
+      {
+        "name": "getMaxLifetime",
+        "parameterTypes": []
+      },
+      {
+        "name": "getMaximumPoolSize",
+        "parameterTypes": []
+      },
+      {
+        "name": "getMetricRegistry",
+        "parameterTypes": []
+      },
+      {
+        "name": "getMetricsTrackerFactory",
+        "parameterTypes": []
+      },
+      {
+        "name": "getMinimumIdle",
+        "parameterTypes": []
+      },
+      {
+        "name": "getPassword",
+        "parameterTypes": []
+      },
+      {
+        "name": "getPoolName",
+        "parameterTypes": []
+      },
+      {
+        "name": "getScheduledExecutorService",
+        "parameterTypes": []
+      },
+      {
+        "name": "getThreadFactory",
+        "parameterTypes": []
+      },
+      {
+        "name": "getTransactionIsolation",
+        "parameterTypes": []
+      },
+      {
+        "name": "getUsername",
+        "parameterTypes": []
+      },
+      {
+        "name": "getValidationTimeout",
+        "parameterTypes": []
+      },
+      {
+        "name": "isAllowPoolSuspension",
+        "parameterTypes": []
+      },
+      {
+        "name": "isAutoCommit",
+        "parameterTypes": []
+      },
+      {
+        "name": "isInitializationFailFast",
+        "parameterTypes": []
+      },
+      {
+        "name": "isIsolateInternalQueries",
+        "parameterTypes": []
+      },
+      {
+        "name": "isJdbc4ConnectionTest",
+        "parameterTypes": []
+      },
+      {
+        "name": "isReadOnly",
+        "parameterTypes": []
+      },
+      {
+        "name": "isRegisterMbeans",
+        "parameterTypes": []
+      }
+    ],
+    "queriedMethods": [
+      {
+        "name": "setAllowPoolSuspension",
+        "parameterTypes": [
+          "boolean"
+        ]
+      },
+      {
+        "name": "setAutoCommit",
+        "parameterTypes": [
+          "boolean"
+        ]
+      },
+      {
+        "name": "setCatalog",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "setConnectionInitSql",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "setConnectionTestQuery",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "setConnectionTimeout",
+        "parameterTypes": [
+          "long"
+        ]
+      },
+      {
+        "name": "setDataSource",
+        "parameterTypes": [
+          "javax.sql.DataSource"
+        ]
+      },
+      {
+        "name": "setDataSourceClassName",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "setDataSourceJNDI",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "setDataSourceProperties",
+        "parameterTypes": [
+          "java.util.Properties"
+        ]
+      },
+      {
+        "name": "setDriverClassName",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "setHealthCheckProperties",
+        "parameterTypes": [
+          "java.util.Properties"
+        ]
+      },
+      {
+        "name": "setHealthCheckRegistry",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "setIdleTimeout",
+        "parameterTypes": [
+          "long"
+        ]
+      },
+      {
+        "name": "setInitializationFailFast",
+        "parameterTypes": [
+          "boolean"
+        ]
+      },
+      {
+        "name": "setIsolateInternalQueries",
+        "parameterTypes": [
+          "boolean"
+        ]
+      },
+      {
+        "name": "setJdbc4ConnectionTest",
+        "parameterTypes": [
+          "boolean"
+        ]
+      },
+      {
+        "name": "setJdbcUrl",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "setLeakDetectionThreshold",
+        "parameterTypes": [
+          "long"
+        ]
+      },
+      {
+        "name": "setMaxLifetime",
+        "parameterTypes": [
+          "long"
+        ]
+      },
+      {
+        "name": "setMaximumPoolSize",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "setMetricRegistry",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "setMetricsTrackerFactory",
+        "parameterTypes": [
+          "com.zaxxer.hikari.metrics.MetricsTrackerFactory"
+        ]
+      },
+      {
+        "name": "setMinimumIdle",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "setPassword",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "setPoolName",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "setReadOnly",
+        "parameterTypes": [
+          "boolean"
+        ]
+      },
+      {
+        "name": "setRegisterMbeans",
+        "parameterTypes": [
+          "boolean"
+        ]
+      },
+      {
+        "name": "setScheduledExecutorService",
+        "parameterTypes": [
+          "java.util.concurrent.ScheduledThreadPoolExecutor"
+        ]
+      },
+      {
+        "name": "setThreadFactory",
+        "parameterTypes": [
+          "java.util.concurrent.ThreadFactory"
+        ]
+      },
+      {
+        "name": "setTransactionIsolation",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "setUsername",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "setValidationTimeout",
+        "parameterTypes": [
+          "long"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.zaxxer.hikari.util.UtilityElf"
+    },
+    "name": "java.sql.Connection",
+    "fields": []
+  },
+  {
+    "condition": {
+      "typeReachable": "com.zaxxer.hikari.util.Sequence$Factory"
+    },
+    "name": "java.util.concurrent.atomic.LongAdder"
+  }
+]

--- a/src/main/resources/META-INF/native-image/com.zaxxer/HikariCP/resource-config.json
+++ b/src/main/resources/META-INF/native-image/com.zaxxer/HikariCP/resource-config.json
@@ -1,0 +1,7 @@
+{
+  "resources": {
+    "includes": [
+    ]
+  },
+  "bundles": []
+}

--- a/src/main/resources/META-INF/native-image/com.zaxxer/HikariCP/serialization-config.json
+++ b/src/main/resources/META-INF/native-image/com.zaxxer/HikariCP/serialization-config.json
@@ -1,0 +1,6 @@
+{
+  "types": [
+  ],
+  "lambdaCapturingTypes": [
+  ]
+}


### PR DESCRIPTION
This allows HikariCP to be used in a GraalVM native image without additional configuration.

The JSON configuration files have been generated by running 'run-tests-with-agent.sh', which executes the test suite with the native-image-agent attached and then generates the configuration metadata located in src/main/resources.

References:

* https://www.graalvm.org/22.1/reference-manual/native-image/Agent/
* https://www.graalvm.org/22.1/reference-manual/native-image/Reflection/