### PR TITLE
Avoid ArrayIndexOutOfBoundsException in ConcurrentBag.getStateCounts() for reserved/removed entries

### DIFF
--- a/src/main/java/com/zaxxer/hikari/util/ConcurrentBag.java
+++ b/src/main/java/com/zaxxer/hikari/util/ConcurrentBag.java
@@ -399,7 +399,10 @@ public class ConcurrentBag<T extends IConcurrentBagEntry> implements AutoCloseab
    {
       final var states = new int[6];
       for (var e : sharedList) {
-         ++states[e.getState()];
+         final var state = e.getState();
+         if (state >= 0) {
+            ++states[state];
+         }
       }
       states[4] = sharedList.size();
       states[5] = waiters.get();

--- a/src/test/java/com/zaxxer/hikari/pool/TestConcurrentBag.java
+++ b/src/test/java/com/zaxxer/hikari/pool/TestConcurrentBag.java
@@ -114,4 +114,19 @@ public class TestConcurrentBag
          assertNotNull(notinuse.toString());
       }
    }
+
+   @Test
+   public void testGetStateCountsWithReservedEntry() throws Exception
+   {
+      try (ConcurrentBag<PoolEntry> bag = new ConcurrentBag<>(x -> CompletableFuture.completedFuture(Boolean.TRUE))) {
+         PoolEntry entry = pool.newPoolEntry(false);
+         bag.add(entry);
+         assertTrue(bag.reserve(entry)); // STATE_RESERVED, still in the shared list
+
+         // getStateCounts() iterates the shared list; a reserved (or transiently removed) entry has a
+         // negative state and must not crash the diagnostic with an ArrayIndexOutOfBoundsException.
+         int[] counts = bag.getStateCounts();
+         assertEquals(6, counts.length);
+      }
+   }
 }


### PR DESCRIPTION
`ConcurrentBag.getStateCounts()` increments `states[e.getState()]` for every entry in the shared list:

```java
for (var e : sharedList) {
   ++states[e.getState()];
}
```

An entry state can be `STATE_RESERVED` (-2) or `STATE_REMOVED` (-1), both reachable through the public API (`reserve()` is public; `remove()` sets `STATE_REMOVED` before unlinking the entry). A negative state is a negative array index, so the call throws `ArrayIndexOutOfBoundsException`:

```java
ConcurrentBag<PoolEntry> bag = ...;
bag.add(entry);
bag.reserve(entry);        // STATE_RESERVED
bag.getStateCounts();      // ArrayIndexOutOfBoundsException: Index -2 out of bounds for length 6
```

This skips negative (transient) states, which have no slot in the counts array (it reports `NOT_IN_USE`/`IN_USE`). Includes a regression test.
