### PR TITLE
ProxyConnection should close when ProxyStatement close

### DIFF
--- a/src/main/java/com/zaxxer/hikari/pool/ProxyStatement.java
+++ b/src/main/java/com/zaxxer/hikari/pool/ProxyStatement.java
@@ -72,6 +72,7 @@ public abstract class ProxyStatement implements Statement
       connection.untrackStatement(delegate);
 
       try {
+         connection.close();
          delegate.close();
       }
       catch (SQLException e) {


### PR DESCRIPTION
If a connection is not closed, the PoolEntry remains in the IN_USE state, leading to a connection leak.