### PR TITLE
Removes final modifier from generated Proxy classes.

### DIFF
--- a/src/main/java/com/zaxxer/hikari/util/JavassistProxyFactory.java
+++ b/src/main/java/com/zaxxer/hikari/util/JavassistProxyFactory.java
@@ -108,7 +108,7 @@ public final class JavassistProxyFactory
 
       var superCt = classPool.getCtClass(superClassName);
       var targetCt = classPool.makeClass(newClassName, superCt);
-      targetCt.setModifiers(Modifier.setPublic(Modifier.FINAL));
+      targetCt.setModifiers(Modifier.PUBLIC);
 
       System.out.println("Generating " + newClassName);
 

--- a/src/test/java/com/zaxxer/hikari/pool/TestJavassistCodegen.java
+++ b/src/test/java/com/zaxxer/hikari/pool/TestJavassistCodegen.java
@@ -33,7 +33,7 @@ public class TestJavassistCodegen {
 
       int mod = fauxClassLoader.loadClass("com.zaxxer.hikari.pool.HikariProxyConnection").getModifiers();
       Assert.assertTrue("Generated proxy class should be public", Modifier.isPublic(mod));
-      Assert.assertTrue("Generated proxy class should be final", Modifier.isFinal(mod));
+      Assert.assertTrue("Generated proxy class shouldnot be final", !Modifier.isFinal(mod));
 
       Class<?> proxyFactoryClass = fauxClassLoader.loadClass("com.zaxxer.hikari.pool.ProxyFactory");
 

--- a/src/test/java/com/zaxxer/hikari/pool/TestJavassistCodegen.java
+++ b/src/test/java/com/zaxxer/hikari/pool/TestJavassistCodegen.java
@@ -33,7 +33,7 @@ public class TestJavassistCodegen {
 
       int mod = fauxClassLoader.loadClass("com.zaxxer.hikari.pool.HikariProxyConnection").getModifiers();
       Assert.assertTrue("Generated proxy class should be public", Modifier.isPublic(mod));
-      Assert.assertTrue("Generated proxy class shouldnot be final", !Modifier.isFinal(mod));
+      Assert.assertTrue("Generated proxy class should not be final", !Modifier.isFinal(mod));
 
       Class<?> proxyFactoryClass = fauxClassLoader.loadClass("com.zaxxer.hikari.pool.ProxyFactory");
 


### PR DESCRIPTION
**Description**

This PR removes the final modifier from the generated proxy classes, allowing clients code to extend them. This PR relates to some changes made here: https://github.com/brettwooldridge/HikariCP/pull/1661 where a small bug was fixed associated with the codegen.

**Reasoning**

My team has extended the HikariProxyResultSet in older versions of HikariCP, to allow us to package up stuff like warnings into the ResultSet implementation. I would be open to the suggestion that only the HikariProxyResultSet be made non-final, and be willing to change the PR to match if is decided that this is the best course of action.

Thanks for your consideration.