### PR TITLE
Duplicate connection in try with resources clause removed (Fixes #2152)

### DIFF
--- a/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
+++ b/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
@@ -133,7 +133,7 @@ abstract class PoolBase
             logger.debug("{} - Closing connection {}: {}", poolName, connection, closureReason);
 
             // continue with the close even if setNetworkTimeout() throws
-            try (connection; connection) {
+            try (connection) {
                if (!connection.isClosed())
                   setNetworkTimeout(connection, SECONDS.toMillis(15));
                } catch (SQLException e) {


### PR DESCRIPTION
Fixes #2152

Duplicate connection in try with resources clause caused close() being called twice on each connection.