### PR TITLE
Add connectionCreatorClassName config property (for dynamic passwords)

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,14 @@ be used for various internally scheduled tasks.  If supplying HikariCP with a ``
 instance, it is recommended that ``setRemoveOnCancelPolicy(true)`` is used.
 *Default: none*
 
+&#128292;``connectionCreatorClassName``<br/>
+HikariCP will by default call the ``DataSource`` ``getConnection`` method directly to create new
+connections. This property allows you to supply your own instance of
+``com.zaxxer.hikari.HikariConnectionCreator`` that will be called any time a new connection is required.
+This is useful for dynamically choosing a username and/or password rather than relying on the
+``username`` and ``password`` properties on ``HikariConfig``.
+*Default: none*
+
 ----------------------------------------------------
 
 #### Missing Knobs

--- a/src/main/java/com/zaxxer/hikari/HikariConnectionCreator.java
+++ b/src/main/java/com/zaxxer/hikari/HikariConnectionCreator.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2022 Brett Wooldridge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.zaxxer.hikari;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import javax.sql.DataSource;
+
+/**
+ * Users can implement this interface to override the default connection creation
+ * procedure.
+ * <p>
+ * Implementors typically determine how the username and password are chosen for
+ * the new connection. For example, the default implementation uses the username
+ * and password from {@link HikariConfig#getUsername()} and
+ * {@link HikariConfig#getPassword()} and passes them directly to
+ * {@link DataSource#getConnection(String, String)} to create the connection.
+ */
+public interface HikariConnectionCreator
+{
+   /**
+    *This method is called when a new connection needs to be added to the pool. One
+    * of {@link DataSource#getConnection(String, String)} or
+    * {@link DataSource#getConnection()} are expected to be called by implementors.
+    *
+    * @param dataSource The {@link DataSource} to use for getting a connection.
+    * @param config The current {@link HikariConfig}
+    * @return A newly created {@link Connection}
+    * @throws SQLException if a database access error occurs
+    */
+   Connection createConnection(DataSource dataSource, HikariConfig config) throws SQLException;
+}

--- a/src/main/java/com/zaxxer/hikari/util/DefaultHikariConnectionCreator.java
+++ b/src/main/java/com/zaxxer/hikari/util/DefaultHikariConnectionCreator.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2022 Brett Wooldridge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.zaxxer.hikari.util;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import javax.sql.DataSource;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariConnectionCreator;
+
+public final class DefaultHikariConnectionCreator implements HikariConnectionCreator
+{
+   @Override
+   public Connection createConnection(DataSource dataSource, HikariConfig config) throws SQLException
+   {
+      var username = config.getUsername();
+      var password = config.getPassword();
+
+      return (username == null) ? dataSource.getConnection() : dataSource.getConnection(username, password);
+   }
+}


### PR DESCRIPTION
add connectionCreatorClassName property to allow users to supply their own logic for creating connections

This is intended to be used for handling situation that require dynamic username/password combinations. For example for systems that require one-time-use passwords. The implementer could lookup or generate the password at the instant that the getConnection method would be called on the DataSource.