### PR TITLE
Fix setCredentialsProviderClassName writing to the wrong field

### DIFF
--- a/src/main/java/com/zaxxer/hikari/HikariConfig.java
+++ b/src/main/java/com/zaxxer/hikari/HikariConfig.java
@@ -890,7 +890,7 @@ public class HikariConfig implements HikariConfigMXBean
 
       try {
          this.credentialsProvider = createInstance(credentialsProviderClassName, HikariCredentialsProvider.class);
-         this.exceptionOverrideClassName = credentialsProviderClassName;
+         this.credentialsProviderClassName = credentialsProviderClassName;
       }
       catch (Exception e) {
          throw new RuntimeException("Failed to instantiate class " + credentialsProviderClassName, e);

--- a/src/test/java/com/zaxxer/hikari/HikariConfigTest.java
+++ b/src/test/java/com/zaxxer/hikari/HikariConfigTest.java
@@ -99,4 +99,12 @@ public class HikariConfigTest {
          return log;
       }
    }
+
+   @Test
+   public void testCredentialsProviderClassNameRoundTrip() {
+      String className = "com.zaxxer.hikari.pool.TestCredentials$TestCredentialsProvider";
+      HikariConfig config = new HikariConfig();
+      config.setCredentialsProviderClassName(className);
+      assertEquals("setCredentialsProviderClassName should store the class name", className, config.getCredentialsProviderClassName());
+   }
 }


### PR DESCRIPTION
## Problem

`HikariConfig.setCredentialsProviderClassName(String)` assigns its argument to the wrong field:

```java
public void setCredentialsProviderClassName(String credentialsProviderClassName) {
   checkIfSealed();
   try {
      this.credentialsProvider = createInstance(credentialsProviderClassName, HikariCredentialsProvider.class);
      this.exceptionOverrideClassName = credentialsProviderClassName; // wrong field
   }
   ...
}
```

Two consequences:

1. `credentialsProviderClassName` is never set, so `getCredentialsProviderClassName()` keeps returning `null` after the setter runs.
2. The unrelated `exceptionOverrideClassName` field is silently overwritten with the credentials-provider class name.

## Fix

Assign the value to `this.credentialsProviderClassName`.

## Test

Adds `testCredentialsProviderClassNameRoundTrip` to `HikariConfigTest`: it sets a provider class name and asserts the getter returns it. The test fails on `dev` (`expected:<...TestCredentialsProvider> but was:<null>`) and passes with this change.