### PR TITLE
Create connections concurrently in separate threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Fast, simple, reliable.  HikariCP is a "zero-overhead" production ready JDBC con
 
 ### Artifacts
 
-_**Java 11+** maven artifact:_
+_**Java 11 or greater** maven artifact:_
 ```xml
 <dependency>
    <groupId>com.zaxxer</groupId>

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Fast, simple, reliable.  HikariCP is a "zero-overhead" production ready JDBC con
 ----------------------------------------------------
 
 > [!IMPORTANT]
-> In order to avoid a rare condition where the pool goes to zero and does not recover it is necessary to configure *TCP keepalive*. Some JDBC drivers support this via properties, for example ``tcpKeepAlive=true`` on PostgreSQL, but in any case it can also be configured at the OS-level. See [Setting OS TCP Keepalive](https://github.com/brettwooldridge/HikariCP/wiki/Setting-OS-TCP-Keepalive) and/or [TCP keepalive for a better PostgreSQL experience](https://www.cybertec-postgresql.com/en/tcp-keepalive-for-a-better-postgresql-experience/#setting-tcp-keepalive-parameters-on-the-operating-system).
+> In order to avoid a rare condition where the pool goes to zero and does not recover it is necessary to configure *TCP keepalive*. Some JDBC drivers support this via properties, for example ``tcpKeepAlive=true`` on PostgreSQL, but in any case it can also be configured at the OS-level. See [Setting OS TCP Keepalive](https://github.com/brettwooldridge/HikariCP/wiki/Setting-Driver-or-OS-TCP-Keepalive) and/or [TCP keepalive for a better PostgreSQL experience](https://www.cybertec-postgresql.com/en/tcp-keepalive-for-a-better-postgresql-experience/#setting-tcp-keepalive-parameters-on-the-operating-system).
 
 ----------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ _**Java 11+** maven artifact:_
 <dependency>
    <groupId>com.zaxxer</groupId>
    <artifactId>HikariCP</artifactId>
-   <version>6.2.1</version>
+   <version>6.3.0</version>
 </dependency>
 ```
 _Java 8 maven artifact (*deprecated*):_

--- a/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
+++ b/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
@@ -38,6 +38,7 @@ import java.sql.SQLException;
 import java.sql.SQLTransientConnectionException;
 import java.util.Optional;
 import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
 import static com.zaxxer.hikari.util.ClockSource.*;
@@ -73,6 +74,8 @@ public final class HikariPool extends PoolBase implements HikariPoolMXBean, IBag
 
    private final PoolEntryCreator poolEntryCreator = new PoolEntryCreator();
    private final PoolEntryCreator postFillPoolEntryCreator = new PoolEntryCreator("After adding ");
+
+   private final AtomicInteger connectionsInProgress = new AtomicInteger(0);
    private final ThreadPoolExecutor addConnectionExecutor;
    private final ThreadPoolExecutor closeConnectionExecutor;
 
@@ -114,7 +117,13 @@ public final class HikariPool extends PoolBase implements HikariPoolMXBean, IBag
       ThreadFactory threadFactory = config.getThreadFactory();
 
       final int maxPoolSize = config.getMaximumPoolSize();
-      this.addConnectionExecutor = createThreadPoolExecutor(maxPoolSize, poolName + ":connection-adder", threadFactory, new CustomDiscardPolicy());
+      this.addConnectionExecutor = createCreatorThreadPoolExecutor(
+         Math.min(Runtime.getRuntime().availableProcessors() * 2, config.getMinimumIdle()),
+         Math.max(Runtime.getRuntime().availableProcessors() * 2, config.getMinimumIdle()),
+         config.getMaximumPoolSize(),
+         ":connection-adder",
+         threadFactory,
+         new CustomDiscardPolicy());
       this.closeConnectionExecutor = createThreadPoolExecutor(maxPoolSize, poolName + ":connection-closer", threadFactory, new ThreadPoolExecutor.CallerRunsPolicy());
 
       this.leakTaskFactory = new ProxyLeakTaskFactory(config.getLeakDetectionThreshold(), houseKeepingExecutorService);
@@ -122,16 +131,10 @@ public final class HikariPool extends PoolBase implements HikariPoolMXBean, IBag
       this.houseKeeperTask = houseKeepingExecutorService.scheduleWithFixedDelay(new HouseKeeper(), 100L, housekeepingPeriodMs, MILLISECONDS);
 
       if (Boolean.getBoolean("com.zaxxer.hikari.blockUntilFilled") && config.getInitializationFailTimeout() > 1) {
-         addConnectionExecutor.setMaximumPoolSize(Math.min(16, Runtime.getRuntime().availableProcessors()));
-         addConnectionExecutor.setCorePoolSize(Math.min(16, Runtime.getRuntime().availableProcessors()));
-
          final long startTime = currentTime();
          while (elapsedMillis(startTime) < config.getInitializationFailTimeout() && getTotalConnections() < config.getMinimumIdle()) {
             quietlySleep(MILLISECONDS.toMillis(100));
          }
-
-         addConnectionExecutor.setCorePoolSize(1);
-         addConnectionExecutor.setMaximumPoolSize(1);
       }
    }
 
@@ -335,7 +338,7 @@ public final class HikariPool extends PoolBase implements HikariPoolMXBean, IBag
    @Override
    public void addBagItem(final int waiting)
    {
-      if (waiting > addConnectionExecutor.getQueue().size())
+      if (waiting > connectionsInProgress.get())
          addConnectionExecutor.submit(poolEntryCreator);
    }
 
@@ -520,10 +523,11 @@ public final class HikariPool extends PoolBase implements HikariPoolMXBean, IBag
    private synchronized void fillPool(final boolean isAfterAdd)
    {
       final var idle = getIdleConnections();
-      final var shouldAdd = getTotalConnections() < config.getMaximumPoolSize() && idle < config.getMinimumIdle();
+      final var connectionsInProgress = this.connectionsInProgress.get();
+      final var shouldAdd = getTotalConnections() < config.getMaximumPoolSize() - connectionsInProgress && idle < config.getMinimumIdle();
 
       if (shouldAdd) {
-         final var countToAdd = config.getMinimumIdle() - idle;
+         final var countToAdd = config.getMinimumIdle() - idle - connectionsInProgress;
          for (int i = 0; i < countToAdd; i++)
             addConnectionExecutor.submit(isAfterAdd ? postFillPoolEntryCreator : poolEntryCreator);
       }
@@ -740,26 +744,26 @@ public final class HikariPool extends PoolBase implements HikariPoolMXBean, IBag
       @Override
       public Boolean call()
       {
-         var backoffMs = 10L;
+         long jitterMs = ThreadLocalRandom.current().nextLong(Math.max(10, config.getConnectionTimeout() / 10));
+         if (connectionsInProgress.get() >= Runtime.getRuntime().availableProcessors()) {
+            quietlySleep(jitterMs);
+         }
          var added = false;
          try {
-            while (shouldContinueCreating()) {
+            if (!Thread.interrupted() && shouldContinueCreating()) {
                final var poolEntry = createPoolEntry();
                if (poolEntry != null) {
                   added = true;
                   connectionBag.add(poolEntry);
                   logger.debug("{} - Added connection {}", poolName, poolEntry.connection);
-                  quietlySleep(30L);
-                  break;
                } else {  // failed to get connection from db, sleep and retry
-                  if (loggingPrefix != null && backoffMs % 50 == 0)
-                     logger.debug("{} - Connection add failed, sleeping with backoff: {}ms", poolName, backoffMs);
-                  quietlySleep(backoffMs);
-                  backoffMs = Math.min(SECONDS.toMillis(5), backoffMs * 2);
+                  if (loggingPrefix != null)
+                     logger.debug("{} - Connection add failed", poolName);
                }
             }
          }
          finally {
+            connectionsInProgress.decrementAndGet();
             if (added && loggingPrefix != null)
                logPoolState(loggingPrefix);
             else if (!added)
@@ -777,8 +781,10 @@ public final class HikariPool extends PoolBase implements HikariPoolMXBean, IBag
        * @return true if we should create a connection, false if the need has disappeared
        */
       private synchronized boolean shouldContinueCreating() {
-         return poolState == POOL_NORMAL && getTotalConnections() < config.getMaximumPoolSize() &&
-            (getIdleConnections() < config.getMinimumIdle() || connectionBag.getWaitingThreadCount() > getIdleConnections());
+         final int idleConnections = getIdleConnections();
+         final int connectionsInProgress = HikariPool.this.connectionsInProgress.incrementAndGet();
+         return poolState == POOL_NORMAL && getTotalConnections() + connectionsInProgress < config.getMaximumPoolSize() &&
+            (idleConnections < config.getMinimumIdle() || connectionBag.getWaitingThreadCount() > idleConnections + connectionsInProgress);
       }
    }
 

--- a/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
+++ b/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
@@ -475,7 +475,7 @@ abstract class PoolBase
    {
       try {
          if (isUseJdbc4Validation) {
-            connection.isValid(1);
+            connection.isValid(Math.max(1, (int) MILLISECONDS.toSeconds(validationTimeout)));
          }
          else {
             executeSql(connection, config.getConnectionTestQuery(), false);

--- a/src/main/java/com/zaxxer/hikari/util/DriverDataSource.java
+++ b/src/main/java/com/zaxxer/hikari/util/DriverDataSource.java
@@ -45,9 +45,7 @@ public final class DriverDataSource implements DataSource
       this.jdbcUrl = jdbcUrl;
       this.driverProperties = new Properties();
 
-      for (var entry : properties.entrySet()) {
-         driverProperties.setProperty(entry.getKey().toString(), entry.getValue().toString());
-      }
+      driverProperties.putAll(properties);
 
       if (username != null) {
          driverProperties.put(USER, driverProperties.getProperty(USER, username));

--- a/src/main/java/com/zaxxer/hikari/util/UtilityElf.java
+++ b/src/main/java/com/zaxxer/hikari/util/UtilityElf.java
@@ -18,6 +18,7 @@ package com.zaxxer.hikari.util;
 
 import java.util.Locale;
 import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Pattern;
 
 import static java.lang.Thread.currentThread;
@@ -131,6 +132,11 @@ public final class UtilityElf
       return createThreadPoolExecutor(new LinkedBlockingQueue<>(queueSize), threadName, threadFactory, policy);
    }
 
+   public static ThreadPoolExecutor createCreatorThreadPoolExecutor(final int corePoolSize, final int maxPoolSize, final int queueSize, final String threadName, ThreadFactory threadFactory, final RejectedExecutionHandler policy)
+   {
+      return createCreatorThreadPoolExecutor(corePoolSize, maxPoolSize, new LinkedBlockingQueue<>(queueSize), threadName, threadFactory, policy);
+   }
+
    /**
     * Create a ThreadPoolExecutor.
     *
@@ -147,6 +153,18 @@ public final class UtilityElf
       }
 
       var executor = new ThreadPoolExecutor(1 /*core*/, 1 /*max*/, 5 /*keepalive*/, SECONDS, queue, threadFactory, policy);
+      executor.allowCoreThreadTimeOut(true);
+      return executor;
+   }
+
+   public static ThreadPoolExecutor createCreatorThreadPoolExecutor(
+      int corePoolSize, int maxPoolSize, final BlockingQueue<Runnable> queue, final String threadName, ThreadFactory threadFactory, final RejectedExecutionHandler policy)
+   {
+      if (threadFactory == null) {
+         threadFactory = new DefaultThreadFactory(threadName);
+      }
+
+      var executor = new ThreadPoolExecutor(corePoolSize /*core*/, maxPoolSize /*max*/, 5 /*keepalive*/, SECONDS, queue, threadFactory, policy);
       executor.allowCoreThreadTimeOut(true);
       return executor;
    }
@@ -198,6 +216,7 @@ public final class UtilityElf
 
    public static final class DefaultThreadFactory implements ThreadFactory
    {
+      private static final AtomicInteger counter = new AtomicInteger(0);
       private final String threadName;
       private final boolean daemon;
 
@@ -209,7 +228,7 @@ public final class UtilityElf
       @Override
       @SuppressWarnings("NullableProblems")
       public Thread newThread(Runnable r) {
-         var thread = new Thread(r, threadName);
+         var thread = new Thread(r, threadName + "_" + counter.incrementAndGet());
          thread.setDaemon(daemon);
          return thread;
       }

--- a/src/test/java/com/zaxxer/hikari/util/DriverDataSourceTest.java
+++ b/src/test/java/com/zaxxer/hikari/util/DriverDataSourceTest.java
@@ -18,6 +18,8 @@ package com.zaxxer.hikari.util;
 
 import org.junit.Test;
 
+import java.lang.reflect.Field;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
@@ -25,6 +27,18 @@ import java.util.Properties;
 import static org.junit.Assert.*;
 
 public class DriverDataSourceTest {
+
+   @Test
+   public void testDriverProperties() throws Exception {
+      Properties properties = new Properties();
+      Duration timeout = Duration.ofSeconds(60);
+      properties.put("timeout", timeout);
+      var driverDataSource = new DriverDataSource("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1", null, properties, "", "");
+      Field field = DriverDataSource.class.getDeclaredField("driverProperties");
+      field.setAccessible(true);
+      Properties driverProperties = (Properties) field.get(driverDataSource);
+      assertEquals(timeout, driverProperties.get("timeout"));
+   }
 
    @Test
    public void testJdbcUrlLogging() {


### PR DESCRIPTION
### The problem
When the cost of creating a connection is high enough (e.g. longer than connection-timeout, like a few seconds or more), the pool fails to reach sufficient number of connections to satisfy demand (rate of requests). Even when `com.zaxxer.hikari.blockUntilFilled` is set to `true` to make the app wait at startup to fill the pool with minimum idle connections, after max-lifetime of connections reaches, the connections are closed faster than the refill rate can keep up. This leads to the high number of waiting threads and small number of active and idle connections (less than the minimum-idle) either periodically or, in the worst case, becomes a new norm.

In addition, since `PoolEntryCreator` creates and adds new connections [sequentially](https://github.com/brettwooldridge/HikariCP/blob/0bff26e03292cec8a45faaecd7200639e63d3701/src/main/java/com/zaxxer/hikari/pool/HikariPool.java#L746), `initialization-fail-timeout` should be large enough to guarantee minimum idle connections are ready which can quickly turn into several minutes, though unnecessarily - had the connections been created concurrently. Moreover, when we prefer the smallest max-lifetime (which is 30s), closing of connections can start in the middle of `blockUntilFilled` at the startup, hence by the end of the prefill, we will have less than the desired number of idle connections.

Another point is that, while a creator task is already running,`refillPool()` method simply submits a creator task which ends up in the queue, because executor's `corePoolsize = maxPoolSize = 1`. As the creator task sequentially adds connections in the loop, by the time it finishes not much changes when the next creator task starts its loop again because `shouldContinueCreating()` has just returned false, and even if the condition satisfies again, it will barely help by adding a few connections. At this point, the queue becomes nothing more  than just an indicator of demand, based on its size, rather than truly preserving refill requests and helping to meet the demand.


### Discussion
Some might ask why would establishing a connection take longer than a few seconds, and that this problem should be fixed in the first place. Although in most of the cases that would be fair enough but this is not always possible, and in fact, I believe that is the whole point of a connection pool to take the burden/cost of creating connections on itself and have warm connections available regardless of the time it takes to create a connection.

Another question some might ask, why would connection-timeout be less than the time it takes to establish a connection? That might be a legit argument if requests can afford running that long, which could be the case with apps with relatively low traffic. However, with comparatively low-latency systems and large number of requests, we have to make sure if DB is not available, we don't wait longer than a few hundreds of milliseconds not to saturate threads and avoid cascading failures. In which case we rely on the connection pool to maintain connections on the side and have ready connections whenever needed.


I think for this type of scenarios, the strategy of maintaining connections could be discussed further and taken to the next level perhaps. In the short term though, creating new connections concurrently should be good enough of a solution to meet the aforementioned requirements.


Overall, if there is a better way of tackling the problem, feel free to comment on how the code change should look like. Will appreciate if you review this PR and let me know what you think. Cheers!