### PR TITLE
Handle null from delegate.getGeneratedKeys() in ProxyStatement, matching getResultSet

### DIFF
--- a/src/main/java/com/zaxxer/hikari/pool/ProxyStatement.java
+++ b/src/main/java/com/zaxxer/hikari/pool/ProxyStatement.java
@@ -228,8 +228,13 @@ public abstract class ProxyStatement implements Statement
    public ResultSet getGeneratedKeys() throws SQLException
    {
       var resultSet = delegate.getGeneratedKeys();
-      if (proxyResultSet == null || ((ProxyResultSet) proxyResultSet).delegate != resultSet) {
-         proxyResultSet = ProxyFactory.getProxyResultSet(connection, this, resultSet);
+      if (resultSet != null) {
+         if (proxyResultSet == null || ((ProxyResultSet) proxyResultSet).delegate != resultSet) {
+            proxyResultSet = ProxyFactory.getProxyResultSet(connection, this, resultSet);
+         }
+      }
+      else {
+         proxyResultSet = null;
       }
       return proxyResultSet;
    }

--- a/src/test/java/com/zaxxer/hikari/mocks/StubStatement.java
+++ b/src/test/java/com/zaxxer/hikari/mocks/StubStatement.java
@@ -32,6 +32,7 @@ import java.sql.Statement;
 public class StubStatement implements Statement
 {
    public static volatile boolean oldDriver;
+   public static volatile boolean returnNullGeneratedKeys;
 
    private static volatile long simulatedQueryTime;
    private boolean closed;
@@ -297,7 +298,7 @@ public class StubStatement implements Statement
    public ResultSet getGeneratedKeys() throws SQLException
    {
       checkClosed();
-      return new StubResultSet();
+      return returnNullGeneratedKeys ? null : new StubResultSet();
    }
 
    /** {@inheritDoc} */

--- a/src/test/java/com/zaxxer/hikari/pool/StatementTest.java
+++ b/src/test/java/com/zaxxer/hikari/pool/StatementTest.java
@@ -22,8 +22,11 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.sql.Connection;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+
+import com.zaxxer.hikari.mocks.StubStatement;
 
 import org.junit.After;
 import org.junit.Before;
@@ -132,6 +135,26 @@ public class StatementTest
             Statement statement2 = connection.createStatement()) {
          statement1.close();
          statement2.close();
+      }
+   }
+
+   @Test
+   public void testGetGeneratedKeysReturnsNull() throws SQLException
+   {
+      StubStatement.returnNullGeneratedKeys = true;
+      try (Connection connection = ds.getConnection()) {
+         assertNotNull(connection);
+
+         Statement statement = connection.createStatement();
+         assertNotNull(statement);
+
+         // Some JDBC drivers return null from getGeneratedKeys().
+         // The proxy should handle this gracefully without NPE.
+         ResultSet rs = statement.getGeneratedKeys();
+         assertTrue(rs == null);
+      }
+      finally {
+         StubStatement.returnNullGeneratedKeys = false;
       }
    }
 }


### PR DESCRIPTION
`ProxyStatement.getResultSet()` null-checks `delegate.getResultSet()` and returns `null` when the delegate result is null. `getGeneratedKeys()` does not — it passes the (possibly null) result straight to `ProxyFactory.getProxyResultSet(...)`. So when a driver returns `null` from `getGeneratedKeys()`, the method returns a **proxy wrapping `null`**, which then throws `NullPointerException` on first use instead of returning `null`.

This applies the same null guard `getResultSet()` already uses, so `getGeneratedKeys()` returns `null` consistently when the delegate does. Adds a regression test (`StatementTest.testGetGeneratedKeysReturnsNull`), driven by a `StubStatement.returnNullGeneratedKeys` toggle, that fails before the change (the proxy is non-null) and passes after.
