### PR TITLE
Add support for Virtual Threads

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
       <commons.csv.version>1.5</commons.csv.version>
       <h2.version>2.1.212</h2.version>
       <junit.version>4.13.1</junit.version>
-      <testcontainers.version>1.15.1</testcontainers.version>
+      <testcontainers.version>1.17.6</testcontainers.version>
    </properties>
 
    <groupId>com.zaxxer</groupId>

--- a/src/main/java/com/zaxxer/hikari/HikariConfig.java
+++ b/src/main/java/com/zaxxer/hikari/HikariConfig.java
@@ -36,6 +36,7 @@ import java.util.TreeSet;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.locks.ReentrantLock;
 
 import static com.zaxxer.hikari.util.UtilityElf.getNullIfEmpty;
 import static com.zaxxer.hikari.util.UtilityElf.safeIsAssignableFrom;
@@ -55,6 +56,7 @@ public class HikariConfig implements HikariConfigMXBean
    private static final long MAX_LIFETIME = MINUTES.toMillis(30);
    private static final long DEFAULT_KEEPALIVE_TIME = 0L;
    private static final int DEFAULT_POOL_SIZE = 10;
+   private static final ReentrantLock HIKARI_CONFIG_LOCK = new ReentrantLock();
 
    private static boolean unitTest = false;
 
@@ -1166,10 +1168,13 @@ public class HikariConfig implements HikariConfigMXBean
       final var prefix = "HikariPool-";
       try {
          // Pool number is global to the VM to avoid overlapping pool numbers in classloader scoped environments
-         synchronized (System.getProperties()) {
+         HIKARI_CONFIG_LOCK.lock();
+         try {
             final var next = String.valueOf(Integer.getInteger("com.zaxxer.hikari.pool_number", 0) + 1);
             System.setProperty("com.zaxxer.hikari.pool_number", next);
             return prefix + next;
+         } finally {
+            HIKARI_CONFIG_LOCK.unlock();
          }
       } catch (AccessControlException e) {
          // The SecurityManager didn't allow us to read/write system properties

--- a/src/main/java/com/zaxxer/hikari/HikariDataSource.java
+++ b/src/main/java/com/zaxxer/hikari/HikariDataSource.java
@@ -29,6 +29,7 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.ReentrantLock;
 
 import static com.zaxxer.hikari.pool.HikariPool.POOL_NORMAL;
 
@@ -45,6 +46,7 @@ public class HikariDataSource extends HikariConfig implements DataSource, Closea
 
    private final HikariPool fastPathPool;
    private volatile HikariPool pool;
+   private final ReentrantLock hikariDataSourceLock = new ReentrantLock();
 
    /**
     * Default constructor.  Setters are used to configure the pool.  Using
@@ -103,7 +105,8 @@ public class HikariDataSource extends HikariConfig implements DataSource, Closea
       // See http://en.wikipedia.org/wiki/Double-checked_locking#Usage_in_Java
       HikariPool result = pool;
       if (result == null) {
-         synchronized (this) {
+         hikariDataSourceLock.lock();
+         try {
             result = pool;
             if (result == null) {
                validate();
@@ -122,6 +125,8 @@ public class HikariDataSource extends HikariConfig implements DataSource, Closea
                }
                LOGGER.info("{} - Start completed.", getPoolName());
             }
+         } finally {
+            hikariDataSourceLock.unlock();
          }
       }
 

--- a/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
+++ b/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
@@ -38,6 +38,7 @@ import java.sql.SQLTransientConnectionException;
 import java.util.Optional;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.concurrent.locks.ReentrantLock;
 
 import static com.zaxxer.hikari.util.ClockSource.*;
 import static com.zaxxer.hikari.util.ConcurrentBag.IConcurrentBagEntry.STATE_IN_USE;
@@ -80,6 +81,7 @@ public final class HikariPool extends PoolBase implements HikariPoolMXBean, IBag
 
    private final ScheduledExecutorService houseKeepingExecutorService;
    private ScheduledFuture<?> houseKeeperTask;
+   private final ReentrantLock hikariPoolLock = new ReentrantLock();
 
    /**
     * Construct a HikariPool with the specified configuration.
@@ -193,8 +195,9 @@ public final class HikariPool extends PoolBase implements HikariPoolMXBean, IBag
     *
     * @throws InterruptedException thrown if the thread is interrupted during shutdown
     */
-   public synchronized void shutdown() throws InterruptedException
+   public void shutdown() throws InterruptedException
    {
+      hikariPoolLock.lock();
       try {
          poolState = POOL_SHUTDOWN;
 
@@ -246,6 +249,7 @@ public final class HikariPool extends PoolBase implements HikariPoolMXBean, IBag
          logPoolState("After shutdown ");
          handleMBeans(this, false);
          metricsTracker.close();
+         hikariPoolLock.unlock();
       }
    }
 
@@ -368,25 +372,35 @@ public final class HikariPool extends PoolBase implements HikariPoolMXBean, IBag
 
    /** {@inheritDoc} */
    @Override
-   public synchronized void suspendPool()
+   public void suspendPool()
    {
-      if (suspendResumeLock == SuspendResumeLock.FAUX_LOCK) {
-         throw new IllegalStateException(poolName + " - is not suspendable");
-      }
-      else if (poolState != POOL_SUSPENDED) {
-         suspendResumeLock.suspend();
-         poolState = POOL_SUSPENDED;
+      hikariPoolLock.lock();
+      try {
+         if (suspendResumeLock == SuspendResumeLock.FAUX_LOCK) {
+            throw new IllegalStateException(poolName + " - is not suspendable");
+         }
+         else if (poolState != POOL_SUSPENDED) {
+            suspendResumeLock.suspend();
+            poolState = POOL_SUSPENDED;
+         }
+      } finally {
+        hikariPoolLock.unlock();
       }
    }
 
    /** {@inheritDoc} */
    @Override
-   public synchronized void resumePool()
+   public void resumePool()
    {
-      if (poolState == POOL_SUSPENDED) {
-         poolState = POOL_NORMAL;
-         fillPool(false);
-         suspendResumeLock.resume();
+      hikariPoolLock.lock();
+      try {
+         if (poolState == POOL_SUSPENDED) {
+            poolState = POOL_NORMAL;
+            fillPool(false);
+            suspendResumeLock.resume();
+         }
+      } finally {
+         hikariPoolLock.unlock();
       }
    }
 
@@ -496,18 +510,23 @@ public final class HikariPool extends PoolBase implements HikariPoolMXBean, IBag
    /**
     * Fill pool up from current idle connections (as they are perceived at the point of execution) to minimumIdle connections.
     */
-   private synchronized void fillPool(final boolean isAfterAdd)
+   private void fillPool(final boolean isAfterAdd)
    {
-      final var idle = getIdleConnections();
-      final var shouldAdd = getTotalConnections() < config.getMaximumPoolSize() && idle < config.getMinimumIdle();
+      hikariPoolLock.lock();
+      try {
+         final var idle = getIdleConnections();
+         final var shouldAdd = getTotalConnections() < config.getMaximumPoolSize() && idle < config.getMinimumIdle();
 
-      if (shouldAdd) {
-         final var countToAdd = config.getMinimumIdle() - idle;
-         for (int i = 0; i < countToAdd; i++)
-            addConnectionExecutor.submit(isAfterAdd ? postFillPoolEntryCreator : poolEntryCreator);
-      }
-      else if (isAfterAdd) {
-         logger.debug("{} - Fill pool skipped, pool has sufficient level or currently being filled.", poolName);
+         if (shouldAdd) {
+            final var countToAdd = config.getMinimumIdle() - idle;
+            for (int i = 0; i < countToAdd; i++)
+               addConnectionExecutor.submit(isAfterAdd ? postFillPoolEntryCreator : poolEntryCreator);
+         }
+         else if (isAfterAdd) {
+            logger.debug("{} - Fill pool skipped, pool has sufficient level or currently being filled.", poolName);
+         }
+      } finally {
+         hikariPoolLock.unlock();
       }
    }
 
@@ -704,6 +723,7 @@ public final class HikariPool extends PoolBase implements HikariPoolMXBean, IBag
    private final class PoolEntryCreator implements Callable<Boolean>
    {
       private final String loggingPrefix;
+      private final ReentrantLock poolEntryLock = new ReentrantLock();
 
       PoolEntryCreator()
       {
@@ -754,9 +774,14 @@ public final class HikariPool extends PoolBase implements HikariPoolMXBean, IBag
        *
        * @return true if we should create a connection, false if the need has disappeared
        */
-      private synchronized boolean shouldContinueCreating() {
-         return poolState == POOL_NORMAL && getTotalConnections() < config.getMaximumPoolSize() &&
-            (getIdleConnections() < config.getMinimumIdle() || connectionBag.getWaitingThreadCount() > getIdleConnections());
+      private boolean shouldContinueCreating() {
+         poolEntryLock.lock();
+         try {
+            return poolState == POOL_NORMAL && getTotalConnections() < config.getMaximumPoolSize() &&
+               (getIdleConnections() < config.getMinimumIdle() || connectionBag.getWaitingThreadCount() > getIdleConnections());
+         } finally {
+            poolEntryLock.unlock();
+         }
       }
    }
 

--- a/src/main/java/com/zaxxer/hikari/pool/ProxyConnection.java
+++ b/src/main/java/com/zaxxer/hikari/pool/ProxyConnection.java
@@ -26,6 +26,7 @@ import java.sql.*;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.Executor;
+import java.util.concurrent.locks.ReentrantLock;
 
 import static com.zaxxer.hikari.SQLExceptionOverride.Override.DO_NOT_EVICT;
 
@@ -63,6 +64,7 @@ public abstract class ProxyConnection implements Connection
    private int transactionIsolation;
    private String dbcatalog;
    private String dbschema;
+   protected final ReentrantLock proxyConnectionLock = new ReentrantLock();
 
    // static initializer
    static {
@@ -184,9 +186,14 @@ public abstract class ProxyConnection implements Connection
       return sqle;
    }
 
-   final synchronized void untrackStatement(final Statement statement)
+   final void untrackStatement(final Statement statement)
    {
-      openStatements.remove(statement);
+      proxyConnectionLock.lock();
+      try {
+         openStatements.remove(statement);
+      } finally {
+         proxyConnectionLock.unlock();
+      }
    }
 
    final void markCommitStateDirty()
@@ -201,32 +208,42 @@ public abstract class ProxyConnection implements Connection
       leakTask.cancel();
    }
 
-   private synchronized <T extends Statement> T trackStatement(final T statement)
+   private <T extends Statement> T trackStatement(final T statement)
    {
-      openStatements.add(statement);
+      proxyConnectionLock.lock();
+      try {
+         openStatements.add(statement);
 
-      return statement;
+         return statement;
+      } finally {
+         proxyConnectionLock.unlock();
+      }
    }
 
    @SuppressWarnings("EmptyTryBlock")
-   private synchronized void closeStatements()
+   private void closeStatements()
    {
-      final var size = openStatements.size();
-      if (size > 0) {
-         for (int i = 0; i < size && delegate != ClosedConnection.CLOSED_CONNECTION; i++) {
-            try (Statement ignored = openStatements.get(i)) {
-               // automatic resource cleanup
+      proxyConnectionLock.lock();
+      try {
+         final var size = openStatements.size();
+         if (size > 0) {
+            for (int i = 0; i < size && delegate != ClosedConnection.CLOSED_CONNECTION; i++) {
+               try (Statement ignored = openStatements.get(i)) {
+                  // automatic resource cleanup
+               }
+               catch (SQLException e) {
+                  LOGGER.warn("{} - Connection {} marked as broken because of an exception closing open statements during Connection.close()",
+                     poolEntry.getPoolName(), delegate);
+                  leakTask.cancel();
+                  poolEntry.evict("(exception closing Statements during Connection.close())");
+                  delegate = ClosedConnection.CLOSED_CONNECTION;
+               }
             }
-            catch (SQLException e) {
-               LOGGER.warn("{} - Connection {} marked as broken because of an exception closing open statements during Connection.close()",
-                           poolEntry.getPoolName(), delegate);
-               leakTask.cancel();
-               poolEntry.evict("(exception closing Statements during Connection.close())");
-               delegate = ClosedConnection.CLOSED_CONNECTION;
-            }
-         }
 
-         openStatements.clear();
+            openStatements.clear();
+         }
+      } finally {
+         proxyConnectionLock.unlock();
       }
    }
 

--- a/src/main/java/com/zaxxer/hikari/pool/ProxyStatement.java
+++ b/src/main/java/com/zaxxer/hikari/pool/ProxyStatement.java
@@ -20,6 +20,7 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * This is the proxy class for java.sql.Statement.
@@ -33,6 +34,7 @@ public abstract class ProxyStatement implements Statement
 
    private boolean isClosed;
    private ResultSet proxyResultSet;
+   protected final ReentrantLock proxyStatementLock = new ReentrantLock();
 
    ProxyStatement(ProxyConnection connection, Statement statement)
    {
@@ -61,12 +63,15 @@ public abstract class ProxyStatement implements Statement
    @Override
    public final void close() throws SQLException
    {
-      synchronized (this) {
+      proxyStatementLock.lock();
+      try {
          if (isClosed) {
             return;
          }
 
          isClosed = true;
+      } finally {
+         proxyStatementLock.unlock();
       }
 
       connection.untrackStatement(delegate);


### PR DESCRIPTION
It seems that `synchronized` will still pinn carrier threads in JDK 21 for the moment. This is the draft JEP for JDK21:
https://openjdk.org/jeps/8303683

So I'm reoping the PR for using ReentrantLock.
