### PR TITLE
Create SQLExceptionOverride instance when exceptionOverrideClassName loaded

### DIFF
--- a/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
+++ b/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
@@ -97,7 +97,7 @@ abstract class PoolBase
       this.schema = config.getSchema();
       this.isReadOnly = config.isReadOnly();
       this.isAutoCommit = config.isAutoCommit();
-      this.exceptionOverride = UtilityElf.createInstance(config.getExceptionOverrideClassName(), SQLExceptionOverride.class);
+      this.exceptionOverride = config.getExceptionOverride();
       this.transactionIsolation = UtilityElf.getTransactionIsolation(config.getTransactionIsolation());
 
       this.isQueryTimeoutSupported = UNINITIALIZED;


### PR DESCRIPTION
Before this commit, exceptionOverrideClass may be loaded by different ClassLoader, and two instances are created but only the latter one is used. This commit make sure the class will only loaded once and only one instance is created.

Fix GH-2124