### PR TITLE
fix: change incorrect default value in keepaliveTime Javadoc comments

### DIFF
--- a/src/main/java/com/zaxxer/hikari/HikariConfig.java
+++ b/src/main/java/com/zaxxer/hikari/HikariConfig.java
@@ -742,7 +742,7 @@ public class HikariConfig implements HikariConfigMXBean
     * This property controls the keepalive interval for a connection in the pool. An in-use connection will never be
     * tested by the keepalive thread, only when it is idle will it be tested.
     *
-    * @return the interval in which connections will be tested for aliveness, thus keeping them alive by the act of checking. Value is in milliseconds, default is 0 (disabled).
+    * @return the interval in which connections will be tested for aliveness, thus keeping them alive by the act of checking. Value is in milliseconds, default is 120000 (2 minutes).
     */
    public long getKeepaliveTime() {
       return keepaliveTime;
@@ -752,7 +752,7 @@ public class HikariConfig implements HikariConfigMXBean
     * This property controls the keepalive interval for a connection in the pool. An in-use connection will never be
     * tested by the keepalive thread, only when it is idle will it be tested.
     *
-    * @param keepaliveTimeMs the interval in which connections will be tested for aliveness, thus keeping them alive by the act of checking. Value is in milliseconds, default is 0 (disabled).
+    * @param keepaliveTimeMs the interval in which connections will be tested for aliveness, thus keeping them alive by the act of checking. Value is in milliseconds, default is 120000 (2 minutes).
     */
    public void setKeepaliveTime(long keepaliveTimeMs) {
       this.keepaliveTime = keepaliveTimeMs;


### PR DESCRIPTION
## Summary                                                                                                                                                                                                          

- Fix incorrect Javadoc comments for `keepaliveTime` in `HikariConfig`
- The documentation stated the default value was `0 (disabled)`, but the actual default is `120000ms (2 minutes)` as defined by `DEFAULT_KEEPALIVE_TIME`                                                            
                                                                                                                                                                                                                      
## Changes                                                                                                                                                                                                          
- Updated `@return` Javadoc of `getKeepaliveTime()`                                                                                                                                                                 
- Updated `@param` Javadoc of `setKeepaliveTime()`                                                                                                                                                                  
                                                                                                                                                                                                                      
## Details
In `HikariConfig.java`, the default value for `keepaliveTime` is set to `MINUTES.toMillis(2)` (120000ms) via the `DEFAULT_KEEPALIVE_TIME` constant, but the Javadoc for both `getKeepaliveTime()` and `setKeepaliveTime()` incorrectly documented it as `default is 0 (disabled)`.