### PR TITLE
Add metrics integration packages to the OSGi exported packages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -434,7 +434,10 @@
                   <Export-Package>
                      com.zaxxer.hikari,
                      com.zaxxer.hikari.hibernate,
-                     com.zaxxer.hikari.metrics
+                     com.zaxxer.hikari.metrics,
+                     com.zaxxer.hikari.metrics.dropwizard,
+                     com.zaxxer.hikari.metrics.micrometer,
+                     com.zaxxer.hikari.metrics.prometheus
                   </Export-Package>
                   <Private-Package>com.zaxxer.hikari.*</Private-Package>
                   <Include-Resource>{maven-resources}</Include-Resource>


### PR DESCRIPTION
Currently, HikariCP OSGi Exports a limited number of packages. 
This change adds `com.zaxxer.hikari.metrics.dropwizard`, `com.zaxxer.hikari.metrics.micrometer` and `com.zaxxer.hikari.metrics.prometheus` to the list so that the relevant `MetricsTrackerFactory` can be instantiated in an OSGi environment.