### PR TITLE
fix: mask authority-embedded passwords in JDBC URLs

### DIFF
--- a/src/main/java/com/zaxxer/hikari/util/UtilityElf.java
+++ b/src/main/java/com/zaxxer/hikari/util/UtilityElf.java
@@ -48,6 +48,12 @@ public final class UtilityElf
     */
    private static final Pattern PASSWORD_MASKING_PATTERN = Pattern.compile("([?&;][^&#;=]*[pP]assword=)[^&#;]*");
 
+   /**
+    * A pattern to match and mask authority-embedded credentials (user:password@host).
+    * Captures {@code //} + username + {@code :}; the password runs up to the following {@code @}.
+    */
+   private static final Pattern USERINFO_PASSWORD_MASKING_PATTERN = Pattern.compile("(//[^/@:]+:)[^@]+@");
+
    private UtilityElf()
    {
       // non-constructable
@@ -55,7 +61,8 @@ public final class UtilityElf
 
    public static String maskPasswordInJdbcUrl(String jdbcUrl)
    {
-      return PASSWORD_MASKING_PATTERN.matcher(jdbcUrl).replaceAll("$1<masked>");
+      var masked = PASSWORD_MASKING_PATTERN.matcher(jdbcUrl).replaceAll("$1<masked>");
+      return USERINFO_PASSWORD_MASKING_PATTERN.matcher(masked).replaceAll("$1<masked>@");
    }
 
    /**

--- a/src/test/java/com/zaxxer/hikari/HikariConfigTest.java
+++ b/src/test/java/com/zaxxer/hikari/HikariConfigTest.java
@@ -71,6 +71,16 @@ public class HikariConfigTest {
       }
    }
 
+   @Test
+   public void testJdbcUrlAuthorityPasswordLogging() {
+      HikariConfig config = newHikariConfig();
+      config.setJdbcUrl("jdbc:postgresql://admin:s3cret@db.internal:5432/prod");
+      config.validate();
+
+      assertTrue(testAppender.getLog().contains("jdbc:postgresql://admin:<masked>@db.internal:5432/prod"));
+      assertFalse("Log should not contain authority password", testAppender.getLog().contains("s3cret"));
+   }
+
    private void testJdbcUrl(String jdbcUrl) {
       HikariConfig config = newHikariConfig();
       config.setJdbcUrl(jdbcUrl);

--- a/src/test/java/com/zaxxer/hikari/util/UtilityElfTest.java
+++ b/src/test/java/com/zaxxer/hikari/util/UtilityElfTest.java
@@ -63,6 +63,42 @@ public class UtilityElfTest
          new ClassD());
    }
 
+   @Test
+   public void shouldMaskQueryParameterPasswordInJdbcUrl()
+   {
+      assertEquals("jdbc:mysql://host/db?password=<masked>",
+         UtilityElf.maskPasswordInJdbcUrl("jdbc:mysql://host/db?password=secret"));
+      assertEquals("jdbc:postgresql://host/d_dlq?user=USER&password=<masked>",
+         UtilityElf.maskPasswordInJdbcUrl("jdbc:postgresql://host/d_dlq?user=USER&password=SECRET"));
+      assertEquals("jdbc:postgresql://host/d_dlq?a=b&sslpassword=<masked>&user=USER",
+         UtilityElf.maskPasswordInJdbcUrl("jdbc:postgresql://host/d_dlq?a=b&sslpassword=SECRET&user=USER"));
+   }
+
+   @Test
+   public void shouldMaskAuthorityEmbeddedPasswordInJdbcUrl()
+   {
+      assertEquals("jdbc:postgresql://admin:<masked>@db.internal:5432/prod",
+         UtilityElf.maskPasswordInJdbcUrl("jdbc:postgresql://admin:s3cret@db.internal:5432/prod"));
+      assertEquals("jdbc:mysql://root:<masked>@localhost:3306/app",
+         UtilityElf.maskPasswordInJdbcUrl("jdbc:mysql://root:p%40ss@localhost:3306/app"));
+   }
+
+   @Test
+   public void shouldMaskBothAuthorityAndQueryParameterPasswords()
+   {
+      assertEquals("jdbc:postgresql://admin:<masked>@host:5432/db?password=<masked>",
+         UtilityElf.maskPasswordInJdbcUrl("jdbc:postgresql://admin:s3cret@host:5432/db?password=querySecret"));
+   }
+
+   @Test
+   public void shouldNotMaskJdbcUrlWithoutPassword()
+   {
+      assertEquals("jdbc:postgresql://host:5432/db",
+         UtilityElf.maskPasswordInJdbcUrl("jdbc:postgresql://host:5432/db"));
+      assertEquals("jdbc:postgresql://admin@host:5432/db",
+         UtilityElf.maskPasswordInJdbcUrl("jdbc:postgresql://admin@host:5432/db"));
+   }
+
    public static class ClassA {}
 
    public static final class ClassB extends ClassA {}


### PR DESCRIPTION
## Summary

`UtilityElf.maskPasswordInJdbcUrl()` only masked query-parameter passwords (`?password=`, `&sslpassword=`, etc.). Authority-embedded credentials such as `jdbc:postgresql://admin:s3cret@host:5432/db` were left intact and could leak when DEBUG logging is enabled via `HikariConfig.logConfiguration()` and `DriverDataSource` constructor logging.

This change also masks the password portion of URI userinfo (`//user:password@host`) while preserving existing query-parameter masking.

## Changes

- Add `USERINFO_PASSWORD_MASKING_PATTERN` for `//user:password@` forms
- Apply it after the existing query-parameter mask in `maskPasswordInJdbcUrl`
- Unit tests for query-param, authority, combined, and no-password cases
- Logging test covering authority-embedded credentials in `HikariConfigTest`

## Test plan

- [x] `mvn -Dtest=UtilityElfTest,HikariConfigTest test` (JDK 21) — 11 tests, 0 failures

Fixes #2413