### PR TITLE
multi-threaded operation

### DIFF
--- a/src/main/java/com/zaxxer/hikari/pool/ProxyLeakTask.java
+++ b/src/main/java/com/zaxxer/hikari/pool/ProxyLeakTask.java
@@ -38,7 +38,7 @@ class ProxyLeakTask implements Runnable
    private String connectionName;
    private Exception exception;
    private String threadName;
-   private boolean isLeaked;
+   private volatile boolean isLeaked;
 
    static
    {


### PR DESCRIPTION
Even if there is no connection leak, after 'leakDetectionThreshold' milliseconds, the timer will still execute com.zaxxer.hikari.pool.ProxyLeakTask#run(). At this point, com.zaxxer.hikari.pool.ProxyLeakTask#isLeaked will be true. If another thread returns the connection and executes com.zaxxer.hikari.pool.ProxyLeakTask#cancel(), there may be a multithread visibility issue with the 'isLeaked' field due to the multi-threaded operation, which will cause the subsequent logic to not execute and the log message "Previously reported leaked connection {} on thread {} was returned to the pool (unleaked)" will not be printed.