### PR TITLE
Don't try to cast metric registry before it is checked for null

### DIFF
--- a/src/main/java/com/zaxxer/hikari/metrics/dropwizard/CodahaleHealthChecker.java
+++ b/src/main/java/com/zaxxer/hikari/metrics/dropwizard/CodahaleHealthChecker.java
@@ -16,16 +16,16 @@
 
 package com.zaxxer.hikari.metrics.dropwizard;
 
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.util.concurrent.TimeUnit;
-
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import com.codahale.metrics.health.HealthCheck;
 import com.codahale.metrics.health.HealthCheckRegistry;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.pool.HikariPool;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Provides Dropwizard HealthChecks.  Two health checks are provided:
@@ -54,18 +54,23 @@ public final class CodahaleHealthChecker
    public static void registerHealthChecks(final HikariPool pool, final HikariConfig hikariConfig, final HealthCheckRegistry registry)
    {
       final var healthCheckProperties = hikariConfig.getHealthCheckProperties();
-      final var metricRegistry = (MetricRegistry) hikariConfig.getMetricRegistry();
 
       final var checkTimeoutMs = Long.parseLong(healthCheckProperties.getProperty("connectivityCheckTimeoutMs", String.valueOf(hikariConfig.getConnectionTimeout())));
       registry.register(MetricRegistry.name(hikariConfig.getPoolName(), "pool", "ConnectivityCheck"), new ConnectivityHealthCheck(pool, checkTimeoutMs));
 
       final var expected99thPercentile = Long.parseLong(healthCheckProperties.getProperty("expected99thPercentileMs", "0"));
-      if (metricRegistry != null && expected99thPercentile > 0) {
-         var timers = metricRegistry.getTimers((name, metric) -> name.equals(MetricRegistry.name(hikariConfig.getPoolName(), "pool", "Wait")));
 
-         if (!timers.isEmpty()) {
-            final var timer = timers.entrySet().iterator().next().getValue();
-            registry.register(MetricRegistry.name(hikariConfig.getPoolName(), "pool", "Connection99Percent"), new Connection99Percent(timer, expected99thPercentile));
+      final Object metricRegistryObj = hikariConfig.getMetricRegistry();
+
+      if (expected99thPercentile > 0 && metricRegistryObj != null) {
+         if (metricRegistryObj instanceof MetricRegistry) {
+            final var metricRegistry = (MetricRegistry) hikariConfig.getMetricRegistry();
+            var timers = metricRegistry.getTimers((name, metric) -> name.equals(MetricRegistry.name(hikariConfig.getPoolName(), "pool", "Wait")));
+
+            if (!timers.isEmpty()) {
+               final var timer = timers.entrySet().iterator().next().getValue();
+               registry.register(MetricRegistry.name(hikariConfig.getPoolName(), "pool", "Connection99Percent"), new Connection99Percent(timer, expected99thPercentile));
+            }
          }
       }
    }

--- a/src/main/java/com/zaxxer/hikari/metrics/dropwizard/CodahaleHealthChecker.java
+++ b/src/main/java/com/zaxxer/hikari/metrics/dropwizard/CodahaleHealthChecker.java
@@ -62,15 +62,13 @@ public final class CodahaleHealthChecker
 
       final Object metricRegistryObj = hikariConfig.getMetricRegistry();
 
-      if (expected99thPercentile > 0 && metricRegistryObj != null) {
-         if (metricRegistryObj instanceof MetricRegistry) {
-            final var metricRegistry = (MetricRegistry) hikariConfig.getMetricRegistry();
-            var timers = metricRegistry.getTimers((name, metric) -> name.equals(MetricRegistry.name(hikariConfig.getPoolName(), "pool", "Wait")));
+      if (expected99thPercentile > 0 && metricRegistryObj instanceof MetricRegistry) {
+         final var metricRegistry = (MetricRegistry) hikariConfig.getMetricRegistry();
+         var timers = metricRegistry.getTimers((name, metric) -> name.equals(MetricRegistry.name(hikariConfig.getPoolName(), "pool", "Wait")));
 
-            if (!timers.isEmpty()) {
-               final var timer = timers.entrySet().iterator().next().getValue();
-               registry.register(MetricRegistry.name(hikariConfig.getPoolName(), "pool", "Connection99Percent"), new Connection99Percent(timer, expected99thPercentile));
-            }
+         if (!timers.isEmpty()) {
+            final var timer = timers.entrySet().iterator().next().getValue();
+            registry.register(MetricRegistry.name(hikariConfig.getPoolName(), "pool", "Connection99Percent"), new Connection99Percent(timer, expected99thPercentile));
          }
       }
    }

--- a/src/main/java/com/zaxxer/hikari/metrics/dropwizard/CodahaleHealthChecker.java
+++ b/src/main/java/com/zaxxer/hikari/metrics/dropwizard/CodahaleHealthChecker.java
@@ -63,7 +63,7 @@ public final class CodahaleHealthChecker
       final Object metricRegistryObj = hikariConfig.getMetricRegistry();
 
       if (expected99thPercentile > 0 && metricRegistryObj instanceof MetricRegistry) {
-         final var metricRegistry = (MetricRegistry) hikariConfig.getMetricRegistry();
+         final var metricRegistry = (MetricRegistry) metricRegistryObj;
          var timers = metricRegistry.getTimers((name, metric) -> name.equals(MetricRegistry.name(hikariConfig.getPoolName(), "pool", "Wait")));
 
          if (!timers.isEmpty()) {


### PR DESCRIPTION
This is a fix for #1234 : if metric register was not set up don't try to cast it to Dopwizard's MetricRegistry; however if it was set up, check for a correct type using `instanceof` before trying casting it.
