### PR TITLE
fix: negative numbers cannot be indexed for java arrays

### DIFF
--- a/src/main/java/com/zaxxer/hikari/util/ConcurrentBag.java
+++ b/src/main/java/com/zaxxer/hikari/util/ConcurrentBag.java
@@ -82,8 +82,8 @@ public class ConcurrentBag<T extends IConcurrentBagEntry> implements AutoCloseab
    {
       int STATE_NOT_IN_USE = 0;
       int STATE_IN_USE = 1;
-      int STATE_REMOVED = -1;
-      int STATE_RESERVED = -2;
+      int STATE_REMOVED = 2;
+      int STATE_RESERVED = 3;
 
       boolean compareAndSet(int expectState, int newState);
       void setState(int newState);

--- a/src/test/java/com/zaxxer/hikari/pool/TestConcurrentBag.java
+++ b/src/test/java/com/zaxxer/hikari/pool/TestConcurrentBag.java
@@ -19,6 +19,10 @@ package com.zaxxer.hikari.pool;
 import static com.zaxxer.hikari.pool.TestElf.getPool;
 import static com.zaxxer.hikari.pool.TestElf.newHikariConfig;
 import static com.zaxxer.hikari.pool.TestElf.setSlf4jTargetStream;
+import static com.zaxxer.hikari.util.ConcurrentBag.IConcurrentBagEntry.STATE_IN_USE;
+import static com.zaxxer.hikari.util.ConcurrentBag.IConcurrentBagEntry.STATE_NOT_IN_USE;
+import static com.zaxxer.hikari.util.ConcurrentBag.IConcurrentBagEntry.STATE_REMOVED;
+import static com.zaxxer.hikari.util.ConcurrentBag.IConcurrentBagEntry.STATE_RESERVED;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
@@ -40,6 +44,7 @@ import com.zaxxer.hikari.util.ConcurrentBag;
 /**
  *
  * @author Brett Wooldridge
+ * @author Chengang Guan
  */
 public class TestConcurrentBag
 {
@@ -112,6 +117,37 @@ public class TestConcurrentBag
          }
 
          assertNotNull(notinuse.toString());
+      }
+   }
+
+   @Test
+   public void testConcurrentBagStateCounts() throws Exception {
+      try (ConcurrentBag<PoolEntry> bag = new ConcurrentBag<>(x -> CompletableFuture.completedFuture(Boolean.TRUE))) {
+         PoolEntry inuse = pool.newPoolEntry(false);
+         bag.add(inuse);
+         bag.borrow(2, MILLISECONDS);
+
+         PoolEntry notInuse = pool.newPoolEntry(false);
+         bag.add(notInuse);
+
+         PoolEntry removed = pool.newPoolEntry(false);
+         bag.add(removed);
+         bag.reserve(removed);
+         bag.remove(removed);
+
+         PoolEntry reserved = pool.newPoolEntry(false);
+         bag.add(reserved);
+         bag.reserve(reserved);
+
+         final int SHARED_LIST_SIZE = 4;
+         final int WAITERS_COUNTS = 5;
+         int[] stateCounts = bag.getStateCounts();
+         assertEquals(1, stateCounts[STATE_NOT_IN_USE]);
+         assertEquals(1, stateCounts[STATE_IN_USE]);
+         assertEquals(0, stateCounts[STATE_REMOVED]); // no STATE_REMOVED intermediate state in a single thread
+         assertEquals(1, stateCounts[STATE_RESERVED]);
+         assertEquals(3, stateCounts[SHARED_LIST_SIZE]); // sharedList.size()
+         assertEquals(0, stateCounts[WAITERS_COUNTS]); // waiters counts
       }
    }
 }


### PR DESCRIPTION
In `ConcurrentBag. getStateCounts()`, state was directly used as the index of the array.
In the original code, there were cases where the state was negative.(`STATE_REMOVED` and `STATE_RESERVED`)
When an item is in one of these two states, `ArrayIndexOutOfBoundsException` will be thrown.
So I modified the values of these two fields and added tests.
If negative values are intentional, we may need to consider modifying the implementation of  `getStateCounts` to return a Map (if so, please let me know and I would be happy to suggest another PR to fix it).