### PR TITLE
When creating physical connections, catch throwable instead of exception

### DIFF
--- a/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
+++ b/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
@@ -505,7 +505,7 @@ public final class HikariPool extends PoolBase implements HikariPoolMXBean, IBag
             logger.debug("{} - Error thrown while acquiring connection from data source", poolName, e.getCause());
          }
       }
-      catch (Exception e) {
+      catch (Throwable e) {
          if (poolState == POOL_NORMAL) { // we check POOL_NORMAL to avoid a flood of messages if shutdown() is running concurrently
             logger.debug("{} - Cannot acquire connection from data source", poolName, e);
          }

--- a/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
+++ b/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
@@ -59,7 +59,7 @@ abstract class PoolBase
    protected final String poolName;
 
    volatile String catalog;
-   final AtomicReference<Exception> lastConnectionFailure;
+   final AtomicReference<Throwable> lastConnectionFailure;
    final AtomicLong connectionFailureTimestamp;
 
    long connectionTimeout;
@@ -186,7 +186,7 @@ abstract class PoolBase
       }
    }
 
-   Exception getLastConnectionFailure()
+   Throwable getLastConnectionFailure()
    {
       return lastConnectionFailure.get();
    }
@@ -378,12 +378,12 @@ abstract class PoolBase
          logger.debug("{} - Established new connection ({})", poolName, id);
          return connection;
       }
-      catch (Exception e) {
-         logger.debug("{} - Failed to create/setup connection ({}): {}", poolName, id, e.getMessage());
+      catch (Throwable t) {
+         logger.debug("{} - Failed to create/setup connection ({}): {}", poolName, id, t.getMessage());
 
          connectionFailureTimestamp.compareAndSet(0, start);
          if (isEmptyPool && elapsedMillis(connectionFailureTimestamp.get()) > MINUTES.toMillis(1)) {
-            logger.warn("{} - Pool is empty, failed to create/setup connection ({})", poolName, id, e);
+            logger.warn("{} - Pool is empty, failed to create/setup connection ({})", poolName, id, t);
             connectionFailureTimestamp.set(0);
          }
 
@@ -391,8 +391,8 @@ abstract class PoolBase
             quietlyCloseConnection(connection, "(Failed to create/setup connection (".concat(id.toString()).concat(")"));
          }
 
-         lastConnectionFailure.set(e);
-         throw e;
+         lastConnectionFailure.set(t);
+         throw t;
       }
       finally {
          // tracker will be null during failFast check


### PR DESCRIPTION
Although rare, JDBC drivers can and do throw java.lang.Error instead of java.lang.Exception under certain conditions. If this occurs, the Error is swallowed since it is not currently caught and it occurs on a separate thread where the result is never checked.

 If the driver continues to throw Error, the backoff logic is bypassed, the connection creation counter spikes and eventually the pool drains of all connections.

See example

Graph of connection creation counter
![image](https://github.com/user-attachments/assets/bc394991-ac31-4962-a11b-a313537f72b5)

Graph of connections for the pool
![image](https://github.com/user-attachments/assets/d1b53ce1-99c1-47fc-94c0-9a2218c67ced)

The trigger was a networking event. At this time, we don't know with absolute certainty that the driver was generating an Error. However, after reviewing the code, I could not determine another explanation. The backoff logic clearly was not being hit as the counter would not increase and stay at the rate. We put out a patched version of Hikari similar to the changes in this PR with hopes of confirming that is what is happening and collecting the actual error being thrown, but we are waiting for the situation to occur again.

In this case we are using oracle's jdbc driver, and we have seen it throw a java.lang.Error before in other situations.

If this change is of interest and you want an explicit test for this, I'm happy to do that, but I may need a little direction on preferences here.


