### PR TITLE
fix: validationTimeout configuration item invalid

### DIFF
--- a/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
+++ b/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
@@ -530,6 +530,9 @@ abstract class PoolBase
             final var originalTimeout = connection.getNetworkTimeout();
             connection.setNetworkTimeout(netTimeoutExecutor, (int) timeoutMs);
             isNetworkTimeoutSupported = TRUE;
+            if (originalTimeout == 0) {
+               return (int) timeoutMs;
+            }
             return originalTimeout;
          }
          catch (Exception | AbstractMethodError e) {


### PR DESCRIPTION
It seems that the validationTimeout configured in the configuration file does not take effect. The SocketTimeout of the database connection will always overwrite this configuration item, even if this parameter is not specified in jdbcurl.
This can be verified with a simple springboot project.
application.yaml as follow
```yaml
server:
  port: 8081
spring:
  application:
    name: hikariTest
  datasource:
    driver-class-name: com.mysql.cj.jdbc.Driver
#    url: jdbc:mysql://localhost/demo?useUnicode=true&characterEncoding=utf8&allowMultiQueries=true&useSSL=false&socketTimeout=100
    url: jdbc:mysql://localhost/demo?useUnicode=true&characterEncoding=utf8&allowMultiQueries=true&useSSL=false
    username: root
    password: root
    hikari:
      validationTimeout: 300
```
We can see from the following code that the value obtained by Connection#getNetworkTimeout is obviously inconsistent with the validationTimeout in the configuration item.
```java
@SpringBootApplication
public class Main {
    public static void main(String[] args) throws SQLException, NoSuchFieldException, IllegalAccessException {
        final ConfigurableApplicationContext run = SpringApplication.run(Main.class, args);
        final Map<String, DataSource> beansOfType = run.getBeansOfType(DataSource.class);
        final HikariDataSource dataSource = (HikariDataSource)beansOfType.get("dataSource");
        final Connection connection = dataSource.getConnection();
        final int networkTimeout = connection.getNetworkTimeout();
        System.out.println("network timeout is [" + networkTimeout + "]");
        final Class<HikariConfig> hikariConfigClass = HikariConfig.class;
        final Field validationTimeout = hikariConfigClass.getDeclaredField("validationTimeout");
        validationTimeout.setAccessible(true);
        final long validationTimeoutValue = (long)validationTimeout.get(dataSource);
        System.out.println("now validationTimeout is [" + validationTimeoutValue + "]");
    }
}
```
results are as follows
```java
network timeout is [0]
now validationTimeout is [300]
```
I think when the socketTimeout value is not specified in jdbcurl, the validationTimeout in the configuration file should be used as this value,instead of being replaced by the default value.
I think the value obtained by Connection#getNetworkTimeout should be consistent with the validationTimeout in the configuration file.
Perhaps the following result should be obtained
```java
network timeout is [300]
now validationTimeout is [300]
```
By reading the source code, I found that the connection is created through PoolBase#newConnection and the SocketTimeout is set through PoolBase#setupConnection, but the validationTimeout is not set correctly in the setupConnection method. If we configure the validationTimeout.
method as follow
```java
private void setupConnection(final Connection connection) throws ConnectionSetupException
   {
      try {
         if (networkTimeout == UNINITIALIZED) {
            networkTimeout = getAndSetNetworkTimeout(connection, validationTimeout);
         }
         else {
            setNetworkTimeout(connection, validationTimeout);
         }

         if (connection.isReadOnly() != isReadOnly) {
            connection.setReadOnly(isReadOnly);
         }

         if (connection.getAutoCommit() != isAutoCommit) {
            connection.setAutoCommit(isAutoCommit);
         }

         checkDriverSupport(connection);

         if (transactionIsolation != defaultTransactionIsolation) {
            connection.setTransactionIsolation(transactionIsolation);
         }

         if (catalog != null) {
            connection.setCatalog(catalog);
         }

         if (schema != null) {
            connection.setSchema(schema);
         }

         executeSql(connection, config.getConnectionInitSql(), true);
         // must be executed
         setNetworkTimeout(connection, networkTimeout);
      }
      catch (SQLException e) {
         throw new ConnectionSetupException(e);
      }
   }
```
Because the following line of code will be executed, but networkTimeout has been assigned to dataSource.getConnection().getNetworkTimeout() during initialization.
```java
setNetworkTimeout(connection, networkTimeout);
```
The Connection of the above method is obtained in newConnection.
```java
private Connection newConnection() throws Exception
   {
      final var start = currentTime();

      Connection connection = null;
      try {
         final var credentials = config.getCredentials();
         final var username = credentials.getUsername();
         final var password = credentials.getPassword();
         // get connection
         connection = (username == null) ? dataSource.getConnection() : dataSource.getConnection(username, password);
         if (connection == null) {
            throw new SQLTransientConnectionException("DataSource returned null unexpectedly");
         }

         setupConnection(connection);
         lastConnectionFailure.set(null);
         return connection;
      }
      catch (Exception e) {
         if (connection != null) {
            quietlyCloseConnection(connection, "(Failed to create/setup connection)");
         }
         else if (getLastConnectionFailure() == null) {
            logger.debug("{} - Failed to create/setup connection: {}", poolName, e.getMessage());
         }

         lastConnectionFailure.set(e);
         throw e;
      }
      finally {
         // tracker will be null during failFast check
         if (metricsTracker != null) {
            metricsTracker.recordConnectionCreated(elapsedMillis(start));
         }
      }
   }
```
networkTimeout will be assigned in the following method
```java
private void setupConnection(final Connection connection) throws ConnectionSetupException
   {
      try {
         if (networkTimeout == UNINITIALIZED) {
            networkTimeout = getAndSetNetworkTimeout(connection, validationTimeout);
         }
     // ...
    }
```

```java
private int getAndSetNetworkTimeout(final Connection connection, final long timeoutMs)
   {
      if (isNetworkTimeoutSupported != FALSE) {
         try {
            final var originalTimeout = connection.getNetworkTimeout();
            connection.setNetworkTimeout(netTimeoutExecutor, (int) timeoutMs);
            isNetworkTimeoutSupported = TRUE;
            if (originalTimeout == 0) {
               return (int) timeoutMs;
            }
            return originalTimeout;
         }
         catch (Exception | AbstractMethodError e) {
            if (isNetworkTimeoutSupported == UNINITIALIZED) {
               isNetworkTimeoutSupported = FALSE;

               logger.info("{} - Driver does not support get/set network timeout for connections. ({})", poolName, e.getMessage());
               if (validationTimeout < SECONDS.toMillis(1)) {
                  logger.warn("{} - A validationTimeout of less than 1 second cannot be honored on drivers without setNetworkTimeout() support.", poolName);
               }
               else if (validationTimeout % SECONDS.toMillis(1) != 0) {
                  logger.warn("{} - A validationTimeout with fractional second granularity cannot be honored on drivers without setNetworkTimeout() support.", poolName);
               }
            }
         }
      }

      return 0;
   }
```
Finally, the value of originalTimeout will be returned, and originalTimeout is directly obtained through dataSource.getConnection().getNetworkTimeout().
That's why validationTimeout is not set correctly in connection.
I'm not sure if this is correct.
If what I said above is not correct, please give me a correct example of setting validationTimeout through the configuration file. Thank you for your time