### PR TITLE
Avoid virtual-thread yield spin in ConcurrentBag

### DIFF
--- a/src/main/java/com/zaxxer/hikari/util/ConcurrentBag.java
+++ b/src/main/java/com/zaxxer/hikari/util/ConcurrentBag.java
@@ -19,6 +19,9 @@ import com.zaxxer.hikari.util.ConcurrentBag.IConcurrentBagEntry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -61,6 +64,7 @@ import static java.util.concurrent.locks.LockSupport.parkNanos;
 public class ConcurrentBag<T extends IConcurrentBagEntry> implements AutoCloseable
 {
    private static final Logger LOGGER = LoggerFactory.getLogger(ConcurrentBag.class);
+   private static final MethodHandle THREAD_IS_VIRTUAL = resolveThreadIsVirtual();
 
    private final CopyOnWriteArrayList<T> sharedList;
    private final boolean useWeakThreadLocals;
@@ -71,6 +75,31 @@ public class ConcurrentBag<T extends IConcurrentBagEntry> implements AutoCloseab
    private volatile boolean closed;
 
    private final SynchronousQueue<T> handoffQueue;
+
+   private static MethodHandle resolveThreadIsVirtual()
+   {
+      try {
+         return MethodHandles.publicLookup()
+            .findVirtual(Thread.class, "isVirtual", MethodType.methodType(boolean.class));
+      }
+      catch (NoSuchMethodException | IllegalAccessException e) {
+         return null;
+      }
+   }
+
+   static boolean isCurrentThreadVirtual()
+   {
+      if (THREAD_IS_VIRTUAL == null) {
+         return false;
+      }
+
+      try {
+         return (boolean) THREAD_IS_VIRTUAL.invokeExact(Thread.currentThread());
+      }
+      catch (Throwable t) {
+         return false;
+      }
+   }
 
    /**
     * This interface defines the contract for an entry in the ConcurrentBag.
@@ -188,11 +217,12 @@ public class ConcurrentBag<T extends IConcurrentBagEntry> implements AutoCloseab
    {
       bagEntry.setState(STATE_NOT_IN_USE);
 
+      final var isVirtualThread = isCurrentThreadVirtual();
       for (int i = 1, waiting = waiters.get(); waiting > 0; i++, waiting = waiters.get()) {
          if (bagEntry.getState() != STATE_NOT_IN_USE || handoffQueue.offer(bagEntry)) {
             return;
          }
-         else if ((i & 0xff) == 0xff || (waiting > 1 && i % waiting == 0)) {
+         else if (isVirtualThread || (i & 0xff) == 0xff || (waiting > 1 && i % waiting == 0)) {
             parkNanos(MICROSECONDS.toNanos(10));
          }
          else {
@@ -319,11 +349,12 @@ public class ConcurrentBag<T extends IConcurrentBagEntry> implements AutoCloseab
    {
       if (bagEntry.compareAndSet(STATE_RESERVED, STATE_NOT_IN_USE)) {
          // spin until a thread takes it or none are waiting
+         final var isVirtualThread = isCurrentThreadVirtual();
          for (int i = 1, waiting = waiters.get(); waiting > 0; i++, waiting = waiters.get()) {
             if (bagEntry.getState() != STATE_NOT_IN_USE || handoffQueue.offer(bagEntry)) {
                return;
             }
-            else if ((i & 0xff) == 0xff || (waiting > 1 && i % waiting == 0)) {
+            else if (isVirtualThread || (i & 0xff) == 0xff || (waiting > 1 && i % waiting == 0)) {
                parkNanos(MICROSECONDS.toNanos(10));
             }
             else {

--- a/src/test/java/com/zaxxer/hikari/util/ConcurrentBagVirtualThreadTest.java
+++ b/src/test/java/com/zaxxer/hikari/util/ConcurrentBagVirtualThreadTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2026 Brett Wooldridge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.zaxxer.hikari.util;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.Test;
+
+public class ConcurrentBagVirtualThreadTest
+{
+   @Test
+   public void detectsCurrentVirtualThread() throws Exception
+   {
+      assertFalse(ConcurrentBag.isCurrentThreadVirtual());
+
+      final var ofVirtual = virtualThreadBuilderFactory();
+      assumeTrue(ofVirtual != null);
+
+      final var virtualThreadBuilder = ofVirtual.invoke(null);
+      final var start = Class.forName("java.lang.Thread$Builder$OfVirtual").getMethod("start", Runnable.class);
+      final var detected = new AtomicBoolean();
+
+      final var virtualThread = (Thread) start.invoke(virtualThreadBuilder,
+         (Runnable) () -> detected.set(ConcurrentBag.isCurrentThreadVirtual()));
+      virtualThread.join();
+
+      assertTrue(detected.get());
+   }
+
+   private static Method virtualThreadBuilderFactory()
+   {
+      try {
+         return Thread.class.getMethod("ofVirtual");
+      }
+      catch (NoSuchMethodException e) {
+         return null;
+      }
+   }
+}


### PR DESCRIPTION
Fixes #2398.

This keeps the existing `Thread.yield()` spin behavior for platform threads, but avoids it when the returning/unreserving thread is virtual. In that case the handoff loops use the existing short `parkNanos(10us)` path instead.

Because HikariCP still targets Java 11, the virtual-thread check is resolved once through a cached `Thread.isVirtual` method handle. On Java 11 through 18 it resolves to `false`; on Java 19+ it detects virtual threads without requiring a higher source/target level.

Verification:

- JDK 21.0.11: `mvn -Djacoco.skip=true -Dtest=TestConcurrentBag,ConcurrentBagVirtualThreadTest test`
- JDK 25.0.3: `mvn -Djacoco.skip=true -Dtest=TestConcurrentBag,ConcurrentBagVirtualThreadTest test`

I also reran the local virtual-thread load harness on JDK 25.0.3, with 2,000 virtual workers contending for 50 bag entries for 20 seconds:

- `HikariCP-7.0.2`: 133,420,285 borrows / 20.032s, about 6.66M/s
- this branch: 232,862,540 borrows / 20.018s, about 11.63M/s

Earlier JDK 21 JFR/load data from the issue discussion showed the same direction: the patch removed the `Thread.yield` samples from this path and improved throughput in the Hikari-only virtual-thread load test, while the existing platform-thread JMH benchmarks stayed within noise.
