### PR TITLE
add support to get and set db credentials in an atomic operation

### DIFF
--- a/src/main/java/com/zaxxer/hikari/HikariConfigMXBean.java
+++ b/src/main/java/com/zaxxer/hikari/HikariConfigMXBean.java
@@ -16,6 +16,8 @@
 
 package com.zaxxer.hikari;
 
+import com.zaxxer.hikari.util.Credentials;
+
 /**
  * The javax.management MBean for a Hikari pool configuration.
  *
@@ -167,6 +169,14 @@ public interface HikariConfigMXBean
     */
    void setUsername(String username);
 
+   /**
+    * Set the username and password used for authentication. Changing this at runtime will apply to new
+    * connections only. Altering this at runtime only works for DataSource-based connections, not Driver-class
+    * or JDBC URL-based connections.
+    *
+    * @param credentials the database username and password pair
+    */
+   void setCredentials(Credentials credentials);
 
    /**
     * The name of the connection pool.

--- a/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
+++ b/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
@@ -311,8 +311,7 @@ abstract class PoolBase
    private void initializeDataSource()
    {
       final var jdbcUrl = config.getJdbcUrl();
-      final var username = config.getUsername();
-      final var password = config.getPassword();
+      final var credentials = config.getCredentials();
       final var dsClassName = config.getDataSourceClassName();
       final var driverClassName = config.getDriverClassName();
       final var dataSourceJNDI = config.getDataSourceJNDI();
@@ -324,7 +323,7 @@ abstract class PoolBase
          PropertyElf.setTargetFromProperties(ds, dataSourceProperties);
       }
       else if (jdbcUrl != null && ds == null) {
-         ds = new DriverDataSource(jdbcUrl, driverClassName, dataSourceProperties, username, password);
+         ds = new DriverDataSource(jdbcUrl, driverClassName, dataSourceProperties, credentials.getUsername(), credentials.getPassword());
       }
       else if (dataSourceJNDI != null && ds == null) {
          try {
@@ -354,8 +353,9 @@ abstract class PoolBase
 
       Connection connection = null;
       try {
-         var username = config.getUsername();
-         var password = config.getPassword();
+         final var credentials = config.getCredentials();
+         final var username = credentials.getUsername();
+         final var password = credentials.getPassword();
 
          connection = (username == null) ? dataSource.getConnection() : dataSource.getConnection(username, password);
          if (connection == null) {

--- a/src/main/java/com/zaxxer/hikari/util/Credentials.java
+++ b/src/main/java/com/zaxxer/hikari/util/Credentials.java
@@ -1,0 +1,57 @@
+package com.zaxxer.hikari.util;
+
+import javax.management.ConstructorParameters;
+
+/**
+ * A simple class to hold connection credentials and is designed to be immutable.
+ */
+public final class Credentials
+{
+
+   private final String username;
+   private final String password;
+
+   /**
+    * Construct an immutable Credentials object with the supplied username and password.
+    *
+    * @param username the username
+    * @param password the password
+    * @return a new Credentials object
+    */
+   public static Credentials of(final String username, final String password) {
+      return new Credentials(username, password);
+   }
+
+   /**
+    * Construct an immutable Credentials object with the supplied username and password.
+    *
+    * @param username the username
+    * @param password the password
+    */
+   @ConstructorParameters({ "username", "password" })
+   public Credentials(final String username, final String password)
+   {
+      this.username = username;
+      this.password = password;
+   }
+
+   /**
+    * Get the username.
+    *
+    * @return the username
+    */
+   public String getUsername()
+   {
+      return username;
+   }
+
+   /**
+    * Get the password.
+    *
+    * @return the password
+    */
+   public String getPassword()
+   {
+      return password;
+   }
+}

--- a/src/test/java/com/zaxxer/hikari/datasource/TestSealedConfig.java
+++ b/src/test/java/com/zaxxer/hikari/datasource/TestSealedConfig.java
@@ -2,6 +2,7 @@ package com.zaxxer.hikari.datasource;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import com.zaxxer.hikari.util.Credentials;
 import org.junit.Test;
 
 import java.sql.Connection;
@@ -68,6 +69,7 @@ public class TestSealedConfig
          ds.setMaximumPoolSize(8);
          ds.setPassword("password");
          ds.setUsername("username");
+         ds.setCredentials(Credentials.of("anothername", "anotherpassword"));
       }
    }
 }


### PR DESCRIPTION
This pull request attempts to address points raised in https://github.com/brettwooldridge/HikariCP/pull/1442#issuecomment-1287697706, https://github.com/brettwooldridge/HikariCP/pull/2011#issuecomment-1336197290, and https://github.com/brettwooldridge/HikariCP/pull/1196#issuecomment-436720123 about rotating both username and password atomically.

Currently, you can call the setUsername and setPassword methods on the MBean or subclass the HikariDataSource to dynamically fetch credentials. Either way this is done presents a (tiny) window where the credentials used to connect may be in flux. In the case of updating via the MBean, a new connection may be created in between the call to setUsername and setPassword. And when subclassing the data source to dynamically provide username and password, the credentials may have changed between PoolBase's call to getUsername and getPassword.

To close these windows, I have introduced a new Credentials pojo that is essentially an immutable pair of username and password and replaced the HikariConfig's username and password fields with an AtomicReference to a Credential. It should be noted that even with these changes, you are still able to individually get and set the username and password, however if you need things to be atomic you should make use of the new API in HikariConfig, getCredentials and setCredentials. PoolBase now makes use of the getCredentials to atomically get the pair. Additionally, there is an extra method on the HikariConfigMXBean to atomically set the pair.



