### PR TITLE
Add uuid to identify connection timings

### DIFF
--- a/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
+++ b/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
@@ -351,27 +351,31 @@ abstract class PoolBase
    private Connection newConnection() throws Exception
    {
       final var start = currentTime();
+      final var id = java.util.UUID.randomUUID();
 
       Connection connection = null;
       try {
          var username = config.getUsername();
          var password = config.getPassword();
 
+         logger.debug("{} - Attempting to create/setup new connection: {}", poolName, id.toString());
+         
          connection = (username == null) ? dataSource.getConnection() : dataSource.getConnection(username, password);
          if (connection == null) {
             throw new SQLTransientConnectionException("DataSource returned null unexpectedly");
          }
 
          setupConnection(connection);
+         logger.debug("{} - Established new connection: {}", poolName, id);
          lastConnectionFailure.set(null);
          return connection;
       }
       catch (Exception e) {
          if (connection != null) {
-            quietlyCloseConnection(connection, "(Failed to create/setup connection)");
+            quietlyCloseConnection(connection, "(Failed to create/setup connection for id:".concat(id.toString()));
          }
          else if (getLastConnectionFailure() == null) {
-            logger.debug("{} - Failed to create/setup connection: {}", poolName, e.getMessage());
+            logger.debug("{} - Failed to create/setup connection: {}", poolName, e.getMessage(), id.toString());
          }
 
          lastConnectionFailure.set(e);

--- a/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
+++ b/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
@@ -358,7 +358,7 @@ abstract class PoolBase
          var username = config.getUsername();
          var password = config.getPassword();
 
-         logger.debug("{} - Attempting to create/setup new connection: {}", poolName, id.toString());
+         logger.debug("{} - Attempting to create/setup new connection: {} ", poolName, id.toString());
          
          connection = (username == null) ? dataSource.getConnection() : dataSource.getConnection(username, password);
          if (connection == null) {
@@ -375,7 +375,7 @@ abstract class PoolBase
             quietlyCloseConnection(connection, "(Failed to create/setup connection for id:".concat(id.toString()));
          }
          else if (getLastConnectionFailure() == null) {
-            logger.debug("{} - Failed to create/setup connection: {}", poolName, e.getMessage(), id.toString());
+            logger.debug("{} - Failed to create/setup connection: {} {}", poolName, e.getMessage(), id.toString());
          }
 
          lastConnectionFailure.set(e);


### PR DESCRIPTION
For our use of HikariCP we have determined that the average duration of time between connection creation attempt and connection established can be an indicator for determining health between the application layer and the database.

AFAIK, there is no way current way to correlate an attempt at establishing a connection and the existing logging "Added connection", this is an attempt to change that.