### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
       <docker.maven.plugin.fabric8.version>0.36.0</docker.maven.plugin.fabric8.version>
       <felix.bundle.plugin.version>5.1.1</felix.bundle.plugin.version>
       <felix.version>6.0.1</felix.version>
-      <hibernate.version>5.4.24.Final</hibernate.version>
+      <hibernate.version>6.1.2.Final</hibernate.version>
       <javassist.version>3.27.0-GA</javassist.version>
       <jndi.version>0.11.4.1</jndi.version>
       <maven.release.version>2.5.3</maven.release.version>
@@ -22,7 +22,7 @@
       <mockito.version>3.7.7</mockito.version>
       <pax.exam.version>4.13.1</pax.exam.version>
       <pax.url.version>2.5.4</pax.url.version>
-      <postgresql.version>42.3.3</postgresql.version>
+      <postgresql.version>42.4.1</postgresql.version>
       <log4j.version>2.17.2</log4j.version>
       <slf4j.version>1.7.30</slf4j.version>
       <commons.csv.version>1.5</commons.csv.version>


### PR DESCRIPTION
Upgrading POM.XML to ensure PostgresSQL and hibernate-core vulnerabilities are mitigated. The versions used in the maven release are vulnerable and should be upgraded.