### PR TITLE
feat: supports metrics exemplars

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
       <maven.release.version>3.0.1</maven.release.version>
       <metrics.version>3.2.5</metrics.version>
       <micrometer.version>1.5.10</micrometer.version>
-      <simpleclient.version>0.9.0</simpleclient.version>
+      <simpleclient.version>0.16.0</simpleclient.version>
       <mockito.version>3.7.7</mockito.version>
       <pax.exam.version>4.13.5</pax.exam.version>
       <pax.url.version>2.5.4</pax.url.version>


### PR DESCRIPTION
Exemplars is only supported as part of [0.11.0 of simple-client](https://github.com/prometheus/client_java/releases/tag/parent-0.11.0).

Without this change, a prometheus scraper might fail scraping metrics out of HikariCP correctly. Ending up in unhealthy state. Due to, (as an example) "metric name hikaricp_connections_usage_seconds_count does not support exemplars".

One possible solution is to stop recording metrics out of hikaricp in the application via registry filters. But if we still want to use those nice metrics, this becomes a challenge.