### PR TITLE
feat: Add fluent-style setters for HikariConfig class

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,15 @@
 HikariCP Changes
 
+Changes in 6.3.1
+
+ * fixed #2315 source jar contains also binary .class files and missing some .java files
+
+ * fixed #2307 remove improper hardcoded timout, use validationTimeout
+
+ * fixed #2305 keep properties key and values as is rather than forcing stringification. Also fixes #2286 and #2304
+
+ * upgraded various maven plugin dependencies to latest versions
+
 Changes in 6.3.0
 
  * increase keepaliveTime variance from 10% to 20%

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Fast, simple, reliable.  HikariCP is a "zero-overhead" production ready JDBC con
 
 ### Artifacts
 
-_**Java 11+** maven artifact:_
+_**Java 11 or greater** maven artifact:_
 ```xml
 <dependency>
    <groupId>com.zaxxer</groupId>

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Fast, simple, reliable.  HikariCP is a "zero-overhead" production ready JDBC con
 ----------------------------------------------------
 
 > [!IMPORTANT]
-> In order to avoid a rare condition where the pool goes to zero and does not recover it is necessary to configure *TCP keepalive*. Some JDBC drivers support this via properties, for example ``tcpKeepAlive=true`` on PostgreSQL, but in any case it can also be configured at the OS-level. See [Setting OS TCP Keepalive](https://github.com/brettwooldridge/HikariCP/wiki/Setting-OS-TCP-Keepalive) and/or [TCP keepalive for a better PostgreSQL experience](https://www.cybertec-postgresql.com/en/tcp-keepalive-for-a-better-postgresql-experience/#setting-tcp-keepalive-parameters-on-the-operating-system).
+> In order to avoid a rare condition where the pool goes to zero and does not recover it is necessary to configure *TCP keepalive*. Some JDBC drivers support this via properties, for example ``tcpKeepAlive=true`` on PostgreSQL, but in any case it can also be configured at the OS-level. See [Setting OS TCP Keepalive](https://github.com/brettwooldridge/HikariCP/wiki/Setting-Driver-or-OS-TCP-Keepalive) and/or [TCP keepalive for a better PostgreSQL experience](https://www.cybertec-postgresql.com/en/tcp-keepalive-for-a-better-postgresql-experience/#setting-tcp-keepalive-parameters-on-the-operating-system).
 
 ----------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ _**Java 11+** maven artifact:_
 <dependency>
    <groupId>com.zaxxer</groupId>
    <artifactId>HikariCP</artifactId>
-   <version>6.2.1</version>
+   <version>6.3.0</version>
 </dependency>
 ```
 _Java 8 maven artifact (*deprecated*):_

--- a/pom.xml
+++ b/pom.xml
@@ -292,13 +292,13 @@
             <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-clean-plugin</artifactId>
-               <version>3.2.0</version>
+               <version>3.4.1</version>
             </plugin>
 
             <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-compiler-plugin</artifactId>
-               <version>3.10.1</version>
+               <version>3.14.0</version>
                <configuration>
                   <source>11</source>
                   <target>11</target>
@@ -309,19 +309,19 @@
             <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-deploy-plugin</artifactId>
-               <version>2.8.2</version>
+               <version>3.1.4</version>
             </plugin>
 
             <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-gpg-plugin</artifactId>
-               <version>3.0.1</version>
+               <version>3.2.7</version>
             </plugin>
 
             <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-release-plugin</artifactId>
-               <version>2.5.3</version>
+               <version>3.1.1</version>
             </plugin>
 
             <plugin>
@@ -333,7 +333,7 @@
             <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-surefire-plugin</artifactId>
-               <version>3.0.0-M8</version>
+               <version>3.5.3</version>
                <configuration>
                   <!-- Sets the VM argument line used when unit tests are run. -->
                   <argLine>${surefireArgLine} ${sureFireOptions11}</argLine>
@@ -344,7 +344,7 @@
             <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-source-plugin</artifactId>
-               <version>3.0.1</version>
+               <version>3.3.1</version>
                <configuration>
                   <!-- outputDirectory>/absolute/path/to/the/output/directory</outputDirectory>
                      <finalName>filename-of-generated-jar-file</finalName -->
@@ -363,7 +363,7 @@
             <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-javadoc-plugin</artifactId>
-               <version>3.6.0</version>
+               <version>3.11.2</version>
                <configuration>
                   <show>public</show>
                   <excludePackageNames>
@@ -389,7 +389,7 @@
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-enforcer-plugin</artifactId>
-            <version>3.4.1</version>
+            <version>3.5.0</version>
             <executions>
                <execution>
                   <id>enforce-maven</id>
@@ -409,7 +409,7 @@
 
          <plugin>
             <artifactId>maven-dependency-plugin</artifactId>
-            <version>2.8</version>
+            <version>3.8.1</version>
             <executions>
                <execution>
                   <phase>generate-sources</phase>
@@ -427,7 +427,7 @@
             <!-- Generate proxies -->
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>exec-maven-plugin</artifactId>
-            <version>1.6.0</version>
+            <version>3.5.0</version>
             <extensions>true</extensions>
             <executions>
                <execution>
@@ -502,7 +502,7 @@
          <plugin>
             <groupId>org.jacoco</groupId>
             <artifactId>jacoco-maven-plugin</artifactId>
-            <version>0.8.8</version>
+            <version>0.8.13</version>
             <executions>
                <!-- Prepares the property pointing to the JaCoCo runtime agent which is passed as VM argument when Maven the Surefire plugin is executed. -->
                <execution>
@@ -543,7 +543,7 @@
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>3.0.0-M3</version>
+            <version>3.5.3</version>
             <executions>
                <execution>
                   <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -287,12 +287,6 @@
    </dependencies>
 
    <build>
-      <resources>
-         <resource>
-            <directory>target/classes</directory>
-         </resource>
-      </resources>
-
       <pluginManagement>
          <plugins>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
 
    <groupId>com.zaxxer</groupId>
    <artifactId>HikariCP</artifactId>
-   <version>6.3.1</version>
+   <version>6.3.2-SNAPSHOT</version>
    <packaging>bundle</packaging>
 
    <name>HikariCP</name>
@@ -65,7 +65,7 @@
       <connection>scm:git:https://github.com/brettwooldridge/HikariCP.git</connection>
       <developerConnection>scm:git:https://github.com/brettwooldridge/HikariCP.git</developerConnection>
       <url>https://github.com/brettwooldridge/HikariCP</url>
-      <tag>HikariCP-6.3.1</tag>
+      <tag>HEAD</tag>
    </scm>
 
    <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -333,7 +333,7 @@
             <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-javadoc-plugin</artifactId>
-               <version>3.11.2</version>
+               <version>3.6.0</version>
                <configuration>
                   <show>public</show>
                   <excludePackageNames>com.zaxxer.hikari.hibernate:com.zaxxer.hikari.metrics.*:com.zaxxer.hikari.pool:com.zaxxer.hikari.util</excludePackageNames>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
       <hibernate.version>5.4.24.Final</hibernate.version>
       <javassist.version>3.29.2-GA</javassist.version>
       <jndi.version>0.11.4.1</jndi.version>
-      <maven.release.version>3.0.1</maven.release.version>
+      <maven.release.version>2.5.3</maven.release.version>
       <metrics.version>3.2.5</metrics.version>
       <metrics5.version>5.0.0-rc17</metrics5.version>
       <micrometer.version>1.5.10</micrometer.version>
@@ -280,24 +280,18 @@
             <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-clean-plugin</artifactId>
-               <version>3.4.1</version>
+               <version>3.2.0</version>
             </plugin>
 
             <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-compiler-plugin</artifactId>
-               <version>3.14.0</version>
+               <version>3.10.1</version>
                <configuration>
                   <source>11</source>
                   <target>11</target>
                   <compilerArgs>-Xlint</compilerArgs>
                </configuration>
-            </plugin>
-
-            <plugin>
-               <groupId>org.apache.maven.plugins</groupId>
-               <artifactId>maven-gpg-plugin</artifactId>
-               <version>3.2.7</version>
             </plugin>
 
             <plugin>
@@ -309,46 +303,6 @@
                   <argLine>${surefireArgLine} ${sureFireOptions11}</argLine>
                   <reuseForks>${sureFireForks11}</reuseForks>
                </configuration>
-            </plugin>
-
-            <plugin>
-               <groupId>org.apache.maven.plugins</groupId>
-               <artifactId>maven-source-plugin</artifactId>
-               <version>3.3.1</version>
-               <configuration>
-                  <!-- outputDirectory>/absolute/path/to/the/output/directory</outputDirectory>
-                     <finalName>filename-of-generated-jar-file</finalName -->
-                  <attach>true</attach>
-               </configuration>
-               <executions>
-                  <execution>
-                     <id>attach-sources</id>
-                     <goals>
-                        <goal>jar-no-fork</goal>
-                     </goals>
-                  </execution>
-               </executions>
-            </plugin>
-
-            <plugin>
-               <groupId>org.apache.maven.plugins</groupId>
-               <artifactId>maven-javadoc-plugin</artifactId>
-               <version>3.6.0</version>
-               <configuration>
-                  <show>public</show>
-                  <excludePackageNames>com.zaxxer.hikari.hibernate:com.zaxxer.hikari.metrics.*:com.zaxxer.hikari.pool:com.zaxxer.hikari.util</excludePackageNames>
-                  <attach>true</attach>
-                  <maxmemory>1024m</maxmemory>
-               </configuration>
-               <executions>
-                  <execution>
-                     <id>bundle-sources</id>
-                     <phase>package</phase>
-                     <goals>
-                        <goal>jar</goal>
-                     </goals>
-                  </execution>
-               </executions>
             </plugin>
          </plugins>
       </pluginManagement>
@@ -395,7 +349,7 @@
             <!-- Generate proxies -->
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>exec-maven-plugin</artifactId>
-            <version>3.5.0</version>
+            <version>1.6.0</version>
             <extensions>true</extensions>
             <executions>
                <execution>
@@ -628,7 +582,48 @@
 
                <plugin>
                   <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-source-plugin</artifactId>
+                  <version>3.0.1</version>
+                  <configuration>
+                     <!-- outputDirectory>/absolute/path/to/the/output/directory</outputDirectory>
+                        <finalName>filename-of-generated-jar-file</finalName -->
+                     <attach>true</attach>
+                  </configuration>
+                  <executions>
+                     <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                           <goal>jar-no-fork</goal>
+                        </goals>
+                     </execution>
+                  </executions>
+               </plugin>
+
+               <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-javadoc-plugin</artifactId>
+                  <version>3.6.0</version>
+                  <configuration>
+                     <show>public</show>
+                     <excludePackageNames>com.zaxxer.hikari.hibernate:com.zaxxer.hikari.metrics.*:com.zaxxer.hikari.pool:com.zaxxer.hikari.util</excludePackageNames>
+                     <attach>true</attach>
+                     <maxmemory>1024m</maxmemory>
+                  </configuration>
+                  <executions>
+                     <execution>
+                        <id>bundle-sources</id>
+                        <phase>package</phase>
+                        <goals>
+                           <goal>jar</goal>
+                        </goals>
+                     </execution>
+                  </executions>
+               </plugin>
+
+               <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
                   <artifactId>maven-gpg-plugin</artifactId>
+                  <version>3.0.1</version>
                   <executions>
                      <execution>
                         <id>sign-artifacts</id>

--- a/pom.xml
+++ b/pom.xml
@@ -605,7 +605,7 @@
                   <version>3.6.0</version>
                   <configuration>
                      <show>public</show>
-                     <sourcepath>src/main/java</sourcepath>
+                     <sourcepath>${project.build.sourceDirectory}</sourcepath>
                      <excludePackageNames>com.zaxxer.hikari.hibernate:com.zaxxer.hikari.metrics.*:com.zaxxer.hikari.pool:com.zaxxer.hikari.util</excludePackageNames>
                      <attach>true</attach>
                      <maxmemory>1024m</maxmemory>

--- a/pom.xml
+++ b/pom.xml
@@ -636,36 +636,6 @@
 
                <plugin>
                   <groupId>org.apache.maven.plugins</groupId>
-                  <artifactId>maven-source-plugin</artifactId>
-                  <version>3.3.0</version>
-                  <executions>
-                     <execution>
-                        <id>attach-sources</id>
-                        <phase>verify</phase>
-                        <goals>
-                           <goal>jar-no-fork</goal>
-                        </goals>
-                     </execution>
-                  </executions>
-               </plugin>
-
-               <plugin>
-                  <groupId>org.apache.maven.plugins</groupId>
-                  <artifactId>maven-javadoc-plugin</artifactId>
-                  <version>3.6.0</version>
-                  <executions>
-                     <execution>
-                        <id>attach-javadocs</id>
-                        <phase>verify</phase>
-                        <goals>
-                           <goal>jar</goal>
-                        </goals>
-                     </execution>
-                  </executions>
-               </plugin>
-
-               <plugin>
-                  <groupId>org.apache.maven.plugins</groupId>
                   <artifactId>maven-gpg-plugin</artifactId>
                   <executions>
                      <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
 
    <groupId>com.zaxxer</groupId>
    <artifactId>HikariCP</artifactId>
-   <version>6.3.1-SNAPSHOT</version>
+   <version>6.3.1</version>
    <packaging>bundle</packaging>
 
    <name>HikariCP</name>
@@ -65,7 +65,7 @@
       <connection>scm:git:https://github.com/brettwooldridge/HikariCP.git</connection>
       <developerConnection>scm:git:https://github.com/brettwooldridge/HikariCP.git</developerConnection>
       <url>https://github.com/brettwooldridge/HikariCP</url>
-      <tag>HEAD</tag>
+      <tag>HikariCP-6.3.1</tag>
    </scm>
 
    <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -605,6 +605,7 @@
                   <version>3.6.0</version>
                   <configuration>
                      <show>public</show>
+                     <failOnError>false</failOnError>
                      <sourcepath>${project.build.sourceDirectory}</sourcepath>
                      <excludePackageNames>com.zaxxer.hikari.hibernate:com.zaxxer.hikari.metrics.*:com.zaxxer.hikari.pool:com.zaxxer.hikari.util</excludePackageNames>
                      <attach>true</attach>

--- a/pom.xml
+++ b/pom.xml
@@ -605,6 +605,7 @@
                   <version>3.6.0</version>
                   <configuration>
                      <show>public</show>
+                     <sourcepath>src/main/java</sourcepath>
                      <excludePackageNames>com.zaxxer.hikari.hibernate:com.zaxxer.hikari.metrics.*:com.zaxxer.hikari.pool:com.zaxxer.hikari.util</excludePackageNames>
                      <attach>true</attach>
                      <maxmemory>1024m</maxmemory>

--- a/pom.xml
+++ b/pom.xml
@@ -342,9 +342,7 @@
                <version>3.11.2</version>
                <configuration>
                   <show>public</show>
-                  <excludePackageNames>
-                     com.zaxxer.hikari.hibernate:com.zaxxer.hikari.metrics.*:com.zaxxer.hikari.pool:com.zaxxer.hikari.util
-                  </excludePackageNames>
+                  <excludePackageNames>com.zaxxer.hikari.hibernate:com.zaxxer.hikari.metrics.*:com.zaxxer.hikari.pool:com.zaxxer.hikari.util</excludePackageNames>
                   <attach>true</attach>
                   <maxmemory>1024m</maxmemory>
                </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -24,11 +24,6 @@
       <!--java11.build.outputDirectory>${project.build.directory}/classes-java11</java11.build.outputDirectory -->
       <artifact.classifier />
 
-      <!-- When releasing a new version, this property controls whether the staged artifacts will be automatically
-           released in Nexus. If this is set to false (-DautoReleaseStagedArtifacts=false), artifacts will need to
-           be manually released via the Nexus UI at https://oss.sonatype.org -->
-      <autoReleaseStagedArtifacts>true</autoReleaseStagedArtifacts>
-
       <docker.maven.plugin.fabric8.version>0.45.0</docker.maven.plugin.fabric8.version>
       <felix.bundle.plugin.version>5.1.1</felix.bundle.plugin.version>
       <felix.version>7.0.5</felix.version>
@@ -309,18 +304,6 @@
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-gpg-plugin</artifactId>
                <version>3.2.7</version>
-            </plugin>
-
-            <plugin>
-               <groupId>org.apache.maven.plugins</groupId>
-               <artifactId>maven-release-plugin</artifactId>
-               <version>3.1.1</version>
-            </plugin>
-
-            <plugin>
-               <groupId>org.sonatype.plugins</groupId>
-               <artifactId>nexus-staging-maven-plugin</artifactId>
-               <version>1.6.12</version>
             </plugin>
 
             <plugin>
@@ -641,6 +624,16 @@
          </activation>
          <build>
             <plugins>
+               <!-- Maven Release Plugin -->
+               <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-release-plugin</artifactId>
+                  <version>${maven.release.version}</version>
+                  <configuration>
+                     <goals>clean verify</goals> <!-- Prevent automatic deploy -->
+                  </configuration>
+               </plugin>
+
                <plugin>
                   <groupId>org.apache.maven.plugins</groupId>
                   <artifactId>maven-source-plugin</artifactId>
@@ -648,6 +641,7 @@
                   <executions>
                      <execution>
                         <id>attach-sources</id>
+                        <phase>verify</phase>
                         <goals>
                            <goal>jar-no-fork</goal>
                         </goals>
@@ -662,6 +656,7 @@
                   <executions>
                      <execution>
                         <id>attach-javadocs</id>
+                        <phase>verify</phase>
                         <goals>
                            <goal>jar</goal>
                         </goals>
@@ -669,8 +664,6 @@
                   </executions>
                </plugin>
 
-               <!-- For release: mvn release:perform -Darguments=-Dgpg.passphrase=PASSPHRASE
-                      With gpg2 you don't need to pass the passphrase; the GPG agent will prompt for it. -->
                <plugin>
                   <groupId>org.apache.maven.plugins</groupId>
                   <artifactId>maven-gpg-plugin</artifactId>
@@ -694,6 +687,15 @@
                      <publishingServerId>central</publishingServerId>
                      <autoPublish>false</autoPublish>
                   </configuration>
+                  <executions>
+                     <execution>
+                        <id>publish</id>
+                        <phase>deploy</phase> <!-- This line is key -->
+                        <goals>
+                           <goal>publish</goal>
+                        </goals>
+                     </execution>
+                  </executions>
                </plugin>
             </plugins>
          </build>

--- a/pom.xml
+++ b/pom.xml
@@ -296,12 +296,6 @@
 
             <plugin>
                <groupId>org.apache.maven.plugins</groupId>
-               <artifactId>maven-deploy-plugin</artifactId>
-               <version>3.1.4</version>
-            </plugin>
-
-            <plugin>
-               <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-gpg-plugin</artifactId>
                <version>3.2.7</version>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -73,13 +73,6 @@
       <tag>HEAD</tag>
    </scm>
 
-   <distributionManagement>
-      <snapshotRepository>
-         <id>ossrh</id>
-         <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-      </snapshotRepository>
-   </distributionManagement>
-
    <issueManagement>
       <url>https://github.com/brettwooldridge/HikariCP/issues</url>
    </issueManagement>
@@ -692,17 +685,14 @@
                   </executions>
                </plugin>
 
-               <!-- nexus-staging-maven-plugin replaces the standard maven-deploy-plugin for releases and
-                    is useful for ensuring artifacts are all-or-nothing, as well as allowing artifacts to
-                    be reviewed before they're made public -->
                <plugin>
-                  <groupId>org.sonatype.plugins</groupId>
-                  <artifactId>nexus-staging-maven-plugin</artifactId>
+                  <groupId>org.sonatype.central</groupId>
+                  <artifactId>central-publishing-maven-plugin</artifactId>
+                  <version>0.7.0</version>
                   <extensions>true</extensions>
                   <configuration>
-                     <autoReleaseAfterClose>${autoReleaseStagedArtifacts}</autoReleaseAfterClose>
-                     <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                     <serverId>ossrh</serverId>
+                     <publishingServerId>central</publishingServerId>
+                     <autoPublish>false</autoPublish>
                   </configuration>
                </plugin>
             </plugins>

--- a/publish.sh
+++ b/publish.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-mvn release:prepare -Prelease && mvn deploy -DperformRelease=true -DskipTests -Dmaven.test.skip=true
+mvn clean && mvn package -DskipTests -Dmaven.test.skip=true && mvn release:prepare -Prelease && mvn deploy -DperformRelease=true -DskipTests -Dmaven.test.skip=true

--- a/publish.sh
+++ b/publish.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+mvn release:prepare -Prelease && mvn deploy -DperformRelease=true
+

--- a/publish.sh
+++ b/publish.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-mvn release:prepare -Prelease && mvn deploy -DperformRelease=true
-
+mvn release:prepare -Prelease && mvn deploy -DperformRelease=true -DskipTests -Dmaven.test.skip=true

--- a/src/main/java/com/zaxxer/hikari/HikariConfig.java
+++ b/src/main/java/com/zaxxer/hikari/HikariConfig.java
@@ -174,6 +174,18 @@ public class HikariConfig implements HikariConfigMXBean
       this.catalog = catalog;
    }
 
+   /**
+    * Fluent-style version of {@link #setCatalog(String)}.
+    *
+    * @param catalog the catalog name, or null
+    * @return this config instance for chaining
+    */
+   public HikariConfig catalog(String catalog)
+   {
+      this.catalog = catalog;
+      return this;
+   }
+
 
    /** {@inheritDoc} */
    @Override
@@ -197,6 +209,26 @@ public class HikariConfig implements HikariConfigMXBean
       }
    }
 
+   /**
+    * Fluent-style version of {@link #setConnectionTimeout(long)}.
+    *
+    * @param connectionTimeoutMs the connection timeout in milliseconds
+    * @return this config instance for chaining
+    */
+   public HikariConfig connectionTimeout(long connectionTimeoutMs)
+   {
+      if (connectionTimeoutMs == 0) {
+         this.connectionTimeout = Integer.MAX_VALUE;
+      }
+      else if (connectionTimeoutMs < SOFT_TIMEOUT_FLOOR) {
+         throw new IllegalArgumentException("connectionTimeout cannot be less than " + SOFT_TIMEOUT_FLOOR + "ms");
+      }
+      else {
+         this.connectionTimeout = connectionTimeoutMs;
+      }
+      return this;
+   }
+
    /** {@inheritDoc} */
    @Override
    public long getIdleTimeout()
@@ -214,6 +246,21 @@ public class HikariConfig implements HikariConfigMXBean
       this.idleTimeout = idleTimeoutMs;
    }
 
+   /**
+    * Fluent-style version of {@link #setIdleTimeout(long)}.
+    *
+    * @param idleTimeoutMs the idle timeout in milliseconds
+    * @return this config instance for chaining
+    */
+   public HikariConfig idleTimeout(long idleTimeoutMs)
+   {
+      if (idleTimeoutMs < 0) {
+         throw new IllegalArgumentException("idleTimeout cannot be negative");
+      }
+      this.idleTimeout = idleTimeoutMs;
+      return this;
+   }
+
    /** {@inheritDoc} */
    @Override
    public long getLeakDetectionThreshold()
@@ -228,6 +275,18 @@ public class HikariConfig implements HikariConfigMXBean
       this.leakDetectionThreshold = leakDetectionThresholdMs;
    }
 
+   /**
+    * Fluent-style version of {@link #setLeakDetectionThreshold(long)}.
+    *
+    * @param leakDetectionThresholdMs the connection leak detection threshold in milliseconds
+    * @return this config instance for chaining
+    */
+   public HikariConfig leakDetectionThreshold(long leakDetectionThresholdMs)
+   {
+      this.leakDetectionThreshold = leakDetectionThresholdMs;
+      return this;
+   }
+
    /** {@inheritDoc} */
    @Override
    public long getMaxLifetime()
@@ -240,6 +299,18 @@ public class HikariConfig implements HikariConfigMXBean
    public void setMaxLifetime(long maxLifetimeMs)
    {
       this.maxLifetime = maxLifetimeMs;
+   }
+
+   /**
+    * Fluent-style version of {@link #setMaxLifetime(long)}.
+    *
+    * @param maxLifetimeMs the maximum connection lifetime in milliseconds
+    * @return this config instance for chaining
+    */
+   public HikariConfig maxLifetime(long maxLifetimeMs)
+   {
+      this.maxLifetime = maxLifetimeMs;
+      return this;
    }
 
    /** {@inheritDoc} */
@@ -257,6 +328,21 @@ public class HikariConfig implements HikariConfigMXBean
          throw new IllegalArgumentException("maxPoolSize cannot be less than 1");
       }
       this.maxPoolSize = maxPoolSize;
+   }
+
+   /**
+    * Fluent-style version of {@link #setMaximumPoolSize(int)}.
+    *
+    * @param maxPoolSize the maximum number of connections in the pool
+    * @return this config instance for chaining
+    */
+   public HikariConfig maximumPoolSize(int maxPoolSize)
+   {
+      if (maxPoolSize < 1) {
+         throw new IllegalArgumentException("maxPoolSize cannot be less than 1");
+      }
+      this.maxPoolSize = maxPoolSize;
+      return this;
    }
 
    /** {@inheritDoc} */
@@ -277,6 +363,21 @@ public class HikariConfig implements HikariConfigMXBean
    }
 
    /**
+    * Fluent-style version of {@link #setMinimumIdle(int)}.
+    *
+    * @param minIdle the minimum number of idle connections in the pool to maintain
+    * @return this config instance for chaining
+    */
+   public HikariConfig minimumIdle(int minIdle)
+   {
+      if (minIdle < 0) {
+         throw new IllegalArgumentException("minimumIdle cannot be negative");
+      }
+      this.minIdle = minIdle;
+      return this;
+   }
+
+   /**
     * Get the default password to use for DataSource.getConnection(username, password) calls.
     * @return the password
     */
@@ -293,6 +394,18 @@ public class HikariConfig implements HikariConfigMXBean
    public void setPassword(String password)
    {
       credentials.updateAndGet(current -> Credentials.of(current.getUsername(), password));
+   }
+
+   /**
+    * Fluent-style version of {@link #setPassword(String)}.
+    *
+    * @param password the password
+    * @return this config instance for chaining
+    */
+   public HikariConfig password(String password)
+   {
+      credentials.updateAndGet(current -> Credentials.of(current.getUsername(), password));
+      return this;
    }
 
    /**
@@ -317,6 +430,18 @@ public class HikariConfig implements HikariConfigMXBean
    }
 
    /**
+    * Fluent-style version of {@link #setUsername(String)}.
+    *
+    * @param username the username
+    * @return this config instance for chaining
+    */
+   public HikariConfig username(String username)
+   {
+      credentials.updateAndGet(current -> Credentials.of(username, current.getPassword()));
+      return this;
+   }
+
+   /**
     * Atomically set the default username and password to use for DataSource.getConnection(username, password) calls.
     *
     * @param credentials the username and password pair
@@ -325,6 +450,18 @@ public class HikariConfig implements HikariConfigMXBean
    public void setCredentials(final Credentials credentials)
    {
       this.credentials.set(credentials);
+   }
+
+   /**
+    * Fluent-style version of {@link #setCredentials(Credentials)}.
+    *
+    * @param credentials the username and password pair
+    * @return this config instance for chaining
+    */
+   public HikariConfig credentials(final Credentials credentials)
+   {
+      this.credentials.set(credentials);
+      return this;
    }
 
    /**
@@ -355,6 +492,22 @@ public class HikariConfig implements HikariConfigMXBean
       this.validationTimeout = validationTimeoutMs;
    }
 
+   /**
+    * Fluent-style version of {@link #setValidationTimeout(long)}.
+    *
+    * @param validationTimeoutMs the validation timeout in milliseconds
+    * @return this config instance for chaining
+    */
+   public HikariConfig validationTimeout(long validationTimeoutMs)
+   {
+      if (validationTimeoutMs < SOFT_TIMEOUT_FLOOR) {
+         throw new IllegalArgumentException("validationTimeout cannot be less than " + SOFT_TIMEOUT_FLOOR + "ms");
+      }
+
+      this.validationTimeout = validationTimeoutMs;
+      return this;
+   }
+
    // ***********************************************************************
    //                     All other configuration methods
    // ***********************************************************************
@@ -383,6 +536,19 @@ public class HikariConfig implements HikariConfigMXBean
    }
 
    /**
+    * Fluent-style version of {@link #setConnectionTestQuery(String)}.
+    *
+    * @param connectionTestQuery a SQL query string
+    * @return this config instance for chaining
+    */
+   public HikariConfig connectionTestQuery(String connectionTestQuery)
+   {
+      checkIfSealed();
+      this.connectionTestQuery = connectionTestQuery;
+      return this;
+   }
+
+   /**
     * Get the SQL string that will be executed on all new connections when they are
     * created, before they are added to the pool.
     *
@@ -404,6 +570,19 @@ public class HikariConfig implements HikariConfigMXBean
    {
       checkIfSealed();
       this.connectionInitSql = connectionInitSql;
+   }
+
+   /**
+    * Fluent-style version of {@link #setConnectionInitSql(String)}.
+    *
+    * @param connectionInitSql the SQL to execute on new connections
+    * @return this config instance for chaining
+    */
+   public HikariConfig connectionInitSql(String connectionInitSql)
+   {
+      checkIfSealed();
+      this.connectionInitSql = connectionInitSql;
+      return this;
    }
 
    /**
@@ -430,6 +609,19 @@ public class HikariConfig implements HikariConfigMXBean
    }
 
    /**
+    * Fluent-style version of {@link #setDataSource(DataSource)}.
+    *
+    * @param dataSource a specific {@link DataSource} to be wrapped by the pool
+    * @return this config instance for chaining
+    */
+   public HikariConfig dataSource(DataSource dataSource)
+   {
+      checkIfSealed();
+      this.dataSource = dataSource;
+      return this;
+   }
+
+   /**
     * Get the name of the JDBC {@link DataSource} class used to create Connections.
     *
     * @return the fully qualified name of the JDBC {@link DataSource} class
@@ -448,6 +640,19 @@ public class HikariConfig implements HikariConfigMXBean
    {
       checkIfSealed();
       this.dataSourceClassName = className;
+   }
+
+   /**
+    * Fluent-style version of {@link #setDataSourceClassName(String)}.
+    *
+    * @param className the fully qualified name of the JDBC {@link DataSource} class
+    * @return this config instance for chaining
+    */
+   public HikariConfig dataSourceClassName(String className)
+   {
+      checkIfSealed();
+      this.dataSourceClassName = className;
+      return this;
    }
 
    /**
@@ -480,6 +685,19 @@ public class HikariConfig implements HikariConfigMXBean
       this.dataSourceJndiName = jndiDataSource;
    }
 
+   /**
+    * Fluent-style version of {@link #setDataSourceJNDI(String)}.
+    *
+    * @param jndiDataSource the dataSource JNDI name
+    * @return this config instance for chaining
+    */
+   public HikariConfig dataSourceJNDI(String jndiDataSource)
+   {
+      checkIfSealed();
+      this.dataSourceJndiName = jndiDataSource;
+      return this;
+   }
+
    public Properties getDataSourceProperties()
    {
       return dataSourceProperties;
@@ -489,6 +707,19 @@ public class HikariConfig implements HikariConfigMXBean
    {
       checkIfSealed();
       dataSourceProperties.putAll(dsProperties);
+   }
+
+   /**
+    * Fluent-style version of {@link #setDataSourceProperties(Properties)}.
+    *
+    * @param dsProperties the dataSource properties
+    * @return this config instance for chaining
+    */
+   public HikariConfig dataSourceProperties(Properties dsProperties)
+   {
+      checkIfSealed();
+      dataSourceProperties.putAll(dsProperties);
+      return this;
    }
 
    public String getDriverClassName()
@@ -523,6 +754,41 @@ public class HikariConfig implements HikariConfigMXBean
       }
    }
 
+   /**
+    * Fluent-style version of {@link #setDriverClassName(String)}.
+    *
+    * @param driverClassName the dataSource driver class name
+    * @return this config instance for chaining
+    */
+   public HikariConfig driverClassName(String driverClassName)
+   {
+      checkIfSealed();
+
+      var driverClass = attemptFromContextLoader(driverClassName);
+      try {
+         if (driverClass == null) {
+            driverClass = this.getClass().getClassLoader().loadClass(driverClassName);
+            LOGGER.debug("Driver class {} found in the HikariConfig class classloader {}", driverClassName, this.getClass().getClassLoader());
+         }
+      } catch (ClassNotFoundException e) {
+         LOGGER.error("Failed to load driver class {} from HikariConfig class classloader {}", driverClassName, this.getClass().getClassLoader());
+      }
+
+      if (driverClass == null) {
+         throw new RuntimeException("Failed to load driver class " + driverClassName + " in either of HikariConfig class loader or Thread context classloader");
+      }
+
+      try {
+         driverClass.getConstructor().newInstance();
+         this.driverClassName = driverClassName;
+      }
+      catch (Exception e) {
+         throw new RuntimeException("Failed to instantiate class " + driverClassName, e);
+      }
+
+      return this;
+   }
+
    public String getJdbcUrl()
    {
       return jdbcUrl;
@@ -532,6 +798,19 @@ public class HikariConfig implements HikariConfigMXBean
    {
       checkIfSealed();
       this.jdbcUrl = jdbcUrl;
+   }
+
+   /**
+    * Fluent-style version of {@link #setJdbcUrl(String)}.
+    *
+    * @param jdbcUrl the dataSource jdbc url
+    * @return this config instance for chaining
+    */
+   public HikariConfig jdbcUrl(String jdbcUrl)
+   {
+      checkIfSealed();
+      this.jdbcUrl = jdbcUrl;
+      return this;
    }
 
    /**
@@ -556,6 +835,19 @@ public class HikariConfig implements HikariConfigMXBean
    }
 
    /**
+    * Fluent-style version of {@link #setAutoCommit(boolean)}.
+    *
+    * @param isAutoCommit the desired auto-commit default for connections
+    * @return this config instance for chaining
+    */
+   public HikariConfig autoCommit(boolean isAutoCommit)
+   {
+      checkIfSealed();
+      this.isAutoCommit = isAutoCommit;
+      return this;
+   }
+
+   /**
     * Get the pool suspension behavior (allowed or disallowed).
     *
     * @return the pool suspension behavior
@@ -576,6 +868,19 @@ public class HikariConfig implements HikariConfigMXBean
    {
       checkIfSealed();
       this.isAllowPoolSuspension = isAllowPoolSuspension;
+   }
+
+   /**
+    * Fluent-style version of {@link #setAllowPoolSuspension(boolean)}.
+    *
+    * @param isAllowPoolSuspension the desired pool suspension allowance
+    * @return this config instance for chaining
+    */
+   public HikariConfig allowPoolSuspension(boolean isAllowPoolSuspension)
+   {
+      checkIfSealed();
+      this.isAllowPoolSuspension = isAllowPoolSuspension;
+      return this;
    }
 
    /**
@@ -630,6 +935,22 @@ public class HikariConfig implements HikariConfigMXBean
    }
 
    /**
+    * Fluent-style version of {@link #setInitializationFailTimeout(long)}.
+    *
+    * @param initializationFailTimeout the number of milliseconds before the
+    *        pool initialization fails, or 0 to validate connection setup but continue with
+    *        pool start, or less than zero to skip all initialization checks and start the
+    *        pool without delay.
+    * @return this config instance for chaining
+    */
+   public HikariConfig initializationFailTimeout(long initializationFailTimeout)
+   {
+      checkIfSealed();
+      this.initializationFailTimeout = initializationFailTimeout;
+      return this;
+   }
+
+   /**
     * Determine whether internal pool queries, principally aliveness checks, will be isolated in their own transaction
     * via {@link Connection#rollback()}.  Defaults to {@code false}.
     *
@@ -652,6 +973,19 @@ public class HikariConfig implements HikariConfigMXBean
       this.isIsolateInternalQueries = isolate;
    }
 
+   /**
+    * Fluent-style version of {@link #setIsolateInternalQueries(boolean)}.
+    *
+    * @param isolate {@code true} if internal pool queries should be isolated, {@code false} if not
+    * @return this config instance for chaining
+    */
+   public HikariConfig isolateInternalQueries(boolean isolate)
+   {
+      checkIfSealed();
+      this.isIsolateInternalQueries = isolate;
+      return this;
+   }
+
    public MetricsTrackerFactory getMetricsTrackerFactory()
    {
       return metricsTrackerFactory;
@@ -664,6 +998,22 @@ public class HikariConfig implements HikariConfigMXBean
       }
 
       this.metricsTrackerFactory = metricsTrackerFactory;
+   }
+
+   /**
+    * Fluent-style version of {@link #setMetricsTrackerFactory(MetricsTrackerFactory)}.
+    *
+    * @param metricsTrackerFactory metricsTrackerFactory
+    * @return this config instance for chaining
+    */
+   public HikariConfig metricsTrackerFactory(MetricsTrackerFactory metricsTrackerFactory)
+   {
+      if (metricRegistry != null) {
+         throw new IllegalStateException("cannot use setMetricsTrackerFactory() and setMetricRegistry() together");
+      }
+
+      this.metricsTrackerFactory = metricsTrackerFactory;
+      return this;
    }
 
    /**
@@ -702,6 +1052,33 @@ public class HikariConfig implements HikariConfigMXBean
    }
 
    /**
+    * Fluent-style version of {@link #setMetricRegistry(Object)}.
+    *
+    * @param metricRegistry the MetricRegistry instance to use
+    * @return this config instance for chaining
+    */
+   public HikariConfig metricRegistry(Object metricRegistry)
+   {
+      if (metricsTrackerFactory != null) {
+         throw new IllegalStateException("cannot use setMetricRegistry() and setMetricsTrackerFactory() together");
+      }
+
+      if (metricRegistry != null) {
+         metricRegistry = getObjectOrPerformJndiLookup(metricRegistry);
+
+         if (!safeIsAssignableFrom(metricRegistry, "com.codahale.metrics.MetricRegistry")
+            && !(safeIsAssignableFrom(metricRegistry, "io.dropwizard.metrics5.MetricRegistry"))
+            && !(safeIsAssignableFrom(metricRegistry, "io.micrometer.core.instrument.MeterRegistry"))) {
+            throw new IllegalArgumentException("Class must be instance of com.codahale.metrics.MetricRegistry, " +
+               "io.dropwizard.metrics5.MetricRegistry, or io.micrometer.core.instrument.MeterRegistry");
+         }
+      }
+
+      this.metricRegistry = metricRegistry;
+      return this;
+   }
+
+   /**
     * Get the HealthCheckRegistry that will be used for registration of health checks by HikariCP.  Currently only
     * Codahale/DropWizard is supported for health checks.
     *
@@ -733,6 +1110,28 @@ public class HikariConfig implements HikariConfigMXBean
       this.healthCheckRegistry = healthCheckRegistry;
    }
 
+   /**
+    * Fluent-style version of {@link #setHealthCheckRegistry(Object)}.
+    *
+    * @param healthCheckRegistry the HealthCheckRegistry to be used
+    * @return this config instance for chaining
+    */
+   public HikariConfig healthCheckRegistry(Object healthCheckRegistry)
+   {
+      checkIfSealed();
+
+      if (healthCheckRegistry != null) {
+         healthCheckRegistry = getObjectOrPerformJndiLookup(healthCheckRegistry);
+
+         if (!(healthCheckRegistry instanceof HealthCheckRegistry)) {
+            throw new IllegalArgumentException("Class must be an instance of com.codahale.metrics.health.HealthCheckRegistry");
+         }
+      }
+
+      this.healthCheckRegistry = healthCheckRegistry;
+      return this;
+   }
+
    public Properties getHealthCheckProperties()
    {
       return healthCheckProperties;
@@ -742,6 +1141,19 @@ public class HikariConfig implements HikariConfigMXBean
    {
       checkIfSealed();
       this.healthCheckProperties.putAll(healthCheckProperties);
+   }
+
+   /**
+    * Fluent-style version of {@link #setHealthCheckProperties(Properties)}.
+    *
+    * @param healthCheckProperties the healthCheckProperties to be used
+    * @return this config instance for chaining
+    */
+   public HikariConfig healthCheckProperties(Properties healthCheckProperties)
+   {
+      checkIfSealed();
+      this.healthCheckProperties.putAll(healthCheckProperties);
+      return this;
    }
 
    public void addHealthCheckProperty(String key, String value)
@@ -771,6 +1183,17 @@ public class HikariConfig implements HikariConfigMXBean
    }
 
    /**
+    * Fluent-style version of {@link #setKeepaliveTime(long)}.
+    *
+    * @param keepaliveTimeMs the interval in which connections will be tested for aliveness, thus keeping them alive by the act of checking. Value is in milliseconds, default is 0 (disabled).
+    * @return this config instance for chaining
+    */
+   public HikariConfig keepaliveTime(long keepaliveTimeMs) {
+      this.keepaliveTime = keepaliveTimeMs;
+      return this;
+   }
+
+   /**
     * Determine whether the Connections in the pool are in read-only mode.
     *
     * @return {@code true} if the Connections in the pool are read-only, {@code false} if not
@@ -789,6 +1212,19 @@ public class HikariConfig implements HikariConfigMXBean
    {
       checkIfSealed();
       this.isReadOnly = readOnly;
+   }
+
+   /**
+    * Fluent-style version of {@link #setReadOnly(boolean)}.
+    *
+    * @param readOnly {@code true} if the Connections in the pool are read-only, {@code false} if not
+    * @return this config instance for chaining
+    */
+   public HikariConfig readOnly(boolean readOnly)
+   {
+      checkIfSealed();
+      this.isReadOnly = readOnly;
+      return this;
    }
 
    /**
@@ -813,6 +1249,19 @@ public class HikariConfig implements HikariConfigMXBean
       this.isRegisterMbeans = register;
    }
 
+   /**
+    * Fluent-style version of {@link #setRegisterMbeans(boolean)}.
+    *
+    * @param register {@code true} if HikariCP should register MXBeans, {@code false} if it should not
+    * @return this config instance for chaining
+    */
+   public HikariConfig registerMbeans(boolean register)
+   {
+      checkIfSealed();
+      this.isRegisterMbeans = register;
+      return this;
+   }
+
    /** {@inheritDoc} */
    @Override
    public String getPoolName()
@@ -830,6 +1279,19 @@ public class HikariConfig implements HikariConfigMXBean
    {
       checkIfSealed();
       this.poolName = poolName;
+   }
+
+   /**
+    * Fluent-style version of {@link #setPoolName(String)}.
+    *
+    * @param poolName the name of the connection pool to use
+    * @return this config instance for chaining
+    */
+   public HikariConfig poolName(String poolName)
+   {
+      checkIfSealed();
+      this.poolName = poolName;
+      return this;
    }
 
    /**
@@ -851,6 +1313,19 @@ public class HikariConfig implements HikariConfigMXBean
    {
       checkIfSealed();
       this.scheduledExecutor = executor;
+   }
+
+   /**
+    * Fluent-style version of {@link #setScheduledExecutor(ScheduledExecutorService)}.
+    *
+    * @param executor the ScheduledExecutorService
+    * @return this config instance for chaining
+    */
+   public HikariConfig scheduledExecutor(ScheduledExecutorService executor)
+   {
+      checkIfSealed();
+      this.scheduledExecutor = executor;
+      return this;
    }
 
    public String getTransactionIsolation()
@@ -877,6 +1352,19 @@ public class HikariConfig implements HikariConfigMXBean
    {
       checkIfSealed();
       this.schema = schema;
+   }
+
+   /**
+    * Fluent-style version of {@link #setSchema(String)}.
+    *
+    * @param schema the name of the default schema
+    * @return this config instance for chaining
+    */
+   public HikariConfig schema(String schema)
+   {
+      checkIfSealed();
+      this.schema = schema;
+      return this;
    }
 
    /**
@@ -927,6 +1415,46 @@ public class HikariConfig implements HikariConfigMXBean
       }
    }
 
+   /**
+    * Fluent-style version of {@link #setExceptionOverrideClassName(String)}.
+    *
+    * @param exceptionOverrideClassName the user supplied SQLExceptionOverride class name
+    * @return this config instance for chaining
+    * @see SQLExceptionOverride
+    */
+   public HikariConfig exceptionOverrideClassName(String exceptionOverrideClassName)
+   {
+      checkIfSealed();
+
+      var overrideClass = attemptFromContextLoader(exceptionOverrideClassName);
+      try {
+         if (overrideClass == null) {
+            overrideClass = this.getClass().getClassLoader().loadClass(exceptionOverrideClassName);
+            LOGGER.debug("SQLExceptionOverride class {} found in the HikariConfig class classloader {}", exceptionOverrideClassName, this.getClass().getClassLoader());
+         }
+      } catch (ClassNotFoundException e) {
+         LOGGER.error("Failed to load SQLExceptionOverride class {} from HikariConfig class classloader {}", exceptionOverrideClassName, this.getClass().getClassLoader());
+      }
+
+      if (overrideClass == null) {
+         throw new RuntimeException("Failed to load SQLExceptionOverride class " + exceptionOverrideClassName + " in either of HikariConfig class loader or Thread context classloader");
+      }
+
+      if (!SQLExceptionOverride.class.isAssignableFrom(overrideClass)) {
+         throw new RuntimeException("Loaded SQLExceptionOverride class " + exceptionOverrideClassName + " does not implement " + SQLExceptionOverride.class.getName());
+      }
+
+      try {
+         this.exceptionOverride = (SQLExceptionOverride) overrideClass.getConstructor().newInstance();
+         this.exceptionOverrideClassName = exceptionOverrideClassName;
+      }
+      catch (Exception e) {
+         throw new RuntimeException("Failed to instantiate class " + exceptionOverrideClassName, e);
+      }
+
+      return this;
+   }
+
 
    /**
     * Get the SQLExceptionOverride instance created by {@link #setExceptionOverrideClassName(String)}.
@@ -951,6 +1479,19 @@ public class HikariConfig implements HikariConfigMXBean
    }
 
    /**
+    * Fluent-style version of {@link #setExceptionOverride(SQLExceptionOverride)}.
+    *
+    * @param exceptionOverride the user supplied SQLExceptionOverride instance
+    * @return this config instance for chaining
+    * @see SQLExceptionOverride
+    */
+   public HikariConfig exceptionOverride(SQLExceptionOverride exceptionOverride) {
+      checkIfSealed();
+      this.exceptionOverride = exceptionOverride;
+      return this;
+   }
+
+   /**
     * Set the default transaction isolation level.  The specified value is the
     * constant name from the <code>Connection</code> class, eg.
     * <code>TRANSACTION_REPEATABLE_READ</code>.
@@ -961,6 +1502,19 @@ public class HikariConfig implements HikariConfigMXBean
    {
       checkIfSealed();
       this.transactionIsolationName = isolationLevel;
+   }
+
+   /**
+    * Fluent-style version of {@link #setTransactionIsolation(String)}.
+    *
+    * @param isolationLevel the name of the isolation level
+    * @return this config instance for chaining
+    */
+   public HikariConfig transactionIsolation(String isolationLevel)
+   {
+      checkIfSealed();
+      this.transactionIsolationName = isolationLevel;
+      return this;
    }
 
    /**
@@ -982,6 +1536,19 @@ public class HikariConfig implements HikariConfigMXBean
    {
       checkIfSealed();
       this.threadFactory = threadFactory;
+   }
+
+   /**
+    * Fluent-style version of {@link #setThreadFactory(ThreadFactory)}.
+    *
+    * @param threadFactory the thread factory (setting to null causes the default thread factory to be used)
+    * @return this config instance for chaining
+    */
+   public HikariConfig threadFactory(ThreadFactory threadFactory)
+   {
+      checkIfSealed();
+      this.threadFactory = threadFactory;
+      return this;
    }
 
    void seal()

--- a/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
+++ b/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
@@ -475,7 +475,7 @@ abstract class PoolBase
    {
       try {
          if (isUseJdbc4Validation) {
-            connection.isValid(1);
+            connection.isValid(Math.max(1, (int) MILLISECONDS.toSeconds(validationTimeout)));
          }
          else {
             executeSql(connection, config.getConnectionTestQuery(), false);

--- a/src/main/java/com/zaxxer/hikari/util/DriverDataSource.java
+++ b/src/main/java/com/zaxxer/hikari/util/DriverDataSource.java
@@ -45,9 +45,7 @@ public final class DriverDataSource implements DataSource
       this.jdbcUrl = jdbcUrl;
       this.driverProperties = new Properties();
 
-      for (var entry : properties.entrySet()) {
-         driverProperties.setProperty(entry.getKey().toString(), entry.getValue().toString());
-      }
+      driverProperties.putAll(properties);
 
       if (username != null) {
          driverProperties.put(USER, driverProperties.getProperty(USER, username));

--- a/src/test/java/com/zaxxer/hikari/util/DriverDataSourceTest.java
+++ b/src/test/java/com/zaxxer/hikari/util/DriverDataSourceTest.java
@@ -18,6 +18,8 @@ package com.zaxxer.hikari.util;
 
 import org.junit.Test;
 
+import java.lang.reflect.Field;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
@@ -25,6 +27,18 @@ import java.util.Properties;
 import static org.junit.Assert.*;
 
 public class DriverDataSourceTest {
+
+   @Test
+   public void testDriverProperties() throws Exception {
+      Properties properties = new Properties();
+      Duration timeout = Duration.ofSeconds(60);
+      properties.put("timeout", timeout);
+      var driverDataSource = new DriverDataSource("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1", null, properties, "", "");
+      Field field = DriverDataSource.class.getDeclaredField("driverProperties");
+      field.setAccessible(true);
+      Properties driverProperties = (Properties) field.get(driverDataSource);
+      assertEquals(timeout, driverProperties.get("timeout"));
+   }
 
    @Test
    public void testJdbcUrlLogging() {

--- a/src/test/resources/log4j2-test.xml
+++ b/src/test/resources/log4j2-test.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration status="OFF">
   <appenders>
-    <Console name="Console" target="SYSTEM_ERR">
+    <Console name="Console" target="SYSTEM_OUT">
       <PatternLayout pattern="%d{ABSOLUTE_MICROS} [seq%5sn] [%-40.40t] %-5level %-20c{1} - %msg%n" />
     </Console>
   </appenders>


### PR DESCRIPTION
Fixes #2318

### Summary

This PR introduces fluent-style setters to the HikariConfig class, allowing for a more readable and concise configuration setup. The new setters enable chaining multiple properties without repeating the variable name, enhancing the overall developer experience.

### Testing

Ran all unit tests using `./mvn test` and verified the log no longer appears.

Please review and let me know if any changes are needed.
