### PR TITLE
#2265 bail out of PoolEntryCreator#call if the thread gets interrupted

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Fast, simple, reliable.  HikariCP is a "zero-overhead" production ready JDBC con
 
 ### Artifacts
 
-_**Java 11+** maven artifact:_
+_**Java 11 or greater** maven artifact:_
 ```xml
 <dependency>
    <groupId>com.zaxxer</groupId>

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ _**Java 11+** maven artifact:_
 <dependency>
    <groupId>com.zaxxer</groupId>
    <artifactId>HikariCP</artifactId>
-   <version>6.2.1</version>
+   <version>6.3.0</version>
 </dependency>
 ```
 _Java 8 maven artifact (*deprecated*):_

--- a/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
+++ b/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
@@ -772,12 +772,13 @@ public final class HikariPool extends PoolBase implements HikariPoolMXBean, IBag
 
       /**
        * We only create connections if we need another idle connection or have threads still waiting
-       * for a new connection.  Otherwise we bail out of the request to create.
+       * for a new connection.  Otherwise we bail out of the request to create. If the thread's interrupt flag
+       * gets set, we bail out and clear the interrupt flag.
        *
        * @return true if we should create a connection, false if the need has disappeared
        */
       private synchronized boolean shouldContinueCreating() {
-         return poolState == POOL_NORMAL && getTotalConnections() < config.getMaximumPoolSize() &&
+         return !Thread.interrupted() && poolState == POOL_NORMAL && getTotalConnections() < config.getMaximumPoolSize() &&
             (getIdleConnections() < config.getMinimumIdle() || connectionBag.getWaitingThreadCount() > getIdleConnections());
       }
    }

--- a/src/test/java/com/zaxxer/hikari/pool/TestConnections.java
+++ b/src/test/java/com/zaxxer/hikari/pool/TestConnections.java
@@ -904,6 +904,42 @@ public class TestConnections
       }
    }
 
+   @Test
+   public void testInterruptedThread() throws SQLException {
+
+      // First call to get a connection mark the thread as interrupted and throw exception
+      final StubDataSource stubDataSource = new StubDataSource() {
+         private int count = 0;
+
+         @Override
+         public Connection getConnection() {
+
+            if (count == 0) {
+               count++;
+               Thread.currentThread().interrupt();
+               throw new RuntimeException("Simulated something bad happening in the driver and thread getting the interrupt flag set");
+            }
+
+            if (Thread.currentThread().isInterrupted()) {
+               throw new RuntimeException("Simulate driver check of the interrupted flag that prevents new connections");
+            }
+
+            return new StubConnection();
+         }
+      };
+
+      HikariConfig config = newHikariConfig();
+      config.setMinimumIdle(1);
+      config.setMaximumPoolSize(2);
+      config.setConnectionTimeout(TimeUnit.SECONDS.toMillis(3));
+      config.setDataSource(stubDataSource);
+      config.setInitializationFailTimeout(-1);
+
+      try (HikariDataSource ds = new HikariDataSource(config)) {
+         assertNotNull(ds.getConnection());
+      }
+   }
+
    static class StubDataSourceWithErrorSwitch extends StubDataSource
    {
       private boolean errorOnConnection = false;


### PR DESCRIPTION
#2265 bail out of PoolEntryCreator#call if the thread's interrupt flag gets set. 

Issue: Connection adder thread does not properly check and handle interrupts. Currently, if the driver fails to create a connection and decides to mark the thread's interrupt flag (and throws an Exception), you end up in the backoff code. In the backoff code, the thread will sleep. Since the thread's interrupt flag has been set, it will immediately throw an InterruptedException which will also clear the thread's interrupt flag. 

![image](https://github.com/user-attachments/assets/9804b4c6-2b06-40d2-aec4-baf020be33e7)


However, this exception is caught and HikariCP resets the interrupt flag. Since we didn't successfully create a connection, shouldContinueCreating will return true. As a result, we try to create a connection again, but if the driver checks to see if the thread has been interrupted and bails out, we end up in an endless loop and can no longer create connections.

This updates it to respond and handle the thread being marked interrupt. Since thread operates in a loop, on each iteration of the loop, it should check to see if it has been interrupted. If it has, it should not continue and clear the interrupt so that if the thread is re-used for the next task in the ThreadPool's queue, it's good to go.

I added a test that simulates the scenario. Without the change, the test fails as the adder thread is stuck in a loop and never able to obtain and return a connection. The test simulates the idea that a database outage or network outage occurred causing a failure that caused the thread to get marked interrupt. Then the database is back online at which point the pool should recover but it currently won't without this change.