### PR TITLE
Fix 6.3.1 - NoSuchMethodException error that is thrown when setting a metric registry

### DIFF
--- a/src/main/java/com/zaxxer/hikari/util/UtilityElf.java
+++ b/src/main/java/com/zaxxer/hikari/util/UtilityElf.java
@@ -121,16 +121,13 @@ public final class UtilityElf
             argClasses[i] = args[i].getClass();
          }
 
-         Constructor<?>[] possibleConstructors = loaded.getConstructors();
-         Constructor<?> constructor = Arrays.stream(possibleConstructors)
-            .filter(possibleConstructor -> {
-               Class<?>[] constructorParameters = possibleConstructor.getParameterTypes();
-               if (possibleConstructor.getParameterTypes().length != totalArgs) {
-                  return false;
-               }
+         Constructor<?> constructor = Arrays.stream(loaded.getConstructors())
+            .filter(c -> {
+               if (c.getParameterCount() != totalArgs) return false;
 
+               Class<?>[] params = c.getParameterTypes();
                return IntStream.range(0, totalArgs)
-                  .allMatch(i -> constructorParameters[i].isAssignableFrom(argClasses[i]));
+                  .allMatch(i -> params[i].isAssignableFrom(argClasses[i]));
             })
             .findFirst()
             .orElseThrow(() -> new RuntimeException("No suitable constructor found"));

--- a/src/main/java/com/zaxxer/hikari/util/UtilityElf.java
+++ b/src/main/java/com/zaxxer/hikari/util/UtilityElf.java
@@ -16,9 +16,13 @@
 
 package com.zaxxer.hikari.util;
 
+import java.lang.reflect.Constructor;
+import java.util.Arrays;
 import java.util.Locale;
 import java.util.concurrent.*;
 import java.util.regex.Pattern;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import static java.lang.Thread.currentThread;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -116,7 +120,21 @@ public final class UtilityElf
          for (int i = 0; i < totalArgs; i++) {
             argClasses[i] = args[i].getClass();
          }
-         var constructor = loaded.getConstructor(argClasses);
+
+         Constructor<?>[] possibleConstructors = loaded.getConstructors();
+         Constructor<?> constructor = Arrays.stream(possibleConstructors)
+            .filter(possibleConstructor -> {
+               Class<?>[] constructorParameters = possibleConstructor.getParameterTypes();
+               if (possibleConstructor.getParameterTypes().length != totalArgs) {
+                  return false;
+               }
+
+               return IntStream.range(0, totalArgs)
+                  .allMatch(i -> constructorParameters[i].isAssignableFrom(argClasses[i]));
+            })
+            .findFirst()
+            .orElseThrow(() -> new RuntimeException("No suitable constructor found"));
+
          return clazz.cast(constructor.newInstance(args));
       }
       catch (Exception e) {

--- a/src/test/java/com/zaxxer/hikari/util/UtilityElfTest.java
+++ b/src/test/java/com/zaxxer/hikari/util/UtilityElfTest.java
@@ -52,4 +52,29 @@ public class UtilityElfTest
       //Act
       UtilityElf.getTransactionIsolation("9999");
    }
+
+   @Test
+   public void shouldCreateInstanceOfClassWithConstructorThatAcceptsSuperClassAndInterfaceAndClassOfArguments()
+   {
+      //Act
+      UtilityElf.createInstance("com.zaxxer.hikari.util.UtilityElfTest$ClassZ",
+            Object.class,
+            new ClassB(),
+            new ClassC(),
+            new ClassD());
+   }
+
+   public static class ClassA {}
+
+   public static final class ClassB extends ClassA {}
+
+   public interface InterfaceC {}
+
+   public final static class ClassC implements InterfaceC {}
+
+   public final static class ClassD {}
+
+   public final static class ClassZ {
+      public ClassZ(ClassA _superClassA, InterfaceC _interfaceC, ClassD _classD) {}
+   }
 }


### PR DESCRIPTION
Fixes the issue mentioned in https://github.com/brettwooldridge/HikariCP/issues/2339

 ### Problem
Upgrading from HikariCP 6.3.0 to 6.3.1 introduced a bug that causes `NoSuchMethodException` when users pass custom `MetricRegistry` implementations to `HikariPool.setMetricRegistry(Object metricRegistry)`.

### Root Cause
The issue occurs in `UtilityElf.createInstance(final String className, final Class<T> clazz, final Object... args)` at line 123 where the code attempts to find a constructor using the exact runtime class types of the arguments:
```
  // This gets the concrete implementation class, not the super class
  argClasses[i] = args[i].getClass();

  // This fails because CodahaleMetricsTrackerFactory expects MetricRegistry.class, not CustomMetricRegistry.class
  var constructor = loaded.getConstructor(argClasses);
```

For example, if a user passes a `CustomMetricRegistry` instance that extends `MetricRegistry`, the code looks for:
  - `CodahaleMetricsTrackerFactory(CustomMetricRegistry.class)` ❌ (doesn't exist)

  Instead of:
  - `CodahaleMetricsTrackerFactory(MetricRegistry.class)` ✅ (exists)

### Solution
Replace the exact type matching with assignability-based constructor resolution. The new implementation:

1. Iterates through all available constructors instead of looking for one specific signature
2. Uses isAssignableFrom() to check if argument types are compatible with parameter types
3. Finds the first matching constructor that can accept the provided arguments

This allows custom implementations to be properly passed to constructors that expect their parent interfaces/classes.

