### PR TITLE
Changed the log level of `final void logPoolState(String... prefix)` from `debug` to `info`.

### DIFF
--- a/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
+++ b/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
@@ -395,17 +395,15 @@ public final class HikariPool extends PoolBase implements HikariPoolMXBean, IBag
    // ***********************************************************************
 
    /**
-    * Log the current pool state at debug level.
+    * Log the current pool state.
     *
     * @param prefix an optional prefix to prepend the log message
     */
    void logPoolState(String... prefix)
    {
-      if (logger.isDebugEnabled()) {
-         logger.debug("{} - {}stats (total={}, active={}, idle={}, waiting={})",
-                      poolName, (prefix.length > 0 ? prefix[0] : ""),
-                      getTotalConnections(), getActiveConnections(), getIdleConnections(), getThreadsAwaitingConnection());
-      }
+      logger.info("{} - {}stats (total={}, active={}, idle={}, waiting={})",
+                   poolName, (prefix.length > 0 ? prefix[0] : ""),
+                   getTotalConnections(), getActiveConnections(), getIdleConnections(), getThreadsAwaitingConnection());
    }
 
    /**


### PR DESCRIPTION
The housekeeper's record of the current status of total, active, idle and waiting connections in the DBCP is highly useful when operating a product targeting real users. However, to view this log, specific log level settings need to be configured, and the relevant information is being shared. Our company also conducts this setup separately to reference the related logs. 

What do you think about changing this log level from debug to info?

Please refer to this Stack Overflow question and answer for more details.

https://stackoverflow.com/questions/60757590/logging-hikaricp-spring-boot
```properties
logging.level.com.zaxxer.hikari.HikariConfig=DEBUG 
logging.level.com.zaxxer.hikari=TRACE
```