### PR TITLE
Support parsing `Duration` values in `PropertyElf`

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,7 @@ HikariCP Changes
 Changes in 6.2.2
 
  * increase keepaliveTime variance from 10% to 20%
+ * support duration values for configuration from properties, such as 10ms, 20s, 30m, 40h or 50d
 
 Changes in 6.2.1
 
@@ -17,7 +18,7 @@ Changes in 6.2.0
 
  * added new enum value, Override.MUST_EVICT, available to implementations of com.zaxxer.hikari.SQLExceptionOverride
 
- * enhanced debug logging in circumstances where the pool falls to zero size and new coonections to the database
+ * enhanced debug logging in circumstances where the pool falls to zero size and new connections to the database
    continue to fail.
 
  * update test dependencies that were flagged as having vulnerabilities

--- a/src/test/resources/duration-config.properties
+++ b/src/test/resources/duration-config.properties
@@ -1,0 +1,8 @@
+connectionTimeout = 11ms
+validationTimeout = 22s
+idleTimeout = 33m
+leakDetectionThreshold = 44h
+maxLifetime = 55d
+
+dataSourceClassName=com.zaxxer.hikari.mocks.StubDataSource
+dataSource.loginTimeout = 47m


### PR DESCRIPTION
From https://github.com/brettwooldridge/HikariCP/issues/2191

Add support for parsing duration values in the `PropertyElf` class. This utility is used to populate the Hikari config and the data source properties from a `Properties` object (possibly parsed from a file).

The pull request adds support for millisecond, second, minute, hour and day durations, in a fixed form. Negative values are not supported.