### PR TITLE
Align HikariPool.logPoolState

### DIFF
--- a/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
+++ b/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
@@ -252,7 +252,7 @@ public final class HikariPool extends PoolBase implements HikariPoolMXBean, IBag
          }
       }
       finally {
-         logPoolState("After shutdown ");
+         logPoolState("After  shutdown ");
          handleMBeans(this, false);
          metricsTracker.close();
       }
@@ -832,7 +832,7 @@ public final class HikariPool extends PoolBase implements HikariPoolMXBean, IBag
                      maxToRemove--;
                   }
                }
-               logPoolState("After cleanup  ");
+               logPoolState("After  cleanup ");
             }
             else
                logPoolState("Pool ");

--- a/src/test/java/com/zaxxer/hikari/pool/TestConnections.java
+++ b/src/test/java/com/zaxxer/hikari/pool/TestConnections.java
@@ -517,7 +517,7 @@ public class TestConnections
 
          assertSame("Total connections not as expected", 0, pool.getTotalConnections());
 
-         pool.logPoolState("testBackfill() after close...");
+         pool.logPoolState("testBackfill() after  close...");
 
          quietlySleep(1250);
 


### PR DESCRIPTION
#### before
``` java
// Inconsistent log style
// 1.
logPoolState("Before acquire ");
logPoolState("After  acquire ");
// 2.
logPoolState("Before cleanup ");
logPoolState("After cleanup  ");
// 3.
logPoolState("Before shutdown ");
logPoolState("After shutdown ");
```

#### after
``` java
logPoolState("Before acquire ");
logPoolState("After  acquire ");

logPoolState("Before cleanup ");
logPoolState("After  cleanup ");

logPoolState("Before shutdown ");
logPoolState("After  shutdown ");
```