### PR TITLE
Added check with exceptionOverride in case of connection dead

### DIFF
--- a/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
+++ b/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
@@ -42,6 +42,7 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static com.zaxxer.hikari.SQLExceptionOverride.Override.DO_NOT_EVICT;
 import static com.zaxxer.hikari.pool.ProxyConnection.*;
 import static com.zaxxer.hikari.util.ClockSource.*;
 import static com.zaxxer.hikari.util.UtilityElf.createInstance;
@@ -145,39 +146,58 @@ abstract class PoolBase
       }
    }
 
+   private boolean doIsConnectionDead(final Connection connection) throws SQLException {
+      setNetworkTimeout(connection, validationTimeout);
+      try {
+         final var validationSeconds = (int) Math.max(1000L, validationTimeout) / 1000;
+
+         if (isUseJdbc4Validation) {
+            return !connection.isValid(validationSeconds);
+         }
+
+         try (var statement = connection.createStatement()) {
+            if (isNetworkTimeoutSupported != TRUE) {
+               setQueryTimeout(statement, validationSeconds);
+            }
+
+            statement.execute(config.getConnectionTestQuery());
+         }
+      }
+      finally {
+         setNetworkTimeout(connection, networkTimeout);
+
+         if (isIsolateInternalQueries && !isAutoCommit) {
+            connection.rollback();
+         }
+      }
+      return false;
+   }
+
+   private void connectionDeadException(final Connection connection, Exception e) {
+      lastConnectionFailure.set(e);
+      logger.warn("{} - Failed to validate connection {} ({}). Possibly consider using a shorter maxLifetime value.",
+         poolName, connection, e.getMessage());
+   }
+
    boolean isConnectionDead(final Connection connection)
    {
       try {
-         setNetworkTimeout(connection, validationTimeout);
-         try {
-            final var validationSeconds = (int) Math.max(1000L, validationTimeout) / 1000;
-
-            if (isUseJdbc4Validation) {
-               return !connection.isValid(validationSeconds);
-            }
-
-            try (var statement = connection.createStatement()) {
-               if (isNetworkTimeoutSupported != TRUE) {
-                  setQueryTimeout(statement, validationSeconds);
-               }
-
-               statement.execute(config.getConnectionTestQuery());
-            }
-         }
-         finally {
-            setNetworkTimeout(connection, networkTimeout);
-
-            if (isIsolateInternalQueries && !isAutoCommit) {
-               connection.rollback();
-            }
-         }
-
-         return false;
+         return doIsConnectionDead(connection);
       }
       catch (Exception e) {
-         lastConnectionFailure.set(e);
-         logger.warn("{} - Failed to validate connection {} ({}). Possibly consider using a shorter maxLifetime value.",
-                     poolName, connection, e.getMessage());
+         if (e instanceof SQLException && exceptionOverride != null &&
+            exceptionOverride.adjudicate((SQLException) e) == DO_NOT_EVICT) {
+            // try one more time, in case of failover
+            try {
+               return doIsConnectionDead(connection);
+            }
+            catch (Exception e2) {
+               connectionDeadException(connection, e2);
+               return true;
+            }
+         }
+
+         connectionDeadException(connection, e);
          return true;
       }
    }


### PR DESCRIPTION
I'm open to suggestions and exploring more on the scenario. :-) 

Scenario:
* Spring boot 2.x
* AWS RDS Aurora MySQL
* Hikari 4.0.3
* aws driver with failover support https://github.com/awslabs/aws-mysql-jdbc

We are trying to take advantage of the `aws-mysql-jdbc` failover plugin.

According to their documentation, they can detect the failover make the switch writer<>reader but an exception will still be thrown to be handled by the pool provider, in our case HikariCP. https://github.com/awslabs/aws-mysql-jdbc#connection-pooling

For the normal scenario, it is ok:
* in the middle of a transaction failover happens
* exception is thrown e.g. Connection.createStatement
* hikaricp will use the `SQLExceptionOverride` and decide to discard or not based on its results
  * with our custom the failover codes `08S02` and `08007` connection is kept and the next interaction everything will be fine

The problem is when acquiring a connection from the pool, the driver has to throw the exception since it is not aware it is in the middle of a transaction of not. But HikariCP doesn't use the `SQLExceptionOverride` at this point, making a good connection to be discarded.

On top of that, in an idle application, the entire pool will be discarded due to the failover, which can occur even hours after the failover has happened.

With the current PR we would use the `SQLExceptionOverride` to decide if the connection is really dead or not by doing one more retry if the error code is a `DO_NOT_EVICT`.



