### PR TITLE
Return `null` when applicable from `getGeneratedKeys`

### DIFF
--- a/src/main/java/com/zaxxer/hikari/pool/ProxyStatement.java
+++ b/src/main/java/com/zaxxer/hikari/pool/ProxyStatement.java
@@ -227,8 +227,13 @@ public abstract class ProxyStatement implements Statement
    public ResultSet getGeneratedKeys() throws SQLException
    {
       var resultSet = delegate.getGeneratedKeys();
-      if (proxyResultSet == null || ((ProxyResultSet) proxyResultSet).delegate != resultSet) {
-         proxyResultSet = ProxyFactory.getProxyResultSet(connection, this, resultSet);
+      if (resultSet != null) {
+         if (proxyResultSet == null || ((ProxyResultSet) proxyResultSet).delegate != resultSet) {
+            proxyResultSet = ProxyFactory.getProxyResultSet(connection, this, resultSet);
+         }
+      }
+      else {
+         proxyResultSet = null;
       }
       return proxyResultSet;
    }


### PR DESCRIPTION
Currently, there is no way to check if `getGeneratedKeys` returned `null`.  Instead, when trying to call `ResultSet.next()` a `NullPointerException` is thrown.

This method [should return an empty `ResultSet` when there are no generated keys]( https://docs.oracle.com/javase/8/docs/api/java/sql/Statement.html#getGeneratedKeys--), but not all JDBC drivers do (like [Apache](https://github.com/apache/derby/blob/4253dcf4aa37dc64cf7235d494cd2f00f72e678a/java/org.apache.derby.client/org/apache/derby/client/am/ClientStatement.java#L271) [Derby](https://github.com/apache/derby/blob/4253dcf4aa37dc64cf7235d494cd2f00f72e678a/java/org.apache.derby.client/org/apache/derby/client/am/ClientStatement.java#L1378-L1394))  In these cases, I think the safest option is to return `null`, which can then be checked (and is checked in popular JDBC libraries [like JOOQ.](https://github.com/jOOQ/jOOQ/blob/181d838797d8238edd52576df6b7d3827cceb797/jOOQ/src/main/java/org/jooq/impl/AbstractDMLQuery.java#L1350-L1352))