### PR TITLE
Optimize PropertyElf

### DIFF
--- a/src/main/java/com/zaxxer/hikari/util/PropertyElf.java
+++ b/src/main/java/com/zaxxer/hikari/util/PropertyElf.java
@@ -200,7 +200,7 @@ public final class PropertyElf
 
    private static int[] parseIntArray(String value)
    {
-      if (value == null || value.isEmpty() ) {
+      if (value == null || value.isEmpty()) {
          return new int[0];
       }
 

--- a/src/main/java/com/zaxxer/hikari/util/PropertyElf.java
+++ b/src/main/java/com/zaxxer/hikari/util/PropertyElf.java
@@ -148,26 +148,29 @@ public final class PropertyElf
       try {
          var paramClass = writeMethod.getParameterTypes()[0];
          String value = propValue.toString();
-         if (paramClass == int.class) {
-            writeMethod.invoke(target, Integer.parseInt(propValue.toString()));
+         if (paramClass == int.class || paramClass == Integer.class) {
+            writeMethod.invoke(target, Integer.parseInt(value));
          }
-         else if (paramClass == long.class) {
+         else if (paramClass == long.class || paramClass == Long.class) {
             writeMethod.invoke(target, parseDuration(value).map(Duration::toMillis).orElseGet(() -> Long.parseLong(value)));
          }
-         else if (paramClass == short.class) {
+         else if (paramClass == short.class || paramClass == Short.class) {
             writeMethod.invoke(target, Short.parseShort(value));
          }
          else if (paramClass == boolean.class || paramClass == Boolean.class) {
             writeMethod.invoke(target, Boolean.parseBoolean(value));
          }
-         else if (paramClass.isArray() && char.class.isAssignableFrom(paramClass.getComponentType())) {
-            writeMethod.invoke(target, value.toCharArray());
+         else if (paramClass == char[].class) {
+            Object charArray = value.toCharArray();
+            writeMethod.invoke(target, charArray);
          }
-         else if (paramClass.isArray() && int.class.isAssignableFrom(paramClass.getComponentType())) {
-            writeMethod.invoke(target, parseIntArray(value));
+         else if (paramClass == int[].class) {
+            Object intArray = parseIntArray(value);
+            writeMethod.invoke(target, intArray);
          }
-         else if (paramClass.isArray() && String.class.isAssignableFrom(paramClass.getComponentType())) {
-            writeMethod.invoke(target, new Object[]{parseStringArray(value)});
+         else if (paramClass == String[].class) {
+            Object stringArray = parseStringArray(value);
+            writeMethod.invoke(target, stringArray);
          }
          else if (paramClass == String.class) {
             writeMethod.invoke(target, value);
@@ -175,7 +178,7 @@ public final class PropertyElf
          else {
             try {
                logger.debug("Try to create a new instance of \"{}\"", propValue);
-               writeMethod.invoke(target, Class.forName(propValue.toString()).getDeclaredConstructor().newInstance());
+               writeMethod.invoke(target, Class.forName(value).getDeclaredConstructor().newInstance());
             }
             catch (InstantiationException | ClassNotFoundException e) {
                logger.debug("Class \"{}\" not found or could not instantiate it (Default constructor)", propValue);

--- a/src/test/java/com/zaxxer/hikari/mocks/TestObject.java
+++ b/src/test/java/com/zaxxer/hikari/mocks/TestObject.java
@@ -1,10 +1,18 @@
 package com.zaxxer.hikari.mocks;
 
+@SuppressWarnings("unused")
 public class TestObject
 {
    private TestObject testObject;
    private String string;
    private short shortRaw;
+   private Short shortObj;
+   private int intRaw;
+   private Integer intObj;
+   private long longRaw;
+   private Long longObj;
+   private boolean boolRaw;
+   private Boolean boolObj;
    private char[] charArray;
    private String[] stringArray;
    private int[] intArray;
@@ -35,6 +43,62 @@ public class TestObject
 
    public void setShortRaw(short shortRaw) {
       this.shortRaw = shortRaw;
+   }
+
+   public Short getShortObj() {
+      return shortObj;
+   }
+
+   public void setShortObj(Short shortObj) {
+      this.shortObj = shortObj;
+   }
+
+   public int getIntRaw() {
+      return intRaw;
+   }
+
+   public void setIntRaw(int intRaw) {
+      this.intRaw = intRaw;
+   }
+
+   public Integer getIntObj() {
+      return intObj;
+   }
+
+   public void setIntObj(Integer intObj) {
+      this.intObj = intObj;
+   }
+
+   public long getLongRaw() {
+      return longRaw;
+   }
+
+   public void setLongRaw(long longRaw) {
+      this.longRaw = longRaw;
+   }
+
+   public Long getLongObj() {
+      return longObj;
+   }
+
+   public void setLongObj(Long longObj) {
+      this.longObj = longObj;
+   }
+
+   public boolean getBoolRaw() {
+      return boolRaw;
+   }
+
+   public void setBoolRaw(boolean boolRaw) {
+      this.boolRaw = boolRaw;
+   }
+
+   public Boolean getBoolObj() {
+      return boolObj;
+   }
+
+   public void setBoolObj(Boolean boolObj) {
+      this.boolObj = boolObj;
    }
 
    public void setCharArray(char[] charArray)

--- a/src/test/java/com/zaxxer/hikari/util/PropertyElfTest.java
+++ b/src/test/java/com/zaxxer/hikari/util/PropertyElfTest.java
@@ -33,13 +33,10 @@ public class PropertyElfTest
       properties.setProperty("string", "aString");
       properties.setProperty("testObject", "it is not a class");
       TestObject testObject = new TestObject();
-      try {
-         PropertyElf.setTargetFromProperties(testObject, properties);
-         fail("Could never come here");
-      }
-      catch (RuntimeException e) {
-         assertEquals("argument type mismatch", e.getCause().getMessage());
-      }
+
+      RuntimeException e =
+         assertThrows(RuntimeException.class, () -> PropertyElf.setTargetFromProperties(testObject, properties));
+      assertEquals("argument type mismatch", e.getCause().getMessage());
    }
 
    @Test

--- a/src/test/java/com/zaxxer/hikari/util/PropertyElfTest.java
+++ b/src/test/java/com/zaxxer/hikari/util/PropertyElfTest.java
@@ -86,4 +86,31 @@ public class PropertyElfTest
       PropertyElf.setTargetFromProperties(testObject, properties);
       assertArrayEquals(new int[] {}, testObject.getIntArray());
    }
+
+   @Test
+   public void shouldHandlePrimitiveTypeBoxing () throws Exception
+   {
+      Properties properties = new Properties();
+      TestObject testObject = new TestObject();
+
+      properties.setProperty("shortRaw", "1");
+      properties.setProperty("shortObj", "1");
+      properties.setProperty("intRaw", "2");
+      properties.setProperty("intObj", "2");
+      properties.setProperty("longRaw", "3");
+      properties.setProperty("longObj", "3");
+      properties.setProperty("boolRaw", "true");
+      properties.setProperty("boolObj", "false");
+
+      PropertyElf.setTargetFromProperties(testObject, properties);
+
+      assertEquals((short) 1, testObject.getShortRaw());
+      assertEquals(Short.valueOf("1"), testObject.getShortObj());
+      assertEquals(2, testObject.getIntRaw());
+      assertEquals(Integer.valueOf(2), testObject.getIntObj());
+      assertEquals(3L, testObject.getLongRaw());
+      assertEquals(Long.valueOf(3L), testObject.getLongObj());
+      assertTrue(testObject.getBoolRaw()); // equivalent to assertEquals(true, testObject.getBoolRaw());
+      assertEquals(Boolean.FALSE, testObject.getBoolObj());
+   }
 }


### PR DESCRIPTION
1.support properties of boxing types
Java automatically performs boxing and unboxing for primitive types, so I believe we should adhere to this feature as well.

2.avoid unnecessary array checks and isAssignableFrom checks
Primitive types, along with their array types and String (which is modified by final), cannot have subclasses. Therefore, the original `isArray` and `isAssignableFrom` checks are meaningless, and we can use `==` directly (This makes the semantics clearer and can lead to some performance improvements).

3.avoid ambiguity when using writeMethod.invoke(Object obj, Object... args)
