### PR TITLE
Fail fast for closed pool health checks

### DIFF
--- a/src/main/java/com/zaxxer/hikari/metrics/dropwizard/CodahaleHealthChecker.java
+++ b/src/main/java/com/zaxxer/hikari/metrics/dropwizard/CodahaleHealthChecker.java
@@ -93,6 +93,10 @@ public final class CodahaleHealthChecker
       @Override
       protected Result check() throws Exception
       {
+         if (pool.poolState == HikariPool.POOL_SHUTDOWN) {
+            return Result.unhealthy("Pool is shutdown");
+         }
+
          try (Connection connection = pool.getConnection(checkTimeoutMs)) {
             return Result.healthy();
          }

--- a/src/test/java/com/zaxxer/hikari/pool/CodahaleMetricsTest.java
+++ b/src/test/java/com/zaxxer/hikari/pool/CodahaleMetricsTest.java
@@ -39,6 +39,7 @@ import static com.zaxxer.hikari.pool.TestElf.newHikariConfig;
 import static com.zaxxer.hikari.pool.TestElf.newHikariDataSource;
 import static com.zaxxer.hikari.util.UtilityElf.quietlySleep;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeFalse;
@@ -95,6 +96,29 @@ public class CodahaleMetricsTest extends TestMetricsBase<MetricRegistry>
          HealthCheck.Result slaResult = healthChecks.get("testHealthChecks.pool.Connection99Percent");
          assertTrue(slaResult.isHealthy());
       }
+   }
+
+   @Test
+   public void testConnectivityHealthCheckFailsFastAfterShutdown()
+   {
+      HealthCheckRegistry healthRegistry = new HealthCheckRegistry();
+
+      HikariConfig config = newHikariConfig();
+      config.setMaximumPoolSize(1);
+      config.setMinimumIdle(0);
+      config.setHealthCheckRegistry(healthRegistry);
+      config.setDataSourceClassName("com.zaxxer.hikari.mocks.StubDataSource");
+      config.addHealthCheckProperty("connectivityCheckTimeoutMs", "750");
+
+      HikariDataSource ds = new HikariDataSource(config);
+      ds.close();
+
+      final var start = System.nanoTime();
+      final var result = healthRegistry.runHealthCheck("testConnectivityHealthCheckFailsFastAfterShutdown.pool.ConnectivityCheck");
+      final var elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
+
+      assertFalse(result.isHealthy());
+      assertTrue("Health check waited " + elapsedMs + "ms after shutdown", elapsedMs < 250);
    }
 
    @Test


### PR DESCRIPTION
Fixes #2325.

The Dropwizard connectivity health check keeps a direct `HikariPool` reference. After `HikariDataSource.close()`, calling the health check still went through `pool.getConnection(checkTimeoutMs)`, so it waited for the configured health-check timeout even though the pool was already shut down and could never provide a connection.

This change makes `ConnectivityHealthCheck` return an unhealthy result immediately when the pool is already shut down.

Reproduction before the fix:

- `CodahaleMetricsTest#testConnectivityHealthCheckFailsFastAfterShutdown` waited 765ms with `connectivityCheckTimeoutMs=750`.

Verification after the fix:

- JDK 21.0.11: `mvn -Djacoco.skip=true -Dtest=CodahaleMetricsTest test`
- JDK 25.0.3: `mvn -Djacoco.skip=true -Dtest=CodahaleMetricsTest test`
