### PR TITLE
Add last connection failure time diff and exception clarification to the pool timeout exception

### DIFF
--- a/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
+++ b/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
@@ -705,14 +705,17 @@ public final class HikariPool extends PoolBase implements HikariPoolMXBean, IBag
       String sqlState = null;
       int errorCode = 0;
       final var originalException = getLastConnectionFailure();
+      Long lastConnectionFailureTimestamp = getLastConnectionFailureTimestamp();
       if (originalException instanceof SQLException) {
          sqlState = ((SQLException) originalException).getSQLState();
          errorCode = ((SQLException) originalException).getErrorCode();
       }
-      final var connectionException = new SQLTransientConnectionException(
-         poolName + " - Connection is not available, request timed out after " + elapsedMillis(startTime) + "ms " +
-            "(total=" + getTotalConnections() + ", active=" + getActiveConnections() + ", idle=" + getIdleConnections() + ", waiting=" + getThreadsAwaitingConnection() + ")",
-         sqlState, errorCode, originalException);
+      String errorDescription = poolName + " - Connection is not available, request timed out after " + elapsedMillis(startTime) + "ms " +
+         "(total=" + getTotalConnections() + ", active=" + getActiveConnections() + ", idle=" + getIdleConnections() + ", waiting=" + getThreadsAwaitingConnection() + ")";
+      if (lastConnectionFailureTimestamp != null && lastConnectionFailureTimestamp != 0) {
+         errorDescription += " - The last connection failure (appended as the next exception below) occurred at: " + lastConnectionFailureTimestamp + " (Unix Time Millis)";
+      }
+      final var connectionException = new SQLTransientConnectionException(errorDescription, sqlState, errorCode, originalException);
       if (originalException instanceof SQLException) {
          connectionException.setNextException((SQLException) originalException);
       }

--- a/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
+++ b/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
@@ -713,8 +713,8 @@ public final class HikariPool extends PoolBase implements HikariPoolMXBean, IBag
       String errorDescription = poolName + " - Connection is not available, request timed out after " + elapsedMillis(startTime) + "ms " +
          "(total=" + getTotalConnections() + ", active=" + getActiveConnections() + ", idle=" + getIdleConnections() + ", waiting=" + getThreadsAwaitingConnection() + ")";
       if (lastConnectionFailureTimestamp != null && lastConnectionFailureTimestamp != 0) {
-         errorDescription += " - The last connection failure (appended as the next exception below) happened "
-            + elapsedDisplayString(lastConnectionFailureTimestamp, currentTime()) + " ago.";
+         errorDescription += " - The last connection failure (appended as the next exception below) happened " +
+            elapsedDisplayString(lastConnectionFailureTimestamp, currentTime()) + " ago.";
       }
       final var connectionException = new SQLTransientConnectionException(errorDescription, sqlState, errorCode, originalException);
       if (originalException instanceof SQLException) {

--- a/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
+++ b/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
@@ -713,7 +713,8 @@ public final class HikariPool extends PoolBase implements HikariPoolMXBean, IBag
       String errorDescription = poolName + " - Connection is not available, request timed out after " + elapsedMillis(startTime) + "ms " +
          "(total=" + getTotalConnections() + ", active=" + getActiveConnections() + ", idle=" + getIdleConnections() + ", waiting=" + getThreadsAwaitingConnection() + ")";
       if (lastConnectionFailureTimestamp != null && lastConnectionFailureTimestamp != 0) {
-         errorDescription += " - The last connection failure (appended as the next exception below) happened " + elapsedDisplayString(startTime, currentTime()) + " ago.";
+         errorDescription += " - The last connection failure (appended as the next exception below) happened "
+            + elapsedDisplayString(lastConnectionFailureTimestamp, currentTime()) + " ago.";
       }
       final var connectionException = new SQLTransientConnectionException(errorDescription, sqlState, errorCode, originalException);
       if (originalException instanceof SQLException) {

--- a/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
+++ b/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
@@ -713,7 +713,7 @@ public final class HikariPool extends PoolBase implements HikariPoolMXBean, IBag
       String errorDescription = poolName + " - Connection is not available, request timed out after " + elapsedMillis(startTime) + "ms " +
          "(total=" + getTotalConnections() + ", active=" + getActiveConnections() + ", idle=" + getIdleConnections() + ", waiting=" + getThreadsAwaitingConnection() + ")";
       if (lastConnectionFailureTimestamp != null && lastConnectionFailureTimestamp != 0) {
-         errorDescription += " - The last connection failure (appended as the next exception below) occurred at: " + lastConnectionFailureTimestamp + " (Unix Time Millis)";
+         errorDescription += " - The last connection failure (appended as the next exception below) happened " + elapsedDisplayString(startTime, currentTime()) + " ago.";
       }
       final var connectionException = new SQLTransientConnectionException(errorDescription, sqlState, errorCode, originalException);
       if (originalException instanceof SQLException) {

--- a/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
+++ b/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
@@ -62,6 +62,7 @@ abstract class PoolBase
 
    volatile String catalog;
    final AtomicReference<Throwable> lastConnectionFailure;
+   final AtomicLong lastConnectionFailureTimestamp;
    final AtomicLong connectionFailureTimestamp;
 
    long connectionTimeout;
@@ -116,6 +117,7 @@ abstract class PoolBase
       this.connectionTimeout = config.getConnectionTimeout();
       this.validationTimeout = config.getValidationTimeout();
       this.lastConnectionFailure = new AtomicReference<>();
+      this.lastConnectionFailureTimestamp = new AtomicLong();
       this.connectionFailureTimestamp = new AtomicLong();
 
       initializeDataSource();
@@ -185,6 +187,7 @@ abstract class PoolBase
       }
       catch (Exception e) {
          lastConnectionFailure.set(e);
+         lastConnectionFailureTimestamp.set(System.currentTimeMillis());
          logger.warn("{} - Failed to validate connection {} ({}). Possibly consider using a shorter maxLifetime value.",
                      poolName, connection, e.getMessage());
          return true;
@@ -194,6 +197,9 @@ abstract class PoolBase
    Throwable getLastConnectionFailure()
    {
       return lastConnectionFailure.get();
+   }
+   Long getLastConnectionFailureTimestamp(){
+      return lastConnectionFailureTimestamp.get();
    }
 
    public DataSource getUnwrappedDataSource()
@@ -378,6 +384,7 @@ abstract class PoolBase
          setupConnection(connection);
 
          lastConnectionFailure.set(null);
+         lastConnectionFailureTimestamp.set(0);
          connectionFailureTimestamp.set(0);
 
          logger.debug("{} - Established new connection ({})", poolName, id);
@@ -397,6 +404,7 @@ abstract class PoolBase
          }
 
          lastConnectionFailure.set(t);
+         lastConnectionFailureTimestamp.set(System.currentTimeMillis());
          throw t;
       }
       finally {

--- a/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
+++ b/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
@@ -198,6 +198,7 @@ abstract class PoolBase
    {
       return lastConnectionFailure.get();
    }
+
    Long getLastConnectionFailureTimestamp(){
       return lastConnectionFailureTimestamp.get();
    }

--- a/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
+++ b/src/main/java/com/zaxxer/hikari/pool/PoolBase.java
@@ -187,7 +187,7 @@ abstract class PoolBase
       }
       catch (Exception e) {
          lastConnectionFailure.set(e);
-         lastConnectionFailureTimestamp.set(System.currentTimeMillis());
+         lastConnectionFailureTimestamp.set(currentTime());
          logger.warn("{} - Failed to validate connection {} ({}). Possibly consider using a shorter maxLifetime value.",
                      poolName, connection, e.getMessage());
          return true;
@@ -405,7 +405,7 @@ abstract class PoolBase
          }
 
          lastConnectionFailure.set(t);
-         lastConnectionFailureTimestamp.set(System.currentTimeMillis());
+         lastConnectionFailureTimestamp.set(currentTime());
          throw t;
       }
       finally {


### PR DESCRIPTION
I just spent a week attempting to diagnose why my services failed to reconnect to my database after an RDS Failover for Postgres. 

What happened was the DNS cache was getting hits and misses, and I hit the race condition where the hikari pool was reaching out to the old unhealthy host after failover (but also after it has reached out to the new host once) - so my service was displaying "The database is not currently accepting connections" as the final "Caused by" in the Hikari stack-trace for connection pool timeouts for 1-2 hours after the failover had succeeded.

I didn't know that the last "Caused by" exception in the Hikari stack trace was actually the last connection failure that happened on a different thread; I thought it was actually part of the stack trace and running on the same thread - and I certainly didn't think it could be delayed by 1+ hours.

Because of this I dove down DNS rabbit holes, when the actual problem was my Postgres JDBC driver got stuck trying to log in (after the startup packet was acknowledged, but before hearing back from auth), that all could have been avoided if the exception message from Hikari was a bit more clear that the Failure shown in the stack trace might be stale and delayed.

I'm hoping that we can add the clarification that the failure happened some other time to Hikari, so some poor soul doesn't have the diagnostic issues I had. 