### PR TITLE
Close connections marked as evicted instead of returning them to the pool

### DIFF
--- a/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
+++ b/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
@@ -417,8 +417,11 @@ public final class HikariPool extends PoolBase implements HikariPoolMXBean, IBag
    void recycle(final PoolEntry poolEntry)
    {
       metricsTracker.recordConnectionUsage(poolEntry);
-
-      connectionBag.requite(poolEntry);
+      if (poolEntry.isMarkedEvicted()) {
+         closeConnection(poolEntry, EVICTED_CONNECTION_MESSAGE);
+      } else {
+         connectionBag.requite(poolEntry);
+      }
    }
 
    /**

--- a/src/test/java/com/zaxxer/hikari/pool/TestConnections.java
+++ b/src/test/java/com/zaxxer/hikari/pool/TestConnections.java
@@ -311,6 +311,28 @@ public class TestConnections
    }
 
    @Test
+   public void testCloseMarkEvicted() throws Exception
+   {
+      HikariConfig config = newHikariConfig();
+      config.setMinimumIdle(0);
+      config.setMaximumPoolSize(5);
+      config.setConnectionTimeout(2500);
+      config.setConnectionTestQuery("VALUES 1");
+      config.setDataSourceClassName("com.zaxxer.hikari.mocks.StubDataSource");
+
+      try (HikariDataSource ds = new HikariDataSource(config)) {
+         ProxyConnection connection = (ProxyConnection) ds.getConnection();
+
+         HikariPool pool = getPool(ds);
+         assertEquals(1, pool.getTotalConnections());
+         connection.getPoolEntry().markEvicted();
+         connection.close();
+
+         assertEquals("Connection should have been evicted after close", 0, pool.getTotalConnections());
+      }
+   }
+
+   @Test
    public void testEviction() throws Exception
    {
       HikariConfig config = newHikariConfig();


### PR DESCRIPTION
### Description
According to the documentation, connections that were in use during a soft eviction, are effectively evicted when returned to the pool. See Javadoc of `com.zaxxer.hikari.HikariPoolMXBean.softEvictConnections`
> Evict currently idle connections from the pool, and mark active (in-use) connections for eviction when they are
> returned to the pool.

That's not how it's currently implemented though. Connections that are marked as evicted are being closed when the connection is tried to be borrowed from the pool.

With this PR, connections marked as evicted are **additionally** closed when returned to the pool.
Because of race conditions, it's still possible that connections that are marked as evicted are being returned to the pool.
Therefore, I left the logic in `com.zaxxer.hikari.pool.HikariPool.getConnection(long)` as is.

### Why?
We use a database cluster in an active/passive setup. The JDBC connection string ensures that connections are always established with the active node.
On database maintenance we are able to switch the roles of the nodes. We then want to evict all current connections (connected to the now passive node) to ensure that new connections are established with the now active node.

With low volume of SQL executions it can take some time until a connection marked as evicted is being borrowed from the pool.
We would therefore have to adjust the minimumIdleTime to ensure that connections are being re-established in a timely manner.
