### PR TITLE
Don't attempt second setNetworkTimeout call if first fails

### DIFF
--- a/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
+++ b/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
@@ -148,9 +148,8 @@ abstract class PoolBase
    boolean isConnectionDead(final Connection connection)
    {
       try {
+         setNetworkTimeout(connection, validationTimeout);
          try {
-            setNetworkTimeout(connection, validationTimeout);
-
             final var validationSeconds = (int) Math.max(1000L, validationTimeout) / 1000;
 
             if (isUseJdbc4Validation) {

--- a/src/test/java/com/zaxxer/hikari/mocks/StubConnection.java
+++ b/src/test/java/com/zaxxer/hikari/mocks/StubConnection.java
@@ -47,6 +47,7 @@ public class StubConnection extends StubBaseConnection
    public static final AtomicInteger count = new AtomicInteger();
    public static volatile boolean slowCreate;
    public static volatile boolean oldDriver;
+   public static volatile Callable<Void> networkTimeoutSetter;
    private volatile boolean isClosed = false;
 
    private static long foo;
@@ -506,6 +507,17 @@ public class StubConnection extends StubBaseConnection
    /** {@inheritDoc} */
    public void setNetworkTimeout(Executor executor, int milliseconds) throws SQLException
    {
+      if (networkTimeoutSetter != null) {
+         try {
+            networkTimeoutSetter.call();
+         }
+         catch (SQLException e) {
+            throw e;
+         }
+         catch (Exception e) {
+            throw new RuntimeException(e);
+         }
+      }
    }
 
    /** {@inheritDoc} */


### PR DESCRIPTION
This pull request intends to reduce at least some of the confusion around exceptions from setNetworkTimeout.

In isConnectionDead (previously isConnectionAlive) there are two calls to setNetworkTimeout. If the first call failed it would attempt to call setNetworkTimeout a second time anyway. I believe that there should be no reason why we would want to call it a second time after the first fails.

In the case where we were calling it a second time it would end up using exception of the second call as the lastConnectionFailure when it is almost certainly more meaningful to see the exception from the first.

The pull request doesn't address any issues related to there already having been an error by the time setNetworkTimeout is called, but looking at previously reported issues, I'm not sure that that is actually a problem.