### PR TITLE
Avoid NegativeArraySizeException in ProxyLeakTask on short stack traces

### DIFF
--- a/src/main/java/com/zaxxer/hikari/pool/ProxyLeakTask.java
+++ b/src/main/java/com/zaxxer/hikari/pool/ProxyLeakTask.java
@@ -77,9 +77,11 @@ class ProxyLeakTask implements Runnable
       isLeaked = true;
 
       final var stackTrace = exception.getStackTrace();
-      final var trace = new StackTraceElement[stackTrace.length - 5];
+      final var trace = new StackTraceElement[Math.max(0, stackTrace.length - 5)];
 
-      System.arraycopy(stackTrace, 5, trace, 0, trace.length);
+      if (trace.length > 0) {
+         System.arraycopy(stackTrace, 5, trace, 0, trace.length);
+      }
 
       exception.setStackTrace(trace);
       LOGGER.warn("Connection leak detection triggered for {} on thread {}, stack trace follows", connectionName, threadName, exception);

--- a/src/test/java/com/zaxxer/hikari/pool/ProxyLeakTaskTest.java
+++ b/src/test/java/com/zaxxer/hikari/pool/ProxyLeakTaskTest.java
@@ -1,0 +1,39 @@
+package com.zaxxer.hikari.pool;
+
+import org.junit.Test;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+
+/**
+ * Tests for {@link ProxyLeakTask}.
+ */
+public class ProxyLeakTaskTest
+{
+   @Test
+   public void runDoesNotThrowWhenStackTraceHasFewerThanFiveFrames() throws Exception
+   {
+      final Exception shortStack = new Exception();
+      shortStack.setStackTrace(new StackTraceElement[] {
+         new StackTraceElement("Foo", "a", "Foo.java", 1),
+         new StackTraceElement("Foo", "b", "Foo.java", 2)
+      });
+
+      final Constructor<ProxyLeakTask> ctor = ProxyLeakTask.class.getDeclaredConstructor();
+      ctor.setAccessible(true);
+      final ProxyLeakTask task = ctor.newInstance();
+      set(task, "exception", shortStack);
+      set(task, "threadName", "test-thread");
+      set(task, "connectionName", "test-connection");
+
+      // run() trims the first 5 (HikariCP-internal) frames; with fewer than 5 it must not throw.
+      task.run();
+   }
+
+   private static void set(final Object target, final String field, final Object value) throws Exception
+   {
+      final Field f = ProxyLeakTask.class.getDeclaredField(field);
+      f.setAccessible(true);
+      f.set(target, value);
+   }
+}


### PR DESCRIPTION
`ProxyLeakTask.run()` trims the first 5 (HikariCP-internal) frames from the captured stack trace:

```java
final var trace = new StackTraceElement[stackTrace.length - 5];
System.arraycopy(stackTrace, 5, trace, 0, trace.length);
```

When the leak-detection exception has fewer than 5 frames (for example when stack traces are disabled via `-XX:-StackTraceInThrowable`, or in minimal stacks), `stackTrace.length - 5` is negative and the scheduled leak-detection task throws `NegativeArraySizeException` instead of logging the leak warning.

This clamps the trimmed length to zero (and skips the copy when empty). Includes a regression test.
