### PR TITLE
 healthcheck registry can be set even if pool is sealed

### DIFF
--- a/src/main/java/com/zaxxer/hikari/HikariConfig.java
+++ b/src/main/java/com/zaxxer/hikari/HikariConfig.java
@@ -698,7 +698,6 @@ public class HikariConfig implements HikariConfigMXBean
     */
    public void setHealthCheckRegistry(Object healthCheckRegistry)
    {
-      checkIfSealed();
 
       if (healthCheckRegistry != null) {
          healthCheckRegistry = getObjectOrPerformJndiLookup(healthCheckRegistry);


### PR DESCRIPTION
Hi All, 

Request you to Please review this PR. 

As of today `HealthCheckRegistry` this property can be set only via programmatic configuration or IoC container.
Since, for the user who are using the `hibernate-hikaricp` and getting the data source from `HikariCPConnectionProvider` by unwrap this option is not available, please find example below - 

 ```
HikariCPConnectionProvider hikariCPConnectionProvider = sessionFactory.getSessionFactoryOptions()
                .getServiceRegistry()
                .getService(HikariCPConnectionProvider.class);
        HikariDataSource dataSource = hikariCPConnectionProvider.unwrap(HikariDataSource.class);

```

Returned `datasource` is `sealed`. 

I believe setting healthcheck should be allowed once! 

Please suggest if you think there exists another approach for such scenarios. 

thanks, 
