### PR TITLE
Do not synchronize on System.getProperties() when generating pool name (#2104)

### DIFF
--- a/src/main/java/com/zaxxer/hikari/HikariConfig.java
+++ b/src/main/java/com/zaxxer/hikari/HikariConfig.java
@@ -47,6 +47,16 @@ public class HikariConfig implements HikariConfigMXBean
    private static final Logger LOGGER = LoggerFactory.getLogger(HikariConfig.class);
 
    private static final char[] ID_CHARACTERS = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ".toCharArray();
+   // The pool-number counter is kept in a JVM-global system property so that pool numbers do not
+   // overlap across class loaders (e.g. two wars in one JVM). Making the read-increment-write of
+   // that property atomic requires a monitor shared by every class loader, but it must NOT be
+   // System.getProperties(): the JVM and third-party code lock that same Properties object (via
+   // System.getProperty(), class initialization, etc.), so holding its monitor across our critical
+   // section opens a lock-ordering window that can deadlock (see #2104). Instead we synchronize on
+   // this interned String constant, which is unique to HikariCP yet resolves to the same instance
+   // in every class loader, and we only touch the Properties object through its own
+   // already-synchronized accessors.
+   private static final String POOL_NUMBER_PROPERTY = "com.zaxxer.hikari.pool_number";
    private static final long CONNECTION_TIMEOUT = SECONDS.toMillis(30);
    private static final long VALIDATION_TIMEOUT = SECONDS.toMillis(5);
    private static final long SOFT_TIMEOUT_FLOOR = Long.getLong("com.zaxxer.hikari.timeoutMs.floor", 250L);
@@ -1231,10 +1241,12 @@ public class HikariConfig implements HikariConfigMXBean
    {
       final var prefix = "HikariPool-";
       try {
-         // Pool number is global to the VM to avoid overlapping pool numbers in classloader scoped environments
-         synchronized (System.getProperties()) {
-            final var next = String.valueOf(Integer.getInteger("com.zaxxer.hikari.pool_number", 0) + 1);
-            System.setProperty("com.zaxxer.hikari.pool_number", next);
+         // Synchronize on POOL_NUMBER_PROPERTY (an interned constant), not System.getProperties()
+         // (see #2104), so the read-increment-write stays atomic without holding the shared
+         // Properties monitor across our critical section.
+         synchronized (POOL_NUMBER_PROPERTY) {
+            final var next = String.valueOf(Integer.getInteger(POOL_NUMBER_PROPERTY, 0) + 1);
+            System.setProperty(POOL_NUMBER_PROPERTY, next);
             return prefix + next;
          }
       } catch (AccessControlException e) {

--- a/src/test/java/com/zaxxer/hikari/PoolNameGenerationTest.java
+++ b/src/test/java/com/zaxxer/hikari/PoolNameGenerationTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2024 Brett Wooldridge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.zaxxer.hikari;
+
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Guards the auto-generated pool-name counter (see #2104): generation no longer holds the
+ * {@code System.getProperties()} monitor, but the read-increment-write of the VM-global
+ * counter must stay atomic so that concurrently generated pool numbers never overlap.
+ */
+public class PoolNameGenerationTest
+{
+   private static Method generatePoolName() throws Exception
+   {
+      Method m = HikariConfig.class.getDeclaredMethod("generatePoolName");
+      m.setAccessible(true);
+      return m;
+   }
+
+   @Test
+   public void testGeneratedPoolNamesAreUniqueUnderConcurrency() throws Exception
+   {
+      final Method generate = generatePoolName();
+      final int threads = 16;
+      final int perThread = 250;
+      final int total = threads * perThread;
+
+      final ConcurrentLinkedQueue<String> names = new ConcurrentLinkedQueue<>();
+      final CountDownLatch start = new CountDownLatch(1);
+      final CountDownLatch done = new CountDownLatch(threads);
+      final Thread[] workers = new Thread[threads];
+
+      for (int t = 0; t < threads; t++) {
+         workers[t] = new Thread(() -> {
+            try {
+               final HikariConfig config = new HikariConfig();
+               start.await();
+               for (int i = 0; i < perThread; i++) {
+                  names.add((String) generate.invoke(config));
+               }
+            }
+            catch (Exception e) {
+               throw new RuntimeException(e);
+            }
+            finally {
+               done.countDown();
+            }
+         });
+         workers[t].start();
+      }
+
+      start.countDown();
+      assertTrue("pool name generation did not complete in time", done.await(30, TimeUnit.SECONDS));
+
+      assertEquals(total, names.size());
+
+      // No two concurrently generated names may collide: a lost update on the shared counter
+      // would produce a duplicate.
+      final Set<String> unique = new HashSet<>(names);
+      assertEquals("generated pool names must be unique (no lost counter updates)", total, unique.size());
+
+      // Every name must follow the documented "HikariPool-<n>" shape.
+      for (String name : names) {
+         assertTrue("unexpected pool name: " + name, name.startsWith("HikariPool-"));
+      }
+   }
+
+   @Test
+   public void testGenerationDoesNotDeadlockWhilePropertiesMonitorIsContended() throws Exception
+   {
+      // A regression guard for the class of deadlock in #2104: other threads constantly hold the
+      // System.getProperties() monitor (as the JVM and third-party code routinely do). Generation
+      // must still make progress rather than wedging behind that foreign monitor.
+      final Method generate = generatePoolName();
+      final HikariConfig config = new HikariConfig();
+
+      final CountDownLatch stop = new CountDownLatch(1);
+      final Thread contender = new Thread(() -> {
+         while (stop.getCount() > 0) {
+            synchronized (System.getProperties()) {
+               System.getProperties().getProperty("java.version");
+            }
+         }
+      });
+      contender.setDaemon(true);
+      contender.start();
+
+      try {
+         final Set<String> names = Collections.synchronizedSet(new HashSet<>());
+         for (int i = 0; i < 500; i++) {
+            names.add((String) generate.invoke(config));
+         }
+         assertEquals("generated pool names must be unique", 500, names.size());
+      }
+      finally {
+         stop.countDown();
+      }
+   }
+}


### PR DESCRIPTION
Fixes #2104

### Root cause
`HikariConfig.generatePoolName()` held the `System.getProperties()` monitor across the whole read-increment-write of the global `com.zaxxer.hikari.pool_number` counter:

```java
synchronized (System.getProperties()) {
   final var next = String.valueOf(Integer.getInteger("com.zaxxer.hikari.pool_number", 0) + 1);
   System.setProperty("com.zaxxer.hikari.pool_number", next);
   return prefix + next;
}
```

The JVM and third-party code lock that *same* `Properties` object (`System.getProperty()`, class initialization touching system properties, etc.). Holding its monitor across a critical section therefore opens a lock-ordering window: another thread initializing classes can hold a class-init lock while waiting for the `Properties` monitor, while our thread holds the `Properties` monitor and (incidentally, during the block) needs that class-init lock. The reporter observed this deadlock roughly 1 in 4 startups in a constrained, multi-core-limited container. A library should not synchronize on a monitor outside its own scope.

### Change
Synchronize on the interned property-key `String` constant instead of the `Properties` object. A string literal is interned into the JVM-global pool, so `POOL_NUMBER_PROPERTY` resolves to the **same instance across all class loaders** — this preserves the cross-class-loader global uniqueness of the counter (the requirement that ruled out a per-class-loader `AtomicInteger`, e.g. two wars in one JVM must not collide). Inside the block the `Properties` object is only ever touched through its own already-synchronized accessors (`Integer.getInteger` / `System.setProperty`), each of which acquires and releases the `Properties` monitor atomically, so it is never *held* across other work — closing the lock-ordering window.

The `AccessControlException` / random-name fallback is unchanged.

### Tests
Added `PoolNameGenerationTest`:
- `testGeneratedPoolNamesAreUniqueUnderConcurrency` — 16 threads × 250 generations; asserts all 4000 names are unique, verifying the read-increment-write stays atomic (a lost update would produce a duplicate). This guards the global-uniqueness contract that previous fix attempts broke.
- `testGenerationDoesNotDeadlockWhilePropertiesMonitorIsContended` — a background thread continuously holds the `System.getProperties()` monitor while pool names are generated; generation must make progress and stay unique.

A fully deterministic reproduction of the original class-init/`Properties` lock inversion is impractical in a unit test, so the fix is argued from the lock-ordering analysis above; the added tests lock in the atomicity/uniqueness contract that the change must not regress.

Verification done: built and ran `mvn test -Dtest=HikariConfigTest,MiscTest,PoolNameGenerationTest` (JDK 21) — all 7 pass. Confirmed the previously-passing `MiscTest` still passes (an earlier iteration that added an `Object`-typed field regressed `copyStateTo`, which reflectively treats any final `Object` field as an `AtomicReference`; typing the constant as `String` avoids that).