### PR TITLE
No reason to issue a warning in the log for any clock-related shifts.

### DIFF
--- a/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
+++ b/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
@@ -787,7 +787,7 @@ public final class HikariPool extends PoolBase implements HikariPoolMXBean, IBag
 
             // Detect retrograde time, allowing +128ms as per NTP spec.
             if (plusMillis(now, 128) < plusMillis(previous, housekeepingPeriodMs)) {
-               logger.warn("{} - Retrograde clock change detected (housekeeper delta={}), soft-evicting connections from pool.",
+               logger.info("{} - Retrograde clock change detected (housekeeper delta={}), soft-evicting connections from pool.",
                            poolName, elapsedDisplayString(previous, now));
                previous = now;
                softEvictConnections();
@@ -795,7 +795,7 @@ public final class HikariPool extends PoolBase implements HikariPoolMXBean, IBag
             }
             else if (now > plusMillis(previous, (3 * housekeepingPeriodMs) / 2)) {
                // No point evicting for forward clock motion, this merely accelerates connection retirement anyway
-               logger.warn("{} - Thread starvation or clock leap detected (housekeeper delta={}).", poolName, elapsedDisplayString(previous, now));
+               logger.info("{} - Thread starvation or clock leap detected (housekeeper delta={}).", poolName, elapsedDisplayString(previous, now));
             }
 
             previous = now;


### PR DESCRIPTION
For years, people's logs have been filled up with warnings about thread starvation and retrograde clock change detections. This change sets the logger level to info for the following reasons:

- There is really nothing the end user can do with this warning, the code solves the issue by itself.
- It creates many questions and searches for solutions on the Internet because people see a WARN, where clearly an INFO would be sufficient
- None of the code paths which follows (hot or cold) has any WARN statements, therefore the granularity of the logger is misleading