### PR TITLE
chore: Log reason when soft evicting a connection that is busy

### DIFF
--- a/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
+++ b/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
@@ -629,6 +629,8 @@ public final class HikariPool extends PoolBase implements HikariPoolMXBean, IBag
       if (owner || connectionBag.reserve(poolEntry)) {
          closeConnection(poolEntry, reason);
          return true;
+      } else {
+         logger.debug("{} - Connection is busy, but marking for eviction {}: {}", poolName, poolEntry.connection, reason);
       }
 
       return false;


### PR DESCRIPTION
**What**
Logs a message when a soft eviction is attempted, but cannot be completed immediately because the connection is busy.

**Why**
In attempting to debug an issue where our connections are being unexpectedly evicted from the pool, I have seen log messages like this:
```
[thread:HikariPool-1:connection-closer] HikariPool-1 - Closing connection org.postgresql.jdbc.PgConnection@5f4f7948: (connection was evicted)
```

However, the "connection was evicted" message doesn't really describe _why_ the connection is being evicted.

I've traced through the code and observed that the path which leads to this is:
1. _something_ calls `#softEvictConnection`, with a `reason`
2. the connection is marked for eviction
3. because the initiator is not the owner of the connection and the connection is in use, it does _not_ call `closeConnection` with that `reason`

The result is that the connection-closer eventually closes the connection. But in the process, the `reason` passed into `softEvictConnection` is dropped, and there is no way to what the true `reason` was from the logs. The "connection was evicted" message is only a default and does not actually come from the initiator.

Having this reason logged would be particularly helpful for debugging why connections are evicted from the pool.
