### PR TITLE
SNAP-15150 Added JVM flag to control rollback of dirty commits

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 
    <groupId>com.zaxxer</groupId>
    <artifactId>HikariCP</artifactId>
-   <version>5.0.2-SNAPSHOT</version>
+   <version>5.1.0-SNAPSHOT</version>
    <packaging>bundle</packaging>
 
    <name>HikariCP</name>

--- a/src/main/java/com/zaxxer/hikari/pool/ProxyConnection.java
+++ b/src/main/java/com/zaxxer/hikari/pool/ProxyConnection.java
@@ -46,6 +46,7 @@ public abstract class ProxyConnection implements Connection
    private static final Logger LOGGER;
    private static final Set<String> ERROR_STATES;
    private static final Set<Integer> ERROR_CODES;
+   private static final boolean ROLLBACK_ON_AUTOCOMMIT_FALSE;
 
    @SuppressWarnings("WeakerAccess")
    protected Connection delegate;
@@ -80,6 +81,9 @@ public abstract class ProxyConnection implements Connection
       ERROR_CODES = new HashSet<>();
       ERROR_CODES.add(500150);
       ERROR_CODES.add(2399);
+
+      ROLLBACK_ON_AUTOCOMMIT_FALSE =
+         Boolean.parseBoolean(System.getProperty("snaplogic.transaction.control.disabled", "true"));
    }
 
    protected ProxyConnection(final PoolEntry poolEntry,
@@ -245,7 +249,7 @@ public abstract class ProxyConnection implements Connection
          leakTask.cancel();
 
          try {
-            if (isCommitStateDirty && !isAutoCommit) {
+            if (isCommitStateDirty && !isAutoCommit && ROLLBACK_ON_AUTOCOMMIT_FALSE) {
                delegate.rollback();
                LOGGER.debug("{} - Executed rollback on connection {} due to dirty commit state on close().", poolEntry.getPoolName(), delegate);
             }


### PR DESCRIPTION
Added JVM system property to control rollback behavior on connection close
Updated version from 5.0.2-SNAPSHOT to 5.1.0-SNAPSHOT
Implemented snaplogic.transaction.control.disabled flag (defaults to true)
The rollback behavior now checks three conditions:

isCommitStateDirty - connection has uncommitted changes
!isAutoCommit - auto-commit is disabled
ROLLBACK_ON_AUTOCOMMIT_FALSE - new configurable flag (defaults to true for backward compatibility