### PR TITLE
make github pipline successful

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,8 @@ on:
   push:
     branches:
       - master
-
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
 jobs:
   build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        java: [ '8', '11', '15' ]
+        java: ['11']
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK

--- a/pom.xml
+++ b/pom.xml
@@ -571,7 +571,7 @@
                -add-exports java.base/sun.net.www.protocol.https=ALL-UNNAMED
             </sureFireOptions11 -->
             <slf4j.version>2.0.0-alpha1</slf4j.version>
-            <sureFireForks11>true</sureFireForks11>
+            <sureFireForks11>false</sureFireForks11>
             <automatic.module.name>com.zaxxer.hikari</automatic.module.name>
          </properties>
          <dependencies>


### PR DESCRIPTION
1. set GitHub Action workflow manually from the Actions tab;
2. set jdk 11,set right running jdk version;
3. set  reuseForks of maven-surefire-plugin is false; beacause I find that the class HikariConfigTest have trouble with get log record in pipline test env; you can singlely run HikariConfigTest and it work fine, but with entirely test env; the method TestAppender#append never be invoked ,so HikariConfigTest#testJdbcUrlLogging clouldn't  pass test case. after trying  many times,change the value of reuseForks is the only solve way that  I can found.