### PR TITLE
doc: clarify pool sizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The customer's environment imposed a high cost of new connection acquisition, an
 <br/>
 #### You're [probably] doing it wrong
 <a href="https://github.com/brettwooldridge/HikariCP/wiki/About-Pool-Sizing"><img width="200" align="right" src="https://github.com/brettwooldridge/HikariCP/wiki/Postgres_Chart.png"></a>
-AKA *"What you probably didn't know about connection pool sizing"*.  Watch a video from the Oracle Real-world Performance group, and learn about why connection pools do not need to be sized as large as they often are.  In fact, oversized connection pools have a clear and demonstrable *negative* impact on performance; a 50x difference in the case of the Oracle demonstration.  [Read on to find out](https://github.com/brettwooldridge/HikariCP/wiki/About-Pool-Sizing).
+AKA *"What you probably didn't know about connection pool sizing"*.  Watch a video from the Oracle Real-world Performance group, and learn about why database connections do not need to be so numerous as they often are. In fact, too many connections have a clear and demonstrable *negative* impact on performance; a 50x difference in the case of the Oracle demonstration.  [Read on to find out](https://github.com/brettwooldridge/HikariCP/wiki/About-Pool-Sizing).
 <br/>
 #### WIX Engineering Analysis
 <a href="https://www.wix.engineering/blog/how-does-hikaricp-compare-to-other-connection-pools"><img width="180" align="left" src="https://github.com/brettwooldridge/HikariCP/wiki/Wix-Engineering.png"></a>


### PR DESCRIPTION
## Problem
Wiki's [entry](https://github.com/brettwooldridge/HikariCP/wiki/About-Pool-Sizing) about pool sizing is great, and I learn many things reading it and watching the video.

However, I get confused because the `pool sizing` in the entry about does not always relate directly to the number of simultaneous connections a database can handle - which is the actual issue the entry is addressing.

You can have, say, ten instance of an application, each with ten connection in each pool, targeting the same database. The entry talk about  "how many connections at the same time in the database", not "how many open connections per pool".

The video use `connection pool` also, but it looks like a singleton pool (like pgbouncer), not a an applicative pool like HikariCP.

 ## Solution

I replaced `connexion pool` by `active connections` in the documentation to clarify.

In the Wiki, I suggest :
- [some clarifications about pool type and sizing](
https://github.com/GradedJestRisk/HikariCP/wiki/About-Pool-Sizing/_compare/e671bc82ea2174b7ad302ff092a8d474d41b315e...c15aeff940d08a5e8e1fd90a3cc33b8b27948817)
- [adding a reference to the formula](https://github.com/GradedJestRisk/HikariCP/wiki/About-Pool-Sizing/_compare/c74af5a5ec93013ff1774cc76ecda9a1a0396cc7...e671bc82ea2174b7ad302ff092a8d474d41b315e)