### PR TITLE
fixes #2404 keep loginTimeout per DriverDataSource instead of the JVM-global DriverManager

### DIFF
--- a/src/main/java/com/zaxxer/hikari/util/DriverDataSource.java
+++ b/src/main/java/com/zaxxer/hikari/util/DriverDataSource.java
@@ -46,6 +46,7 @@ public final class DriverDataSource implements DataSource
    private final String jdbcUrl;
    private final Properties driverProperties;
    private Driver driver;
+   private int loginTimeout;
 
    public DriverDataSource(String jdbcUrl, String driverClassName, Properties properties, String username, String password)
    {
@@ -156,16 +157,23 @@ public final class DriverDataSource implements DataSource
       throw new SQLFeatureNotSupportedException();
    }
 
+   /**
+    * {@inheritDoc}
+    * <p>
+    * The value is kept per-instance rather than written through to {@link DriverManager#setLoginTimeout(int)},
+    * which is global to the JVM: the last pool to initialize would otherwise dictate the login timeout of every
+    * other {@code jdbcUrl}-configured pool, and of any unrelated JDBC code sharing the JVM.
+    */
    @Override
    public void setLoginTimeout(int seconds) throws SQLException
    {
-      DriverManager.setLoginTimeout(seconds);
+      loginTimeout = seconds;
    }
 
    @Override
    public int getLoginTimeout() throws SQLException
    {
-      return DriverManager.getLoginTimeout();
+      return loginTimeout;
    }
 
    @Override

--- a/src/test/java/com/zaxxer/hikari/util/DriverDataSourceTest.java
+++ b/src/test/java/com/zaxxer/hikari/util/DriverDataSourceTest.java
@@ -41,6 +41,18 @@ public class DriverDataSourceTest {
    }
 
    @Test
+   public void testLoginTimeoutIsNotSharedBetweenDataSources() throws Exception {
+      var dataSourceA = new DriverDataSource("jdbc:h2:mem:loginTimeoutA;DB_CLOSE_DELAY=-1", null, new Properties(), "", "");
+      var dataSourceB = new DriverDataSource("jdbc:h2:mem:loginTimeoutB;DB_CLOSE_DELAY=-1", null, new Properties(), "", "");
+
+      dataSourceA.setLoginTimeout(10);
+      dataSourceB.setLoginTimeout(20);
+
+      assertEquals(10, dataSourceA.getLoginTimeout());
+      assertEquals(20, dataSourceB.getLoginTimeout());
+   }
+
+   @Test
    public void testJdbcUrlLogging() {
       List<String> urls = Arrays.asList(
          "jdbc:invalid://host/d_dlq?user=USER&password=SECRET",


### PR DESCRIPTION
Replaces #2412. I closed that one on Aug 6 while cutting down the number of repos I had open PRs in, then settled on a shorter list that HikariCP is on. I'd deleted my fork in the same pass, so GitHub wouldn't let me reopen it — this is the same commit (6b7d87f), unchanged.

`DriverDataSource#setLoginTimeout` delegates to `DriverManager.setLoginTimeout`, which is a JVM-wide static. So with two pools configured by `jdbcUrl`, the second one to initialize overwrites the first one's login timeout, and `getLoginTimeout` then reports that same value back to both. That's #2404. It also leaks HikariCP's timeout into unrelated JDBC code in the same JVM, which is what #2042 hit with hive-jdbc.

I changed it to keep the value in an instance field.

One thing I'd like your call on: drivers that read `DriverManager.getLoginTimeout()` will no longer see a value set by HikariCP. That hint was already unreliable as soon as there was more than one pool (last one to start wins), but it did do something in the single-pool case, so removing it isn't free. If you'd rather keep it somehow, I'm happy to rework this.

The test in `DriverDataSourceTest` fails on dev with `expected:<10> but was:<20>` and passes with the change. Rest of the suite is unchanged locally — the 7 `PostgresTest` errors I see are just Docker not being available on my machine, same before and after.

Co-authored with Claude (the code and reasoning are mine to defend).
