### PR TITLE
Fix setCredentialsProviderClassName storing the value in the wrong field

### DIFF
--- a/src/main/java/com/zaxxer/hikari/HikariConfig.java
+++ b/src/main/java/com/zaxxer/hikari/HikariConfig.java
@@ -890,7 +890,7 @@ public class HikariConfig implements HikariConfigMXBean
 
       try {
          this.credentialsProvider = createInstance(credentialsProviderClassName, HikariCredentialsProvider.class);
-         this.exceptionOverrideClassName = credentialsProviderClassName;
+         this.credentialsProviderClassName = credentialsProviderClassName;
       }
       catch (Exception e) {
          throw new RuntimeException("Failed to instantiate class " + credentialsProviderClassName, e);

--- a/src/test/java/com/zaxxer/hikari/HikariConfigTest.java
+++ b/src/test/java/com/zaxxer/hikari/HikariConfigTest.java
@@ -99,4 +99,18 @@ public class HikariConfigTest {
          return log;
       }
    }
+
+   @Test
+   public void testSetCredentialsProviderClassNameSetsItsOwnField() {
+      HikariConfig config = new HikariConfig();
+      String providerClass = "com.zaxxer.hikari.pool.TestCredentials$TestCredentialsProvider";
+
+      config.setCredentialsProviderClassName(providerClass);
+
+      // the setter must record the credentials-provider class name
+      assertEquals(providerClass, config.getCredentialsProviderClassName());
+      // ...and must NOT overwrite the unrelated SQLExceptionOverride class name
+      assertNull(config.getExceptionOverrideClassName());
+   }
+
 }


### PR DESCRIPTION
`HikariConfig.setCredentialsProviderClassName(String)` assigns the class name to the `exceptionOverrideClassName` field instead of `credentialsProviderClassName`:

```java
this.credentialsProvider = createInstance(credentialsProviderClassName, HikariCredentialsProvider.class);
this.exceptionOverrideClassName = credentialsProviderClassName;
```

Two consequences:

- `getCredentialsProviderClassName()` always returns `null`, because the field is never assigned.
- The unrelated `exceptionOverrideClassName` (a `SQLExceptionOverride` class name) is silently overwritten, so HikariCP later tries to load the credentials-provider class as a `SQLExceptionOverride`.

This assigns the correct field, mirroring `setExceptionOverrideClassName()`. Includes a regression test.
