### PR TITLE
Fix addConnectionExecutor silent discard and SPOF (#2161, #2378)

### DIFF
--- a/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
+++ b/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
@@ -33,6 +33,7 @@ import java.sql.SQLException;
 import java.sql.SQLTransientConnectionException;
 import java.util.Optional;
 import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
 import static com.zaxxer.hikari.util.ClockSource.*;
@@ -71,6 +72,7 @@ public final class HikariPool extends PoolBase implements HikariPoolMXBean, IBag
    private final PoolEntryCreator postFillPoolEntryCreator = new PoolEntryCreator("After adding ");
    private final ThreadPoolExecutor addConnectionExecutor;
    private final ThreadPoolExecutor closeConnectionExecutor;
+   private final AtomicInteger pendingConnectionAdds = new AtomicInteger(0);
 
    private final ConcurrentBag<PoolEntry> connectionBag;
 
@@ -110,7 +112,7 @@ public final class HikariPool extends PoolBase implements HikariPoolMXBean, IBag
       ThreadFactory threadFactory = config.getThreadFactory();
 
       final int maxPoolSize = config.getMaximumPoolSize();
-      this.addConnectionExecutor = createThreadPoolExecutor(maxPoolSize, poolName + ":connection-adder", threadFactory, new CustomDiscardPolicy());
+      this.addConnectionExecutor = createThreadPoolExecutor(maxPoolSize, poolName + ":connection-adder", threadFactory, new CounterAwareDiscardPolicy(pendingConnectionAdds, poolName));
       this.closeConnectionExecutor = createThreadPoolExecutor(maxPoolSize, poolName + ":connection-closer", threadFactory, new ThreadPoolExecutor.CallerRunsPolicy());
 
       this.leakTaskFactory = new ProxyLeakTaskFactory(config.getLeakDetectionThreshold(), houseKeepingExecutorService);
@@ -340,8 +342,8 @@ public final class HikariPool extends PoolBase implements HikariPoolMXBean, IBag
    @Override
    public void addBagItem(final int waiting)
    {
-      if (waiting > addConnectionExecutor.getQueue().size())
-         addConnectionExecutor.submit(poolEntryCreator);
+      if (waiting > pendingConnectionAdds.get())
+         submitConnectionAdder(poolEntryCreator);
    }
 
    // ***********************************************************************
@@ -530,11 +532,24 @@ public final class HikariPool extends PoolBase implements HikariPoolMXBean, IBag
       if (shouldAdd) {
          final var countToAdd = config.getMinimumIdle() - idle;
          for (int i = 0; i < countToAdd; i++)
-            addConnectionExecutor.submit(isAfterAdd ? postFillPoolEntryCreator : poolEntryCreator);
+            submitConnectionAdder(isAfterAdd ? postFillPoolEntryCreator : poolEntryCreator);
       }
       else if (isAfterAdd) {
          logger.debug("{} - Fill pool skipped, pool has sufficient level or currently being filled.", poolName);
       }
+   }
+
+   private void submitConnectionAdder(final Callable<Boolean> creator)
+   {
+      pendingConnectionAdds.incrementAndGet();
+      addConnectionExecutor.submit(() -> {
+         try {
+            return creator.call();
+         }
+         finally {
+            pendingConnectionAdds.decrementAndGet();
+         }
+      });
    }
 
    /**

--- a/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
+++ b/src/main/java/com/zaxxer/hikari/pool/HikariPool.java
@@ -113,6 +113,8 @@ public final class HikariPool extends PoolBase implements HikariPoolMXBean, IBag
 
       final int maxPoolSize = config.getMaximumPoolSize();
       this.addConnectionExecutor = createThreadPoolExecutor(maxPoolSize, poolName + ":connection-adder", threadFactory, new CounterAwareDiscardPolicy(pendingConnectionAdds, poolName));
+      this.addConnectionExecutor.setMaximumPoolSize(2);
+      this.addConnectionExecutor.setCorePoolSize(2);
       this.closeConnectionExecutor = createThreadPoolExecutor(maxPoolSize, poolName + ":connection-closer", threadFactory, new ThreadPoolExecutor.CallerRunsPolicy());
 
       this.leakTaskFactory = new ProxyLeakTaskFactory(config.getLeakDetectionThreshold(), houseKeepingExecutorService);
@@ -128,8 +130,8 @@ public final class HikariPool extends PoolBase implements HikariPoolMXBean, IBag
             quietlySleep(MILLISECONDS.toMillis(100));
          }
 
-         addConnectionExecutor.setCorePoolSize(1);
-         addConnectionExecutor.setMaximumPoolSize(1);
+         addConnectionExecutor.setCorePoolSize(2);
+         addConnectionExecutor.setMaximumPoolSize(2);
       }
    }
 

--- a/src/main/java/com/zaxxer/hikari/util/UtilityElf.java
+++ b/src/main/java/com/zaxxer/hikari/util/UtilityElf.java
@@ -23,6 +23,7 @@ import java.lang.reflect.Constructor;
 import java.util.Arrays;
 import java.util.Locale;
 import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Pattern;
 import java.util.stream.IntStream;
 
@@ -239,6 +240,31 @@ public final class UtilityElf
    {
       @Override
       public void rejectedExecution(Runnable r, ThreadPoolExecutor executor) {
+      }
+   }
+
+   /**
+    * RejectedExecutionHandler that decrements a counter and logs a warning when a task is rejected.
+    * Used by addConnectionExecutor to keep pendingConnectionAdds accurate on discard.
+    *
+    * @hidden
+    */
+   public static class CounterAwareDiscardPolicy implements RejectedExecutionHandler
+   {
+      private static final Logger LOGGER = LoggerFactory.getLogger(CounterAwareDiscardPolicy.class);
+
+      private final AtomicInteger counter;
+      private final String poolName;
+
+      public CounterAwareDiscardPolicy(final AtomicInteger counter, final String poolName) {
+         this.counter = counter;
+         this.poolName = poolName;
+      }
+
+      @Override
+      public void rejectedExecution(Runnable r, ThreadPoolExecutor executor) {
+         counter.decrementAndGet();
+         LOGGER.warn("{} - Connection adder task rejected (queue full, size={})", poolName, executor.getQueue().size());
       }
    }
 


### PR DESCRIPTION
Fixes #2161, #2378

**Root cause:** `addConnectionExecutor` uses `CustomDiscardPolicy` (silent drop) with a single worker thread. Two compounding bugs:

- `addBagItem()` guard (`waiting > queue.size()`) is non-atomic — concurrent threads pass simultaneously and flood the queue, triggering silent discards (#2378)
- Single worker stuck in JDBC handshake permanently kills pool growth capacity (#2161)

**Fix:**
- Replace `queue.size()` race with `AtomicInteger pendingConnectionAdds`; swap `CustomDiscardPolicy` → `CounterAwareDiscardPolicy` (logs WARN on discard)
- Increase `addConnectionExecutor` workers from 1 → 2 to eliminate single point of failure