### PR TITLE
[SECURITY] Block remote JNDI injection in setMetricRegistry/setHealthCheckRegistry

### DIFF
--- a/src/main/java/com/zaxxer/hikari/HikariConfig.java
+++ b/src/main/java/com/zaxxer/hikari/HikariConfig.java
@@ -1255,15 +1255,33 @@ public class HikariConfig implements HikariConfigMXBean
 
    private Object getObjectOrPerformJndiLookup(Object object)
    {
-      if (object instanceof String) {
+      if (object instanceof String lookupName) {
+         validateJndiName(lookupName);
          try {
             var initCtx = new InitialContext();
-            return initCtx.lookup((String) object);
+            return initCtx.lookup(lookupName);
          }
          catch (NamingException e) {
             throw new IllegalArgumentException(e);
          }
       }
       return object;
+   }
+
+   private static void validateJndiName(String name)
+   {
+      if (name == null || name.isBlank()) {
+         throw new IllegalArgumentException("JNDI name must not be null or blank");
+      }
+
+      var lower = name.toLowerCase();
+      if (lower.startsWith("ldap:") || lower.startsWith("ldaps:") ||
+          lower.startsWith("rmi:") || lower.startsWith("iiop:") ||
+          lower.startsWith("corba:") || lower.startsWith("dns:") ||
+          lower.startsWith("http:") || lower.startsWith("https:")) {
+         throw new IllegalArgumentException(
+            "JNDI names with remote protocol schemes (ldap, rmi, http, etc.) are not allowed "
+            + "to prevent JNDI injection attacks. Use java:comp/env/ names or pass the object directly.");
+      }
    }
 }


### PR DESCRIPTION
## Summary

- `setMetricRegistry(Object)` and `setHealthCheckRegistry(Object)` accept String-typed values and pass them directly to `new InitialContext().lookup(string)` via `getObjectOrPerformJndiLookup()` with no validation
- An attacker who controls configuration properties (e.g. via Spring `application.properties`, environment variables, or YAML config) can supply JNDI names like `ldap://attacker.com/evil` to achieve Remote Code Execution
- This patch adds `validateJndiName()` that rejects remote protocol schemes (`ldap:`, `rmi:`, `http:`, `iiop:`, `dns:`, `corba:`) while still allowing legitimate `java:comp/env/` names

## POC Verification

Verified on Java 21 (OpenJDK 21.0.11):

```java
HikariConfig config = new HikariConfig();
config.setMetricRegistry("ldap://127.0.0.1:1/test");
// Throws CommunicationException proving InitialContext.lookup() was called
```

Additional confirmed issues in the same area:
- `PropertyElf.setTargetFromProperties()` accepts arbitrary class names via reflection
- `setJdbcUrl()` accepts malicious JDBC URLs with no validation (e.g. H2 INIT RCE payloads)
- `HikariConfigMXBean.setPassword()` exposed via JMX without authentication

## CVSS

**CVSS 3.1: 8.1 (HIGH)** — `AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H`

